### PR TITLE
First part of Schema support

### DIFF
--- a/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
@@ -8,7 +8,6 @@ import lombok.Value;
 import lombok.experimental.Accessors;
 
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
@@ -16,8 +15,8 @@ import java.util.Map;
 /**
  * Note: Lombok has a Value/Defaults bug which means we have messy accessors to cope with default values:
  * See
- * - https://stackoverflow.com/questions/47883931/default-value-in-lombok-how-to-init-default-with-both-constructor-and-builder
- * - https://github.com/projectlombok/lombok/issues/1347
+ * - <a href="https://stackoverflow.com/questions/47883931/default-value-in-lombok-how-to-init-default-with-both-constructor-and-builder">...</a>
+ * - <a href="https://github.com/projectlombok/lombok/issues/1347">...</a>
  */
 
 
@@ -43,16 +42,17 @@ public class KafkaBinding {
     @JsonProperty
     int retention;
 
-    @SuppressWarnings("rawtypes")
     @JsonProperty
-    Map configs = Collections.EMPTY_MAP;
+    Map<String, String> configs = Collections.emptyMap();
 
     @JsonProperty
     String groupId;
 
-    @SuppressWarnings({"rawtypes", "unchecked"})
-    public Map configs() {
-        final Map results = new LinkedHashMap(configs != null ? configs : new HashMap());
+    @JsonProperty
+    String schemaIdLocation;
+
+    public Map<String, String> configs() {
+        final Map<String, String> results = new LinkedHashMap<>(configs);
 
         if (!results.containsKey(RETENTION_MS) && retention != 0) {
             results.put("retention.ms", String.valueOf(retention * DAYS_TO_MS));

--- a/parser/src/main/java/io/specmesh/apiparser/model/Message.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Message.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * https://www.asyncapi.com/docs/reference/specification/v2.4.0#messageObject
+ * <a href="https://www.asyncapi.com/docs/reference/specification/v2.4.0#messageObject">...</a>
  */
 @Value
 @Accessors(fluent=true)
@@ -26,31 +26,43 @@ public class Message {
     String messageId;
 
     @JsonProperty
-    Map headers = Collections.EMPTY_MAP;;
+    Map headers = Collections.EMPTY_MAP;
 
     @JsonProperty
-    Map payload = Collections.EMPTY_MAP;;
+    Map payload = Collections.EMPTY_MAP;
 
     @JsonProperty
     Map correlationId = Collections.EMPTY_MAP;
+
     @JsonProperty
     String schemaFormat;
+
     @JsonProperty
     String contentType;
+
     @JsonProperty
     String name;
+
     @JsonProperty
     String title;
+
     @JsonProperty
     String summary;
+
     @JsonProperty
     String description;
 
     @JsonProperty
     List<Tag> tags = Collections.EMPTY_LIST ;
+
     @JsonProperty
-    Map bindings;
+    Bindings bindings;
+
     @JsonProperty
     Map traits = Collections.EMPTY_MAP;
+
+    public String schemaRef() {
+        return (String) payload.get("$ref");
+    }
 
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/Tag.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Tag.java
@@ -18,6 +18,4 @@ public class Tag {
 
     @JsonProperty
     String description;
-
-
 }

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
@@ -1,17 +1,16 @@
 package io.specmesh.apiparser;
 
-import io.specmesh.apiparser.model.ApiSpec;
-import io.specmesh.apiparser.model.Bindings;
-import io.specmesh.apiparser.model.Channel;
-import org.hamcrest.Matchers;
-import org.junit.jupiter.api.Test;
-
-import java.util.Map;
-import java.util.Set;
-
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.specmesh.apiparser.model.ApiSpec;
+import io.specmesh.apiparser.model.Bindings;
+import io.specmesh.apiparser.model.Channel;
+import java.util.Map;
+import java.util.Set;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
 
 public class AsyncApiParserTest {
     final ApiSpec apiSpec = getAPISpecFromResource();

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
@@ -1,27 +1,28 @@
 package io.specmesh.apiparser;
 
-import static org.hamcrest.CoreMatchers.hasItem;
-import static org.hamcrest.CoreMatchers.is;
-import static org.hamcrest.MatcherAssert.assertThat;
-
 import io.specmesh.apiparser.model.ApiSpec;
 import io.specmesh.apiparser.model.Bindings;
 import io.specmesh.apiparser.model.Channel;
-import java.io.IOException;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
 import java.util.Map;
 import java.util.Set;
-import org.junit.jupiter.api.Test;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
 
 public class AsyncApiParserTest {
     final ApiSpec apiSpec = getAPISpecFromResource();
 
     @Test
-    public void shouldReturnRootIdWithDelimiter() throws IOException {
+    public void shouldReturnRootIdWithDelimiter() {
         assertThat(apiSpec.id(), is("simple.streetlights"));
     }
 
     @Test
-    public void shouldReturnCanonicalChannelNames() throws IOException {
+    public void shouldReturnCanonicalChannelNames() {
         final Map<String, Channel> channelsMap = apiSpec.channels();
         assertThat(channelsMap.size(), is(2));
         assertThat("Should have assembled id + channelname", channelsMap.keySet(), hasItem("simple.streetlights.public.light.measured"));
@@ -29,7 +30,7 @@ public class AsyncApiParserTest {
     }
 
     @Test
-    public void shouldReturnKafkaBindingsForCreation() throws IOException {
+    public void shouldReturnKafkaBindingsForCreation() {
         final Map<String, Channel> channelsMap = apiSpec.channels();
         assertThat(channelsMap.size(), is(2));
         assertThat("Should have assembled id + channelname", channelsMap.keySet(), hasItem("simple.streetlights.public.light.measured"));
@@ -44,7 +45,7 @@ public class AsyncApiParserTest {
     }
 
     @Test
-    public void shouldReturnOperationTags() throws IOException {
+    public void shouldReturnOperationTags() {
         final Map<String, Channel> channelsMap = apiSpec.channels();
         assertThat(channelsMap.size(), is(2));
         assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(), hasItem("simple.streetlights.public.light.measured"));
@@ -54,13 +55,23 @@ public class AsyncApiParserTest {
         assertThat(producerBindings.kafka().configs().keySet(), is(Set.of("cleanup.policy", "retention.ms")));
         assertThat(producerBindings.kafka().envs().size(), is(2));
 
-//        assertThat(channelsMap.values().iterator().next().publish().message().tags(),
-//                is(List.of(
-//                        Tag.builder().build()new Tag("human","eats food"),
-//                        new Tag("big data london","data mesh thing")
-//                        ))
-//        );
+        assertThat(channelsMap.values().iterator().next().publish().message().tags(), Matchers.iterableWithSize(2));
     }
+
+    @Test
+    public void shouldReturnProducerMessageSchema() {
+        final Map<String, Channel> channelsMap = apiSpec.channels();
+        assertThat(channelsMap.size(), is(2));
+        assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(), hasItem("simple.streetlights.public.light.measured"));
+
+        final Bindings producerBindings = channelsMap.get("simple.streetlights.public.light.measured").bindings();
+        assertThat(producerBindings.kafka().configs().size(), is(2));
+        assertThat(producerBindings.kafka().configs().keySet(), is(Set.of("cleanup.policy", "retention.ms")));
+        assertThat(producerBindings.kafka().envs().size(), is(2));
+
+        assertThat(channelsMap.values().iterator().next().publish().message().tags(), Matchers.iterableWithSize(2));
+    }
+
 
 
     private ApiSpec getAPISpecFromResource() {

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
@@ -1,15 +1,14 @@
 package io.specmesh.apiparser;
 
-import io.specmesh.apiparser.model.ApiSpec;
-import io.specmesh.apiparser.model.Channel;
-import io.specmesh.apiparser.model.Operation;
-import org.junit.jupiter.api.Test;
-
-import java.util.Map;
-
 import static org.hamcrest.CoreMatchers.hasItem;
 import static org.hamcrest.CoreMatchers.is;
 import static org.hamcrest.MatcherAssert.assertThat;
+
+import io.specmesh.apiparser.model.ApiSpec;
+import io.specmesh.apiparser.model.Channel;
+import io.specmesh.apiparser.model.Operation;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
 
 public class AsyncApiSchemaParserTest {
     final ApiSpec apiSpec = getAPISpecFromResource();

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
@@ -20,14 +20,12 @@ public class AsyncApiSchemaParserTest {
         assertThat(channelsMap.size(), is(2));
         assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(), hasItem("simple.schema-demo.public.user.signed"));
 
-        Operation publish = channelsMap.get("simple.schema-demo.public.user.signed").publish();
+        final Operation publish = channelsMap.get("simple.schema-demo.public.user.signed").publish();
         assertThat(publish.message().schemaRef(), is("simple_schema_demo_user-signedup.avsc"));
 
         assertThat(publish.message().schemaFormat(), is("application/vnd.apache.avro+json;version=1.9.0"));
         assertThat(publish.message().contentType(), is("application/octet-stream"));
         assertThat(publish.message().bindings().kafka().schemaIdLocation(), is("header"));
-
-
     }
 
     @Test
@@ -36,12 +34,11 @@ public class AsyncApiSchemaParserTest {
         assertThat(channelsMap.size(), is(2));
         assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(), hasItem("london.hammersmith.transport.public.tube"));
 
-        Operation subscribe = channelsMap.get("london.hammersmith.transport.public.tube").subscribe();
+        final Operation subscribe = channelsMap.get("london.hammersmith.transport.public.tube").subscribe();
         assertThat(subscribe.message().schemaRef(), is("london_hammersmith_transport_public_passenger.avsc"));
         assertThat(subscribe.message().schemaFormat(), is("application/vnd.apache.avro+json;version=1.9.0"));
         assertThat(subscribe.message().contentType(), is("application/octet-stream"));
         assertThat(subscribe.message().bindings().kafka().schemaIdLocation(), is("header"));
-
     }
 
 

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
@@ -1,0 +1,57 @@
+package io.specmesh.apiparser;
+
+import io.specmesh.apiparser.model.ApiSpec;
+import io.specmesh.apiparser.model.Channel;
+import io.specmesh.apiparser.model.Operation;
+import org.junit.jupiter.api.Test;
+
+import java.util.Map;
+
+import static org.hamcrest.CoreMatchers.hasItem;
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.MatcherAssert.assertThat;
+
+public class AsyncApiSchemaParserTest {
+    final ApiSpec apiSpec = getAPISpecFromResource();
+
+    @Test
+    public void shouldReturnProducerMessageSchema() {
+        final Map<String, Channel> channelsMap = apiSpec.channels();
+        assertThat(channelsMap.size(), is(2));
+        assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(), hasItem("simple.schema-demo.public.user.signed"));
+
+        Operation publish = channelsMap.get("simple.schema-demo.public.user.signed").publish();
+        assertThat(publish.message().schemaRef(), is("simple_schema_demo_user-signedup.avsc"));
+
+        assertThat(publish.message().schemaFormat(), is("application/vnd.apache.avro+json;version=1.9.0"));
+        assertThat(publish.message().contentType(), is("application/octet-stream"));
+        assertThat(publish.message().bindings().kafka().schemaIdLocation(), is("header"));
+
+
+    }
+
+    @Test
+    public void shouldReturnSubscriberMessageSchema() {
+        final Map<String, Channel> channelsMap = apiSpec.channels();
+        assertThat(channelsMap.size(), is(2));
+        assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(), hasItem("london.hammersmith.transport.public.tube"));
+
+        Operation subscribe = channelsMap.get("london.hammersmith.transport.public.tube").subscribe();
+        assertThat(subscribe.message().schemaRef(), is("london_hammersmith_transport_public_passenger.avsc"));
+        assertThat(subscribe.message().schemaFormat(), is("application/vnd.apache.avro+json;version=1.9.0"));
+        assertThat(subscribe.message().contentType(), is("application/octet-stream"));
+        assertThat(subscribe.message().bindings().kafka().schemaIdLocation(), is("header"));
+
+    }
+
+
+
+
+    private ApiSpec getAPISpecFromResource() {
+        try {
+            return new AsyncApiParser().loadResource(getClass().getClassLoader().getResourceAsStream("simple_schema_demo-api.yaml"));
+        } catch (Throwable t) {
+            throw new RuntimeException("Failed to load test resource", t);
+        }
+    }
+}

--- a/parser/src/test/resources/london_hammersmith_transport_public_passenger.avsc
+++ b/parser/src/test/resources/london_hammersmith_transport_public_passenger.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "london.hammersmith.transport",
+  "type": "record",
+  "name": "Passenger",
+  "fields": [
+    {"name": "fullName", "type": "string"},
+    {"name": "email",  "type": "string"},
+    {"name": "age", "type": "int"}
+  ]
+}

--- a/parser/src/test/resources/simple_schema_demo-api.yaml
+++ b/parser/src/test/resources/simple_schema_demo-api.yaml
@@ -1,0 +1,61 @@
+asyncapi: '2.4.0'
+id: 'urn:simple:schema-demo'
+info:
+  title: Streetlights API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you
+    to remotely manage the city lights.
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+servers:
+  mosquitto:
+    url: mqtt://test.mosquitto.org
+    protocol: mqtt
+channels:
+  # PRODUCER WILL PUBLISH SCHEMA to SR
+  public/user/signed:
+    # publish bindings to instruct topic configuration per environment
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 3
+        replicas: 1
+        retention: 1
+        configs:
+          cleanup.policy: delete
+
+    publish:
+      summary: Inform about environmental lighting conditions for a particular streetlight.
+      operationId: onLightMeasured
+      message:
+        bindings:
+          kafka:
+            schemaIdLocation: "header"
+        schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
+        contentType: "application/octet-stream"
+        payload:
+          $ref: "simple_schema_demo_user-signedup.avsc"
+
+# SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
+  /london/hammersmith/transport/public/tube:
+    subscribe:
+      summary: Humans arriving in the borough
+      bindings:
+        kafka:
+          groupId: 'aConsumerGroupId'
+      message:
+        schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
+        contentType: "application/octet-stream"
+        bindings:
+          kafka:
+            schemaIdLocation: "header"
+            key:
+              type: string
+        payload:
+          # client should lookup this schema remotely from the schema registry - it is owned by the publisher
+          $ref: "london_hammersmith_transport_public_passenger.avsc"
+

--- a/parser/src/test/resources/simple_schema_demo_user-signedup.avsc
+++ b/parser/src/test/resources/simple_schema_demo_user-signedup.avsc
@@ -1,0 +1,10 @@
+{
+  "namespace": "simple.schema.demo",
+  "type": "record",
+  "name": "User",
+  "fields": [
+    {"name": "fullName", "type": "string"},
+    {"name": "email",  "type": "string"},
+    {"name": "age", "type": "int"}
+  ]
+}


### PR DESCRIPTION
Important semantic notes
- Publisher will need to publish schema to SR
- Subscriber will reference the schema name from the spec and load it from the required SR to codegen classes.
- Schema is not shipped outside of the data product, and only available to subscribers via the SR and should no be contained in subscriber apps