### PR TITLE
Enable releasing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,6 +13,8 @@ jobs:
   release:
     runs-on: ubuntu-latest
     if: github.ref == 'refs/heads/main'
+    permissions:
+      contents: write
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
       - name: Fetch version history


### PR DESCRIPTION
Releasing writes a tag back to the repo's main branch, (which then triggers the build), so the job needs write permission on the repo's content to be able to push the tag.