### PR TITLE
Allow release workflow to trigger another workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,6 +17,8 @@ jobs:
       contents: write
     steps:
       - uses: actions/checkout@ac593985615ec2ede58e132d2e21d2b1cbd6127c # v3.3.0
+        with:
+          token: ${{ secrets.TRIGGER_GITHUB_TOKEN }}
       - name: Fetch version history
         run: git fetch --tags --unshallow
       - name: Set up JDK


### PR DESCRIPTION
By default, if a GitHub workflow pushes a tag it will NOT trigger any other workflows that would normally trigger if the tag was pushed manually.

To trigger workflows a PAT must be used.

(Which is a bit rubbish!)