### PR TITLE
Switch to spotless google format

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -136,7 +136,7 @@ subprojects {
 
     spotless {
         java {
-            eclipse()
+            googleJavaFormat("1.15.0").aosp()
             indentWithSpaces()
             importOrder()
             removeUnusedImports()

--- a/kafka-test/src/main/java/io/specmesh/kafka/AbstractContainerTest.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/AbstractContainerTest.java
@@ -31,24 +31,33 @@ import org.testcontainers.utility.DockerImageName;
  * https://www.testcontainers.org/test_framework_integration/manual_lifecycle_control/#singleton-containers
  */
 abstract class AbstractContainerTest {
-    protected AbstractContainerTest() {
-    }
+    protected AbstractContainerTest() {}
+
     static final String CFLT_VERSION = "7.2.2";
     static final Network network = Network.newNetwork();
     static KafkaContainer kafkaContainer;
     static SchemaRegistryContainer schemaRegistryContainer;
 
     static {
-
         try {
-            kafkaContainer = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:" + CFLT_VERSION))
-                    .withNetwork(network).withStartupTimeout(Duration.ofSeconds(90))
-                    .withEnv(Provisioner.testAuthorizerConfig("simple.schema_demo", "simple.schema_demo-secret",
-                            "foreignDomain", "foreignDomain-secret",
-                            Map.of("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")));
+            kafkaContainer =
+                    new KafkaContainer(
+                                    DockerImageName.parse("confluentinc/cp-kafka:" + CFLT_VERSION))
+                            .withNetwork(network)
+                            .withStartupTimeout(Duration.ofSeconds(90))
+                            .withEnv(
+                                    Provisioner.testAuthorizerConfig(
+                                            "simple.schema_demo",
+                                            "simple.schema_demo-secret",
+                                            "foreignDomain",
+                                            "foreignDomain-secret",
+                                            Map.of("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")));
 
-            schemaRegistryContainer = new SchemaRegistryContainer(CFLT_VERSION).withNetwork(network)
-                    .withKafka(kafkaContainer).withStartupTimeout(Duration.ofSeconds(90));
+            schemaRegistryContainer =
+                    new SchemaRegistryContainer(CFLT_VERSION)
+                            .withNetwork(network)
+                            .withKafka(kafkaContainer)
+                            .withStartupTimeout(Duration.ofSeconds(90));
 
             Startables.deepStart(Stream.of(kafkaContainer, schemaRegistryContainer)).join();
 
@@ -56,5 +65,4 @@ abstract class AbstractContainerTest {
             t.printStackTrace();
         }
     }
-
 }

--- a/kafka-test/src/main/java/io/specmesh/kafka/schema/SchemaRegistryContainer.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/schema/SchemaRegistryContainer.java
@@ -22,23 +22,19 @@ import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.containers.Network;
 import org.testcontainers.utility.DockerImageName;
 
-/**
- * Test container for the Schema Registry
- */
+/** Test container for the Schema Registry */
 public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
 
-    private static final String SCHEMA_REGISTRY_DOCKER_IMAGE_NAME = "confluentinc/cp-schema-registry:6.0.2";
-    private static final DockerImageName SCHEMA_REGISTRY_DOCKER_IMAGE = DockerImageName
-            .parse(SCHEMA_REGISTRY_DOCKER_IMAGE_NAME);
+    private static final String SCHEMA_REGISTRY_DOCKER_IMAGE_NAME =
+            "confluentinc/cp-schema-registry:6.0.2";
+    private static final DockerImageName SCHEMA_REGISTRY_DOCKER_IMAGE =
+            DockerImageName.parse(SCHEMA_REGISTRY_DOCKER_IMAGE_NAME);
 
-    /**
-     * Port the SR will listen on.
-     */
+    /** Port the SR will listen on. */
     public static final int SCHEMA_REGISTRY_PORT = 8081;
 
     /**
-     * @param version
-     *            docker image version of schema registry
+     * @param version docker image version of schema registry
      */
     public SchemaRegistryContainer(final String version) {
         super(SCHEMA_REGISTRY_DOCKER_IMAGE.withTag(version));
@@ -48,8 +44,7 @@ public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryCont
     /**
      * Link to Kafka container
      *
-     * @param kafka
-     *            kafka container
+     * @param kafka kafka container
      * @return self.
      */
     public SchemaRegistryContainer withKafka(final KafkaContainer kafka) {
@@ -59,10 +54,8 @@ public class SchemaRegistryContainer extends GenericContainer<SchemaRegistryCont
     /**
      * Link to Network with Kafka
      *
-     * @param network
-     *            the network Kafka is running on
-     * @param bootstrapServers
-     *            the Kafka bootstrap servers
+     * @param network the network Kafka is running on
+     * @param bootstrapServers the Kafka bootstrap servers
      * @return self.
      */
     public SchemaRegistryContainer withKafka(final Network network, final String bootstrapServers) {

--- a/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
@@ -72,8 +72,10 @@ class ClientsFunctionalDemoTest extends AbstractContainerTest {
     private final SchemaRegistryClient schemaRegistryClient;
 
     ClientsFunctionalDemoTest() throws Exception {
-        final AdminClient adminClient = AdminClient.create(getClientProperties("admin", "admin-secret"));
-        schemaRegistryClient = new CachedSchemaRegistryClient(schemaRegistryContainer.getUrl(), 1000);
+        final AdminClient adminClient =
+                AdminClient.create(getClientProperties("admin", "admin-secret"));
+        schemaRegistryClient =
+                new CachedSchemaRegistryClient(schemaRegistryContainer.getUrl(), 1000);
         Provisioner.provision(apiSpec, "./build/resources/test", adminClient, schemaRegistryClient);
     }
 
@@ -82,31 +84,57 @@ class ClientsFunctionalDemoTest extends AbstractContainerTest {
     void shouldProvisionProduceAndConsumeUsingAvroWithSpeccy() throws Exception {
 
         final var domainTopics = apiSpec.listDomainOwnedTopics();
-        final var userSignedUpTopic = domainTopics.stream()
-                .filter(topic -> topic.name().endsWith("_public.user_signed_up")).findFirst()
-                .orElseThrow(() -> new RuntimeException("user_signed_up topic not found")).name();
+        final var userSignedUpTopic =
+                domainTopics.stream()
+                        .filter(topic -> topic.name().endsWith("_public.user_signed_up"))
+                        .findFirst()
+                        .orElseThrow(() -> new RuntimeException("user_signed_up topic not found"))
+                        .name();
 
         /*
          * Produce on the schema
          */
-        final KafkaProducer<Long, UserSignedUp> producer = producer(Long.class, UserSignedUp.class,
-                producerProperties(apiSpec.id(), "do-things", kafkaContainer.getBootstrapServers(),
-                        schemaRegistryContainer.getUrl(), LongSerializer.class, KafkaAvroSerializer.class, false,
-                        Provisioner.clientAuthProperties("simple.schema_demo", "simple.schema_demo-secret")));
+        final KafkaProducer<Long, UserSignedUp> producer =
+                producer(
+                        Long.class,
+                        UserSignedUp.class,
+                        producerProperties(
+                                apiSpec.id(),
+                                "do-things",
+                                kafkaContainer.getBootstrapServers(),
+                                schemaRegistryContainer.getUrl(),
+                                LongSerializer.class,
+                                KafkaAvroSerializer.class,
+                                false,
+                                Provisioner.clientAuthProperties(
+                                        "simple.schema_demo", "simple.schema_demo-secret")));
         final var sentRecord = new UserSignedUp("joe blogs", "blogy@twasmail.com", 100);
 
-        producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L, sentRecord)).get(60, TimeUnit.SECONDS);
+        producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L, sentRecord))
+                .get(60, TimeUnit.SECONDS);
 
-        final KafkaConsumer<Long, UserSignedUp> consumer = consumer(Long.class, UserSignedUp.class,
-                consumerProperties(apiSpec.id(), "do-things-in", kafkaContainer.getBootstrapServers(),
-                        schemaRegistryContainer.getUrl(), LongDeserializer.class, KafkaAvroDeserializer.class, true,
-                        Provisioner.clientAuthProperties("simple.schema_demo", "simple.schema_demo-secret")));
+        final KafkaConsumer<Long, UserSignedUp> consumer =
+                consumer(
+                        Long.class,
+                        UserSignedUp.class,
+                        consumerProperties(
+                                apiSpec.id(),
+                                "do-things-in",
+                                kafkaContainer.getBootstrapServers(),
+                                schemaRegistryContainer.getUrl(),
+                                LongDeserializer.class,
+                                KafkaAvroDeserializer.class,
+                                true,
+                                Provisioner.clientAuthProperties(
+                                        "simple.schema_demo", "simple.schema_demo-secret")));
         consumer.subscribe(Collections.singleton(userSignedUpTopic));
 
-        final ConsumerRecords<Long, UserSignedUp> consumerRecords = consumer.poll(Duration.ofSeconds(10));
+        final ConsumerRecords<Long, UserSignedUp> consumerRecords =
+                consumer.poll(Duration.ofSeconds(10));
         assertThat(consumerRecords, is(notNullValue()));
         assertThat(consumerRecords.count(), is(1));
-        MatcherAssert.assertThat(consumerRecords.iterator().next().value(), Matchers.is(sentRecord));
+        MatcherAssert.assertThat(
+                consumerRecords.iterator().next().value(), Matchers.is(sentRecord));
     }
 
     @Order(2)
@@ -114,30 +142,63 @@ class ClientsFunctionalDemoTest extends AbstractContainerTest {
     void shouldProvisionProduceAndConsumeProtoWithSpeccyClient() throws Exception {
 
         final List<NewTopic> domainTopics = apiSpec.listDomainOwnedTopics();
-        final var userInfoTopic = domainTopics.stream().filter(topic -> topic.name().endsWith("_public.user_info"))
-                .findFirst().orElseThrow().name();
+        final var userInfoTopic =
+                domainTopics.stream()
+                        .filter(topic -> topic.name().endsWith("_public.user_info"))
+                        .findFirst()
+                        .orElseThrow()
+                        .name();
 
         /*
          * Produce on the schema
          */
-        final KafkaProducer<Long, UserInfo> producer = producer(Long.class, UserInfo.class,
-                producerProperties(apiSpec.id(), "do-things-user-info", kafkaContainer.getBootstrapServers(),
-                        schemaRegistryContainer.getUrl(), LongSerializer.class, KafkaProtobufSerializer.class, false,
-                        Provisioner.clientAuthProperties("simple.schema_demo", "simple.schema_demo-secret")));
-        final var userSam = UserInfo.newBuilder().setFullName("sam fteex").setEmail("hello-sam@bahamas.island")
-                .setAge(52).build();
+        final KafkaProducer<Long, UserInfo> producer =
+                producer(
+                        Long.class,
+                        UserInfo.class,
+                        producerProperties(
+                                apiSpec.id(),
+                                "do-things-user-info",
+                                kafkaContainer.getBootstrapServers(),
+                                schemaRegistryContainer.getUrl(),
+                                LongSerializer.class,
+                                KafkaProtobufSerializer.class,
+                                false,
+                                Provisioner.clientAuthProperties(
+                                        "simple.schema_demo", "simple.schema_demo-secret")));
+        final var userSam =
+                UserInfo.newBuilder()
+                        .setFullName("sam fteex")
+                        .setEmail("hello-sam@bahamas.island")
+                        .setAge(52)
+                        .build();
 
-        producer.send(new ProducerRecord<>(userInfoTopic, 1000L, userSam)).get(60, TimeUnit.SECONDS);
+        producer.send(new ProducerRecord<>(userInfoTopic, 1000L, userSam))
+                .get(60, TimeUnit.SECONDS);
 
-        final KafkaConsumer<Long, UserInfo> consumer = consumer(Long.class, UserInfo.class, consumerProperties(
-                apiSpec.id(), "do-things-user-info-in", kafkaContainer.getBootstrapServers(),
-                schemaRegistryContainer.getUrl(), LongDeserializer.class, KafkaProtobufDeserializer.class, true,
-                Clients.mergeMaps(Provisioner.clientAuthProperties("simple.schema_demo", "simple.schema_demo-secret"),
-                        Map.of(KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_VALUE_TYPE, UserInfo.class.getName()))
+        final KafkaConsumer<Long, UserInfo> consumer =
+                consumer(
+                        Long.class,
+                        UserInfo.class,
+                        consumerProperties(
+                                apiSpec.id(),
+                                "do-things-user-info-in",
+                                kafkaContainer.getBootstrapServers(),
+                                schemaRegistryContainer.getUrl(),
+                                LongDeserializer.class,
+                                KafkaProtobufDeserializer.class,
+                                true,
+                                Clients.mergeMaps(
+                                        Provisioner.clientAuthProperties(
+                                                "simple.schema_demo", "simple.schema_demo-secret"),
+                                        Map.of(
+                                                KafkaProtobufDeserializerConfig
+                                                        .SPECIFIC_PROTOBUF_VALUE_TYPE,
+                                                UserInfo.class.getName()))));
 
-        ));
         consumer.subscribe(Collections.singleton(userInfoTopic));
-        final ConsumerRecords<Long, UserInfo> consumerRecords = consumer.poll(Duration.ofSeconds(10));
+        final ConsumerRecords<Long, UserInfo> consumerRecords =
+                consumer.poll(Duration.ofSeconds(10));
         assertThat(consumerRecords, is(notNullValue()));
         assertThat(consumerRecords.count(), is(1));
         MatcherAssert.assertThat(consumerRecords.iterator().next().value(), Matchers.is(userSam));
@@ -148,53 +209,109 @@ class ClientsFunctionalDemoTest extends AbstractContainerTest {
     void shouldProvisionInfraAndStreamStuffUsingProtoAndSpeccyClient() throws Exception {
 
         final var domainTopics = apiSpec.listDomainOwnedTopics();
-        final var userInfoTopic = domainTopics.stream().filter(topic -> topic.name().endsWith("_public.user_info"))
-                .findFirst().orElseThrow().name();
-        final var userInfoEnrichedTopic = domainTopics.stream()
-                .filter(topic -> topic.name().endsWith("_public.user_info_enriched")).findFirst().orElseThrow().name();
+        final var userInfoTopic =
+                domainTopics.stream()
+                        .filter(topic -> topic.name().endsWith("_public.user_info"))
+                        .findFirst()
+                        .orElseThrow()
+                        .name();
+        final var userInfoEnrichedTopic =
+                domainTopics.stream()
+                        .filter(topic -> topic.name().endsWith("_public.user_info_enriched"))
+                        .findFirst()
+                        .orElseThrow()
+                        .name();
 
-        final var streamsConfiguration = Clients.kstreamsProperties(apiSpec.id(), "streams-appid-service-thing",
-                kafkaContainer.getBootstrapServers(), schemaRegistryContainer.getUrl(), Serdes.LongSerde.class,
-                KafkaProtobufSerde.class, false,
-                Clients.mergeMaps(Provisioner.clientAuthProperties("simple.schema_demo", "simple.schema_demo-secret"),
-                        Map.of(KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_VALUE_TYPE,
-                                UserInfo.class.getName())));
+        final var streamsConfiguration =
+                Clients.kstreamsProperties(
+                        apiSpec.id(),
+                        "streams-appid-service-thing",
+                        kafkaContainer.getBootstrapServers(),
+                        schemaRegistryContainer.getUrl(),
+                        Serdes.LongSerde.class,
+                        KafkaProtobufSerde.class,
+                        false,
+                        Clients.mergeMaps(
+                                Provisioner.clientAuthProperties(
+                                        "simple.schema_demo", "simple.schema_demo-secret"),
+                                Map.of(
+                                        KafkaProtobufDeserializerConfig
+                                                .SPECIFIC_PROTOBUF_VALUE_TYPE,
+                                        UserInfo.class.getName())));
 
         final var builder = new StreamsBuilder();
 
         final KStream<Long, UserInfo> userInfos = builder.stream(userInfoTopic);
 
-        final var enrichedUsersStream = userInfos.mapValues(userInfo -> UserInfoEnriched.newBuilder()
-                .setAddress("hiding in the bahamas").setAge(userInfo.getAge()).setEmail(userInfo.getEmail()).build());
+        final var enrichedUsersStream =
+                userInfos.mapValues(
+                        userInfo ->
+                                UserInfoEnriched.newBuilder()
+                                        .setAddress("hiding in the bahamas")
+                                        .setAge(userInfo.getAge())
+                                        .setEmail(userInfo.getEmail())
+                                        .build());
 
-        enrichedUsersStream.to(userInfoEnrichedTopic,
-                with(Serdes.Long(), new KafkaProtobufSerde(schemaRegistryClient, UserInfoEnriched.class)));
+        enrichedUsersStream.to(
+                userInfoEnrichedTopic,
+                with(
+                        Serdes.Long(),
+                        new KafkaProtobufSerde(schemaRegistryClient, UserInfoEnriched.class)));
 
-        final var streams = new KafkaStreams(builder.build(), MapUtils.toProperties(streamsConfiguration));
+        final var streams =
+                new KafkaStreams(builder.build(), MapUtils.toProperties(streamsConfiguration));
         streams.start();
 
         /*
          * Run it
          */
-        final KafkaProducer<Long, UserInfo> producer = producer(Long.class, UserInfo.class,
-                producerProperties(apiSpec.id(), "do-things-user-info", kafkaContainer.getBootstrapServers(),
-                        schemaRegistryContainer.getUrl(), LongSerializer.class, KafkaProtobufSerializer.class, false,
-                        Provisioner.clientAuthProperties("simple.schema_demo", "simple.schema_demo-secret")));
+        final KafkaProducer<Long, UserInfo> producer =
+                producer(
+                        Long.class,
+                        UserInfo.class,
+                        producerProperties(
+                                apiSpec.id(),
+                                "do-things-user-info",
+                                kafkaContainer.getBootstrapServers(),
+                                schemaRegistryContainer.getUrl(),
+                                LongSerializer.class,
+                                KafkaProtobufSerializer.class,
+                                false,
+                                Provisioner.clientAuthProperties(
+                                        "simple.schema_demo", "simple.schema_demo-secret")));
 
-        final var userSam = UserInfo.newBuilder().setFullName("sam fteex").setEmail("hello-sam@bahamas.island")
-                .setAge(52).build();
-        producer.send(new ProducerRecord<>(userInfoTopic, 1000L, userSam)).get(60, TimeUnit.SECONDS);
+        final var userSam =
+                UserInfo.newBuilder()
+                        .setFullName("sam fteex")
+                        .setEmail("hello-sam@bahamas.island")
+                        .setAge(52)
+                        .build();
+        producer.send(new ProducerRecord<>(userInfoTopic, 1000L, userSam))
+                .get(60, TimeUnit.SECONDS);
 
-        final KafkaConsumer<Long, UserInfoEnriched> consumer = consumer(Long.class, UserInfoEnriched.class,
-                consumerProperties(apiSpec.id(), "streams-consumer-validate", kafkaContainer.getBootstrapServers(),
-                        schemaRegistryContainer.getUrl(), LongDeserializer.class, KafkaProtobufDeserializer.class, true,
-                        Clients.mergeMaps(
-                                Provisioner.clientAuthProperties("simple.schema_demo", "simple.schema_demo-secret"),
-                                Map.of(KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_VALUE_TYPE,
-                                        UserInfoEnriched.class.getName()))));
+        final KafkaConsumer<Long, UserInfoEnriched> consumer =
+                consumer(
+                        Long.class,
+                        UserInfoEnriched.class,
+                        consumerProperties(
+                                apiSpec.id(),
+                                "streams-consumer-validate",
+                                kafkaContainer.getBootstrapServers(),
+                                schemaRegistryContainer.getUrl(),
+                                LongDeserializer.class,
+                                KafkaProtobufDeserializer.class,
+                                true,
+                                Clients.mergeMaps(
+                                        Provisioner.clientAuthProperties(
+                                                "simple.schema_demo", "simple.schema_demo-secret"),
+                                        Map.of(
+                                                KafkaProtobufDeserializerConfig
+                                                        .SPECIFIC_PROTOBUF_VALUE_TYPE,
+                                                UserInfoEnriched.class.getName()))));
 
         consumer.subscribe(Collections.singleton(userInfoEnrichedTopic));
-        final ConsumerRecords<Long, UserInfoEnriched> consumerRecords = consumer.poll(Duration.ofSeconds(10));
+        final ConsumerRecords<Long, UserInfoEnriched> consumerRecords =
+                consumer.poll(Duration.ofSeconds(10));
 
         final var consumerRecordStream = Stream.generate(consumerRecords.iterator()::next);
 
@@ -202,15 +319,22 @@ class ClientsFunctionalDemoTest extends AbstractContainerTest {
          * Verify
          */
         assertThat(consumerRecords, is(notNullValue()));
-        final var foundIt = consumerRecordStream
-                .filter((record) -> record.value().getAddress().equals("hiding in the bahamas")).findFirst();
+        final var foundIt =
+                consumerRecordStream
+                        .filter(
+                                (record) ->
+                                        record.value().getAddress().equals("hiding in the bahamas"))
+                        .findFirst();
         assertThat(foundIt.isPresent(), is(true));
     }
 
     private static ApiSpec getAPISpecFromResource() {
         try {
-            return new AsyncApiParser().loadResource(ClientsFunctionalDemoTest.class.getClassLoader()
-                    .getResourceAsStream("simple_schema_demo-api.yaml"));
+            return new AsyncApiParser()
+                    .loadResource(
+                            ClientsFunctionalDemoTest.class
+                                    .getClassLoader()
+                                    .getResourceAsStream("simple_schema_demo-api.yaml"));
         } catch (Throwable t) {
             throw new RuntimeException("Failed to load test resource", t);
         }
@@ -220,7 +344,8 @@ class ClientsFunctionalDemoTest extends AbstractContainerTest {
         final Properties properties = new Properties();
         properties.putAll(Provisioner.clientAuthProperties(principle, secret));
         properties.put(AdminClientConfig.CLIENT_ID_CONFIG, apiSpec.id());
-        properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
+        properties.put(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafkaContainer.getBootstrapServers());
 
         return properties;
     }

--- a/kafka-test/src/test/java/io/specmesh/kafka/schema/SimpleSchemaDemoPublicUserInfo.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/schema/SimpleSchemaDemoPublicUserInfo.java
@@ -25,18 +25,18 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressWarnings("all")
 @SuppressFBWarnings
 public final class SimpleSchemaDemoPublicUserInfo {
-    private SimpleSchemaDemoPublicUserInfo() {
-    }
-    public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite registry) {
-    }
+    private SimpleSchemaDemoPublicUserInfo() {}
+
+    public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite registry) {}
 
     public static void registerAllExtensions(com.google.protobuf.ExtensionRegistry registry) {
         registerAllExtensions((com.google.protobuf.ExtensionRegistryLite) registry);
     }
+
     public interface UserInfoOrBuilder
             extends
-                // @@protoc_insertion_point(interface_extends:io.specmesh.kafka.schema.UserInfo)
-                com.google.protobuf.MessageOrBuilder {
+            // @@protoc_insertion_point(interface_extends:io.specmesh.kafka.schema.UserInfo)
+            com.google.protobuf.MessageOrBuilder {
 
         /**
          * <code>string fullName = 1;</code>
@@ -71,18 +71,17 @@ public final class SimpleSchemaDemoPublicUserInfo {
          */
         int getAge();
     }
-    /**
-     * Protobuf type {@code io.specmesh.kafka.schema.UserInfo}
-     */
+    /** Protobuf type {@code io.specmesh.kafka.schema.UserInfo} */
     public static final class UserInfo extends com.google.protobuf.GeneratedMessageV3
             implements
-                // @@protoc_insertion_point(message_implements:io.specmesh.kafka.schema.UserInfo)
-                UserInfoOrBuilder {
+            // @@protoc_insertion_point(message_implements:io.specmesh.kafka.schema.UserInfo)
+            UserInfoOrBuilder {
         private static final long serialVersionUID = 0L;
         // Use UserInfo.newBuilder() to construct.
         private UserInfo(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
             super(builder);
         }
+
         private UserInfo() {
             fullName_ = "";
             email_ = "";
@@ -98,19 +97,25 @@ public final class SimpleSchemaDemoPublicUserInfo {
         public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
             return this.unknownFields;
         }
+
         public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.internal_static_io_specmesh_kafka_schema_UserInfo_descriptor;
+            return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo
+                    .internal_static_io_specmesh_kafka_schema_UserInfo_descriptor;
         }
 
         @java.lang.Override
-        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable() {
-            return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.internal_static_io_specmesh_kafka_schema_UserInfo_fieldAccessorTable
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+                internalGetFieldAccessorTable() {
+            return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo
+                    .internal_static_io_specmesh_kafka_schema_UserInfo_fieldAccessorTable
                     .ensureFieldAccessorsInitialized(
                             io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo.class,
-                            io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo.Builder.class);
+                            io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo.Builder
+                                    .class);
         }
 
         public static final int FULLNAME_FIELD_NUMBER = 1;
+
         @SuppressWarnings("serial")
         private volatile java.lang.Object fullName_ = "";
         /**
@@ -139,7 +144,8 @@ public final class SimpleSchemaDemoPublicUserInfo {
         public com.google.protobuf.ByteString getFullNameBytes() {
             java.lang.Object ref = fullName_;
             if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+                com.google.protobuf.ByteString b =
+                        com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                 fullName_ = b;
                 return b;
             } else {
@@ -148,6 +154,7 @@ public final class SimpleSchemaDemoPublicUserInfo {
         }
 
         public static final int EMAIL_FIELD_NUMBER = 2;
+
         @SuppressWarnings("serial")
         private volatile java.lang.Object email_ = "";
         /**
@@ -176,7 +183,8 @@ public final class SimpleSchemaDemoPublicUserInfo {
         public com.google.protobuf.ByteString getEmailBytes() {
             java.lang.Object ref = email_;
             if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+                com.google.protobuf.ByteString b =
+                        com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                 email_ = b;
                 return b;
             } else {
@@ -197,20 +205,20 @@ public final class SimpleSchemaDemoPublicUserInfo {
         }
 
         private byte memoizedIsInitialized = -1;
+
         @java.lang.Override
         public final boolean isInitialized() {
             byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1)
-                return true;
-            if (isInitialized == 0)
-                return false;
+            if (isInitialized == 1) return true;
+            if (isInitialized == 0) return false;
 
             memoizedIsInitialized = 1;
             return true;
         }
 
         @java.lang.Override
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
+        public void writeTo(com.google.protobuf.CodedOutputStream output)
+                throws java.io.IOException {
             if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(fullName_)) {
                 com.google.protobuf.GeneratedMessageV3.writeString(output, 1, fullName_);
             }
@@ -226,8 +234,7 @@ public final class SimpleSchemaDemoPublicUserInfo {
         @java.lang.Override
         public int getSerializedSize() {
             int size = memoizedSize;
-            if (size != -1)
-                return size;
+            if (size != -1) return size;
 
             size = 0;
             if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(fullName_)) {
@@ -249,19 +256,17 @@ public final class SimpleSchemaDemoPublicUserInfo {
             if (obj == this) {
                 return true;
             }
-            if (!(obj instanceof io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo)) {
+            if (!(obj
+                    instanceof io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo)) {
                 return super.equals(obj);
             }
-            io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo other = (io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo) obj;
+            io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo other =
+                    (io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo) obj;
 
-            if (!getFullName().equals(other.getFullName()))
-                return false;
-            if (!getEmail().equals(other.getEmail()))
-                return false;
-            if (getAge() != other.getAge())
-                return false;
-            if (!getUnknownFields().equals(other.getUnknownFields()))
-                return false;
+            if (!getFullName().equals(other.getFullName())) return false;
+            if (!getEmail().equals(other.getEmail())) return false;
+            if (getAge() != other.getAge()) return false;
+            if (!getUnknownFields().equals(other.getUnknownFields())) return false;
             return true;
         }
 
@@ -284,110 +289,139 @@ public final class SimpleSchemaDemoPublicUserInfo {
         }
 
         public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
-                java.nio.ByteBuffer data) throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
-                java.nio.ByteBuffer data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
-                com.google.protobuf.ByteString data) throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data);
-        }
-        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
-                com.google.protobuf.ByteString data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                throws com.google.protobuf.InvalidProtocolBufferException {
-            return PARSER.parseFrom(data, extensionRegistry);
-        }
-        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(byte[] data)
+                java.nio.ByteBuffer data)
                 throws com.google.protobuf.InvalidProtocolBufferException {
             return PARSER.parseFrom(data);
         }
-        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(byte[] data,
+
+        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
+                java.nio.ByteBuffer data,
                 com.google.protobuf.ExtensionRegistryLite extensionRegistry)
                 throws com.google.protobuf.InvalidProtocolBufferException {
             return PARSER.parseFrom(data, extensionRegistry);
         }
+
+        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
+                com.google.protobuf.ByteString data)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data);
+        }
+
+        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
+                com.google.protobuf.ByteString data,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data, extensionRegistry);
+        }
+
+        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
+                byte[] data) throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data);
+        }
+
+        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
+                byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws com.google.protobuf.InvalidProtocolBufferException {
+            return PARSER.parseFrom(data, extensionRegistry);
+        }
+
         public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
                 java.io.InputStream input) throws java.io.IOException {
             return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
         }
+
         public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
-                java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                java.io.InputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
                 throws java.io.IOException {
-            return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input, extensionRegistry);
+            return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+                    PARSER, input, extensionRegistry);
         }
-        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseDelimitedFrom(
-                java.io.InputStream input) throws java.io.IOException {
-            return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
+
+        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                parseDelimitedFrom(java.io.InputStream input) throws java.io.IOException {
+            return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+                    PARSER, input);
         }
-        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseDelimitedFrom(
-                java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                throws java.io.IOException {
-            return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input,
-                    extensionRegistry);
+
+        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                parseDelimitedFrom(
+                        java.io.InputStream input,
+                        com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                        throws java.io.IOException {
+            return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+                    PARSER, input, extensionRegistry);
         }
+
         public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
                 com.google.protobuf.CodedInputStream input) throws java.io.IOException {
             return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
         }
+
         public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo parseFrom(
-                com.google.protobuf.CodedInputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
                 throws java.io.IOException {
-            return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input, extensionRegistry);
+            return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+                    PARSER, input, extensionRegistry);
         }
 
         @java.lang.Override
         public Builder newBuilderForType() {
             return newBuilder();
         }
+
         public static Builder newBuilder() {
             return DEFAULT_INSTANCE.toBuilder();
         }
-        public static Builder newBuilder(io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo prototype) {
+
+        public static Builder newBuilder(
+                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo prototype) {
             return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
         }
+
         @java.lang.Override
         public Builder toBuilder() {
             return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
         }
 
         @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        protected Builder newBuilderForType(
+                com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
             Builder builder = new Builder(parent);
             return builder;
         }
-        /**
-         * Protobuf type {@code io.specmesh.kafka.schema.UserInfo}
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+        /** Protobuf type {@code io.specmesh.kafka.schema.UserInfo} */
+        public static final class Builder
+                extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
                 implements
-                    // @@protoc_insertion_point(builder_implements:io.specmesh.kafka.schema.UserInfo)
-                    io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfoOrBuilder {
+                // @@protoc_insertion_point(builder_implements:io.specmesh.kafka.schema.UserInfo)
+                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfoOrBuilder {
             public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.internal_static_io_specmesh_kafka_schema_UserInfo_descriptor;
+                return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo
+                        .internal_static_io_specmesh_kafka_schema_UserInfo_descriptor;
             }
 
             @java.lang.Override
-            protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable() {
-                return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.internal_static_io_specmesh_kafka_schema_UserInfo_fieldAccessorTable
+            protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+                    internalGetFieldAccessorTable() {
+                return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo
+                        .internal_static_io_specmesh_kafka_schema_UserInfo_fieldAccessorTable
                         .ensureFieldAccessorsInitialized(
-                                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo.class,
-                                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo.Builder.class);
+                                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                                        .class,
+                                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                                        .Builder.class);
             }
 
             // Construct using
             // io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo.newBuilder()
-            private Builder() {
-
-            }
+            private Builder() {}
 
             private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
                 super(parent);
-
             }
+
             @java.lang.Override
             public Builder clear() {
                 super.clear();
@@ -400,17 +434,21 @@ public final class SimpleSchemaDemoPublicUserInfo {
 
             @java.lang.Override
             public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.internal_static_io_specmesh_kafka_schema_UserInfo_descriptor;
+                return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo
+                        .internal_static_io_specmesh_kafka_schema_UserInfo_descriptor;
             }
 
             @java.lang.Override
-            public io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo getDefaultInstanceForType() {
-                return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo.getDefaultInstance();
+            public io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                    getDefaultInstanceForType() {
+                return io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                        .getDefaultInstance();
             }
 
             @java.lang.Override
             public io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo build() {
-                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo result = buildPartial();
+                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo result =
+                        buildPartial();
                 if (!result.isInitialized()) {
                     throw newUninitializedMessageException(result);
                 }
@@ -419,8 +457,8 @@ public final class SimpleSchemaDemoPublicUserInfo {
 
             @java.lang.Override
             public io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo buildPartial() {
-                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo result = new io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo(
-                        this);
+                io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo result =
+                        new io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo(this);
                 if (bitField0_ != 0) {
                     buildPartial0(result);
                 }
@@ -428,7 +466,8 @@ public final class SimpleSchemaDemoPublicUserInfo {
                 return result;
             }
 
-            private void buildPartial0(io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo result) {
+            private void buildPartial0(
+                    io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo result) {
                 int from_bitField0_ = bitField0_;
                 if (((from_bitField0_ & 0x00000001) != 0)) {
                     result.fullName_ = fullName_;
@@ -445,41 +484,56 @@ public final class SimpleSchemaDemoPublicUserInfo {
             public Builder clone() {
                 return super.clone();
             }
+
             @java.lang.Override
-            public Builder setField(com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
+            public Builder setField(
+                    com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
                 return super.setField(field, value);
             }
+
             @java.lang.Override
             public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
                 return super.clearField(field);
             }
+
             @java.lang.Override
             public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
                 return super.clearOneof(oneof);
             }
+
             @java.lang.Override
-            public Builder setRepeatedField(com.google.protobuf.Descriptors.FieldDescriptor field, int index,
+            public Builder setRepeatedField(
+                    com.google.protobuf.Descriptors.FieldDescriptor field,
+                    int index,
                     java.lang.Object value) {
                 return super.setRepeatedField(field, index, value);
             }
+
             @java.lang.Override
-            public Builder addRepeatedField(com.google.protobuf.Descriptors.FieldDescriptor field,
-                    java.lang.Object value) {
+            public Builder addRepeatedField(
+                    com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
                 return super.addRepeatedField(field, value);
             }
+
             @java.lang.Override
             public Builder mergeFrom(com.google.protobuf.Message other) {
-                if (other instanceof io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo) {
-                    return mergeFrom((io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo) other);
+                if (other
+                        instanceof
+                        io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo) {
+                    return mergeFrom(
+                            (io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo)
+                                    other);
                 } else {
                     super.mergeFrom(other);
                     return this;
                 }
             }
 
-            public Builder mergeFrom(io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo other) {
-                if (other == io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo.getDefaultInstance())
-                    return this;
+            public Builder mergeFrom(
+                    io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo other) {
+                if (other
+                        == io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                                .getDefaultInstance()) return this;
                 if (!other.getFullName().isEmpty()) {
                     fullName_ = other.fullName_;
                     bitField0_ |= 0x00000001;
@@ -504,8 +558,10 @@ public final class SimpleSchemaDemoPublicUserInfo {
             }
 
             @java.lang.Override
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                    com.google.protobuf.ExtensionRegistryLite extensionRegistry) throws java.io.IOException {
+            public Builder mergeFrom(
+                    com.google.protobuf.CodedInputStream input,
+                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                    throws java.io.IOException {
                 if (extensionRegistry == null) {
                     throw new java.lang.NullPointerException();
                 }
@@ -514,30 +570,34 @@ public final class SimpleSchemaDemoPublicUserInfo {
                     while (!done) {
                         int tag = input.readTag();
                         switch (tag) {
-                            case 0 :
+                            case 0:
                                 done = true;
                                 break;
-                            case 10 : {
-                                fullName_ = input.readStringRequireUtf8();
-                                bitField0_ |= 0x00000001;
-                                break;
-                            } // case 10
-                            case 18 : {
-                                email_ = input.readStringRequireUtf8();
-                                bitField0_ |= 0x00000002;
-                                break;
-                            } // case 18
-                            case 24 : {
-                                age_ = input.readInt32();
-                                bitField0_ |= 0x00000004;
-                                break;
-                            } // case 24
-                            default : {
-                                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
-                                    done = true; // was an endgroup tag
-                                }
-                                break;
-                            } // default:
+                            case 10:
+                                {
+                                    fullName_ = input.readStringRequireUtf8();
+                                    bitField0_ |= 0x00000001;
+                                    break;
+                                } // case 10
+                            case 18:
+                                {
+                                    email_ = input.readStringRequireUtf8();
+                                    bitField0_ |= 0x00000002;
+                                    break;
+                                } // case 18
+                            case 24:
+                                {
+                                    age_ = input.readInt32();
+                                    bitField0_ |= 0x00000004;
+                                    break;
+                                } // case 24
+                            default:
+                                {
+                                    if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                                        done = true; // was an endgroup tag
+                                    }
+                                    break;
+                                } // default:
                         } // switch (tag)
                     } // while (!done)
                 } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -547,6 +607,7 @@ public final class SimpleSchemaDemoPublicUserInfo {
                 } // finally
                 return this;
             }
+
             private int bitField0_;
 
             private java.lang.Object fullName_ = "";
@@ -574,8 +635,8 @@ public final class SimpleSchemaDemoPublicUserInfo {
             public com.google.protobuf.ByteString getFullNameBytes() {
                 java.lang.Object ref = fullName_;
                 if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString
-                            .copyFromUtf8((java.lang.String) ref);
+                    com.google.protobuf.ByteString b =
+                            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                     fullName_ = b;
                     return b;
                 } else {
@@ -585,8 +646,7 @@ public final class SimpleSchemaDemoPublicUserInfo {
             /**
              * <code>string fullName = 1;</code>
              *
-             * @param value
-             *            The fullName to set.
+             * @param value The fullName to set.
              * @return This builder for chaining.
              */
             public Builder setFullName(java.lang.String value) {
@@ -612,8 +672,7 @@ public final class SimpleSchemaDemoPublicUserInfo {
             /**
              * <code>string fullName = 1;</code>
              *
-             * @param value
-             *            The bytes for fullName to set.
+             * @param value The bytes for fullName to set.
              * @return This builder for chaining.
              */
             public Builder setFullNameBytes(com.google.protobuf.ByteString value) {
@@ -652,8 +711,8 @@ public final class SimpleSchemaDemoPublicUserInfo {
             public com.google.protobuf.ByteString getEmailBytes() {
                 java.lang.Object ref = email_;
                 if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString
-                            .copyFromUtf8((java.lang.String) ref);
+                    com.google.protobuf.ByteString b =
+                            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                     email_ = b;
                     return b;
                 } else {
@@ -663,8 +722,7 @@ public final class SimpleSchemaDemoPublicUserInfo {
             /**
              * <code>string email = 2;</code>
              *
-             * @param value
-             *            The email to set.
+             * @param value The email to set.
              * @return This builder for chaining.
              */
             public Builder setEmail(java.lang.String value) {
@@ -690,8 +748,7 @@ public final class SimpleSchemaDemoPublicUserInfo {
             /**
              * <code>string email = 2;</code>
              *
-             * @param value
-             *            The bytes for email to set.
+             * @param value The bytes for email to set.
              * @return This builder for chaining.
              */
             public Builder setEmailBytes(com.google.protobuf.ByteString value) {
@@ -718,8 +775,7 @@ public final class SimpleSchemaDemoPublicUserInfo {
             /**
              * <code>int32 age = 3;</code>
              *
-             * @param value
-             *            The age to set.
+             * @param value The age to set.
              * @return This builder for chaining.
              */
             public Builder setAge(int value) {
@@ -740,13 +796,16 @@ public final class SimpleSchemaDemoPublicUserInfo {
                 onChanged();
                 return this;
             }
+
             @java.lang.Override
-            public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
+            public final Builder setUnknownFields(
+                    final com.google.protobuf.UnknownFieldSet unknownFields) {
                 return super.setUnknownFields(unknownFields);
             }
 
             @java.lang.Override
-            public final Builder mergeUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
+            public final Builder mergeUnknownFields(
+                    final com.google.protobuf.UnknownFieldSet unknownFields) {
                 return super.mergeUnknownFields(unknownFields);
             }
 
@@ -754,34 +813,41 @@ public final class SimpleSchemaDemoPublicUserInfo {
         }
 
         // @@protoc_insertion_point(class_scope:io.specmesh.kafka.schema.UserInfo)
-        private static final io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo DEFAULT_INSTANCE;
+        private static final io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                DEFAULT_INSTANCE;
+
         static {
-            DEFAULT_INSTANCE = new io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo();
+            DEFAULT_INSTANCE =
+                    new io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo();
         }
 
-        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo getDefaultInstance() {
+        public static io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                getDefaultInstance() {
             return DEFAULT_INSTANCE;
         }
 
-        private static final com.google.protobuf.Parser<UserInfo> PARSER = new com.google.protobuf.AbstractParser<UserInfo>() {
-            @java.lang.Override
-            public UserInfo parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                    throws com.google.protobuf.InvalidProtocolBufferException {
-                Builder builder = newBuilder();
-                try {
-                    builder.mergeFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    throw e.setUnfinishedMessage(builder.buildPartial());
-                } catch (com.google.protobuf.UninitializedMessageException e) {
-                    throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-                } catch (java.io.IOException e) {
-                    throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                            .setUnfinishedMessage(builder.buildPartial());
-                }
-                return builder.buildPartial();
-            }
-        };
+        private static final com.google.protobuf.Parser<UserInfo> PARSER =
+                new com.google.protobuf.AbstractParser<UserInfo>() {
+                    @java.lang.Override
+                    public UserInfo parsePartialFrom(
+                            com.google.protobuf.CodedInputStream input,
+                            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                            throws com.google.protobuf.InvalidProtocolBufferException {
+                        Builder builder = newBuilder();
+                        try {
+                            builder.mergeFrom(input, extensionRegistry);
+                        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                            throw e.setUnfinishedMessage(builder.buildPartial());
+                        } catch (com.google.protobuf.UninitializedMessageException e) {
+                            throw e.asInvalidProtocolBufferException()
+                                    .setUnfinishedMessage(builder.buildPartial());
+                        } catch (java.io.IOException e) {
+                            throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                                    .setUnfinishedMessage(builder.buildPartial());
+                        }
+                        return builder.buildPartial();
+                    }
+                };
 
         public static com.google.protobuf.Parser<UserInfo> parser() {
             return PARSER;
@@ -793,30 +859,41 @@ public final class SimpleSchemaDemoPublicUserInfo {
         }
 
         @java.lang.Override
-        public io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo getDefaultInstanceForType() {
+        public io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo
+                getDefaultInstanceForType() {
             return DEFAULT_INSTANCE;
         }
-
     }
 
-    private static final com.google.protobuf.Descriptors.Descriptor internal_static_io_specmesh_kafka_schema_UserInfo_descriptor;
-    private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable internal_static_io_specmesh_kafka_schema_UserInfo_fieldAccessorTable;
+    private static final com.google.protobuf.Descriptors.Descriptor
+            internal_static_io_specmesh_kafka_schema_UserInfo_descriptor;
+    private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internal_static_io_specmesh_kafka_schema_UserInfo_fieldAccessorTable;
 
     public static com.google.protobuf.Descriptors.FileDescriptor getDescriptor() {
         return descriptor;
     }
+
     private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
+
     static {
         java.lang.String[] descriptorData = {
-                "\n*simple.schema_demo._public.user_info.p" + "roto\022\030io.specmesh.kafka.schema\"8\n\010UserIn"
-                        + "fo\022\020\n\010fullName\030\001 \001(\t\022\r\n\005email\030\002 \001(\t\022\013\n\003a"
-                        + "ge\030\003 \001(\005b\006proto3"};
-        descriptor = com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(descriptorData,
-                new com.google.protobuf.Descriptors.FileDescriptor[]{});
-        internal_static_io_specmesh_kafka_schema_UserInfo_descriptor = getDescriptor().getMessageTypes().get(0);
-        internal_static_io_specmesh_kafka_schema_UserInfo_fieldAccessorTable = new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-                internal_static_io_specmesh_kafka_schema_UserInfo_descriptor,
-                new java.lang.String[]{"FullName", "Email", "Age",});
+            "\n*simple.schema_demo._public.user_info.p"
+                    + "roto\022\030io.specmesh.kafka.schema\"8\n\010UserIn"
+                    + "fo\022\020\n\010fullName\030\001 \001(\t\022\r\n\005email\030\002 \001(\t\022\013\n\003a"
+                    + "ge\030\003 \001(\005b\006proto3"
+        };
+        descriptor =
+                com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+                        descriptorData, new com.google.protobuf.Descriptors.FileDescriptor[] {});
+        internal_static_io_specmesh_kafka_schema_UserInfo_descriptor =
+                getDescriptor().getMessageTypes().get(0);
+        internal_static_io_specmesh_kafka_schema_UserInfo_fieldAccessorTable =
+                new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+                        internal_static_io_specmesh_kafka_schema_UserInfo_descriptor,
+                        new java.lang.String[] {
+                            "FullName", "Email", "Age",
+                        });
     }
 
     // @@protoc_insertion_point(outer_class_scope)

--- a/kafka-test/src/test/java/io/specmesh/kafka/schema/SimpleSchemaDemoPublicUserInfoEnriched.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/schema/SimpleSchemaDemoPublicUserInfoEnriched.java
@@ -25,18 +25,18 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 @SuppressWarnings("all")
 @SuppressFBWarnings
 public final class SimpleSchemaDemoPublicUserInfoEnriched {
-    private SimpleSchemaDemoPublicUserInfoEnriched() {
-    }
-    public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite registry) {
-    }
+    private SimpleSchemaDemoPublicUserInfoEnriched() {}
+
+    public static void registerAllExtensions(com.google.protobuf.ExtensionRegistryLite registry) {}
 
     public static void registerAllExtensions(com.google.protobuf.ExtensionRegistry registry) {
         registerAllExtensions((com.google.protobuf.ExtensionRegistryLite) registry);
     }
+
     public interface UserInfoEnrichedOrBuilder
             extends
-                // @@protoc_insertion_point(interface_extends:io.specmesh.kafka.schema.UserInfoEnriched)
-                com.google.protobuf.MessageOrBuilder {
+            // @@protoc_insertion_point(interface_extends:io.specmesh.kafka.schema.UserInfoEnriched)
+            com.google.protobuf.MessageOrBuilder {
 
         /**
          * <code>string fullName = 1;</code>
@@ -84,18 +84,17 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
          */
         int getAge();
     }
-    /**
-     * Protobuf type {@code io.specmesh.kafka.schema.UserInfoEnriched}
-     */
+    /** Protobuf type {@code io.specmesh.kafka.schema.UserInfoEnriched} */
     public static final class UserInfoEnriched extends com.google.protobuf.GeneratedMessageV3
             implements
-                // @@protoc_insertion_point(message_implements:io.specmesh.kafka.schema.UserInfoEnriched)
-                UserInfoEnrichedOrBuilder {
+            // @@protoc_insertion_point(message_implements:io.specmesh.kafka.schema.UserInfoEnriched)
+            UserInfoEnrichedOrBuilder {
         private static final long serialVersionUID = 0L;
         // Use UserInfoEnriched.newBuilder() to construct.
         private UserInfoEnriched(com.google.protobuf.GeneratedMessageV3.Builder<?> builder) {
             super(builder);
         }
+
         private UserInfoEnriched() {
             fullName_ = "";
             email_ = "";
@@ -112,18 +111,24 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         public final com.google.protobuf.UnknownFieldSet getUnknownFields() {
             return this.unknownFields;
         }
+
         public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-            return SimpleSchemaDemoPublicUserInfoEnriched.internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor;
+            return SimpleSchemaDemoPublicUserInfoEnriched
+                    .internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor;
         }
 
         @java.lang.Override
-        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable() {
-            return SimpleSchemaDemoPublicUserInfoEnriched.internal_static_io_specmesh_kafka_schema_UserInfoEnriched_fieldAccessorTable
-                    .ensureFieldAccessorsInitialized(SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.class,
+        protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+                internalGetFieldAccessorTable() {
+            return SimpleSchemaDemoPublicUserInfoEnriched
+                    .internal_static_io_specmesh_kafka_schema_UserInfoEnriched_fieldAccessorTable
+                    .ensureFieldAccessorsInitialized(
+                            SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.class,
                             SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.Builder.class);
         }
 
         public static final int FULLNAME_FIELD_NUMBER = 1;
+
         @SuppressWarnings("serial")
         private volatile java.lang.Object fullName_ = "";
         /**
@@ -152,7 +157,8 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         public com.google.protobuf.ByteString getFullNameBytes() {
             java.lang.Object ref = fullName_;
             if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+                com.google.protobuf.ByteString b =
+                        com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                 fullName_ = b;
                 return b;
             } else {
@@ -161,6 +167,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         }
 
         public static final int EMAIL_FIELD_NUMBER = 2;
+
         @SuppressWarnings("serial")
         private volatile java.lang.Object email_ = "";
         /**
@@ -189,7 +196,8 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         public com.google.protobuf.ByteString getEmailBytes() {
             java.lang.Object ref = email_;
             if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+                com.google.protobuf.ByteString b =
+                        com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                 email_ = b;
                 return b;
             } else {
@@ -198,6 +206,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         }
 
         public static final int ADDRESS_FIELD_NUMBER = 3;
+
         @SuppressWarnings("serial")
         private volatile java.lang.Object address_ = "";
         /**
@@ -226,7 +235,8 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         public com.google.protobuf.ByteString getAddressBytes() {
             java.lang.Object ref = address_;
             if (ref instanceof java.lang.String) {
-                com.google.protobuf.ByteString b = com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
+                com.google.protobuf.ByteString b =
+                        com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                 address_ = b;
                 return b;
             } else {
@@ -247,20 +257,20 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         }
 
         private byte memoizedIsInitialized = -1;
+
         @java.lang.Override
         public final boolean isInitialized() {
             byte isInitialized = memoizedIsInitialized;
-            if (isInitialized == 1)
-                return true;
-            if (isInitialized == 0)
-                return false;
+            if (isInitialized == 1) return true;
+            if (isInitialized == 0) return false;
 
             memoizedIsInitialized = 1;
             return true;
         }
 
         @java.lang.Override
-        public void writeTo(com.google.protobuf.CodedOutputStream output) throws java.io.IOException {
+        public void writeTo(com.google.protobuf.CodedOutputStream output)
+                throws java.io.IOException {
             if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(fullName_)) {
                 com.google.protobuf.GeneratedMessageV3.writeString(output, 1, fullName_);
             }
@@ -279,8 +289,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         @java.lang.Override
         public int getSerializedSize() {
             int size = memoizedSize;
-            if (size != -1)
-                return size;
+            if (size != -1) return size;
 
             size = 0;
             if (!com.google.protobuf.GeneratedMessageV3.isStringEmpty(fullName_)) {
@@ -308,18 +317,14 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             if (!(obj instanceof SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched)) {
                 return super.equals(obj);
             }
-            SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched other = (SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched) obj;
+            SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched other =
+                    (SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched) obj;
 
-            if (!getFullName().equals(other.getFullName()))
-                return false;
-            if (!getEmail().equals(other.getEmail()))
-                return false;
-            if (!getAddress().equals(other.getAddress()))
-                return false;
-            if (getAge() != other.getAge())
-                return false;
-            if (!getUnknownFields().equals(other.getUnknownFields()))
-                return false;
+            if (!getFullName().equals(other.getFullName())) return false;
+            if (!getEmail().equals(other.getEmail())) return false;
+            if (!getAddress().equals(other.getAddress())) return false;
+            if (getAge() != other.getAge()) return false;
+            if (!getUnknownFields().equals(other.getUnknownFields())) return false;
             return true;
         }
 
@@ -343,109 +348,138 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             return hash;
         }
 
-        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(java.nio.ByteBuffer data)
+        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(
+                java.nio.ByteBuffer data)
                 throws com.google.protobuf.InvalidProtocolBufferException {
             return PARSER.parseFrom(data);
         }
-        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(java.nio.ByteBuffer data,
+
+        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(
+                java.nio.ByteBuffer data,
                 com.google.protobuf.ExtensionRegistryLite extensionRegistry)
                 throws com.google.protobuf.InvalidProtocolBufferException {
             return PARSER.parseFrom(data, extensionRegistry);
         }
+
         public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(
-                com.google.protobuf.ByteString data) throws com.google.protobuf.InvalidProtocolBufferException {
+                com.google.protobuf.ByteString data)
+                throws com.google.protobuf.InvalidProtocolBufferException {
             return PARSER.parseFrom(data);
         }
+
         public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(
-                com.google.protobuf.ByteString data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                com.google.protobuf.ByteString data,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
                 throws com.google.protobuf.InvalidProtocolBufferException {
             return PARSER.parseFrom(data, extensionRegistry);
         }
+
         public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(byte[] data)
                 throws com.google.protobuf.InvalidProtocolBufferException {
             return PARSER.parseFrom(data);
         }
-        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(byte[] data,
-                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+
+        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(
+                byte[] data, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
                 throws com.google.protobuf.InvalidProtocolBufferException {
             return PARSER.parseFrom(data, extensionRegistry);
         }
-        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(java.io.InputStream input)
-                throws java.io.IOException {
+
+        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(
+                java.io.InputStream input) throws java.io.IOException {
             return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
         }
-        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(java.io.InputStream input,
-                com.google.protobuf.ExtensionRegistryLite extensionRegistry) throws java.io.IOException {
-            return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input, extensionRegistry);
+
+        public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(
+                java.io.InputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                throws java.io.IOException {
+            return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+                    PARSER, input, extensionRegistry);
         }
+
         public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseDelimitedFrom(
                 java.io.InputStream input) throws java.io.IOException {
-            return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input);
+            return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+                    PARSER, input);
         }
+
         public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseDelimitedFrom(
-                java.io.InputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                java.io.InputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
                 throws java.io.IOException {
-            return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(PARSER, input,
-                    extensionRegistry);
+            return com.google.protobuf.GeneratedMessageV3.parseDelimitedWithIOException(
+                    PARSER, input, extensionRegistry);
         }
+
         public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(
                 com.google.protobuf.CodedInputStream input) throws java.io.IOException {
             return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input);
         }
+
         public static SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched parseFrom(
-                com.google.protobuf.CodedInputStream input, com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                com.google.protobuf.CodedInputStream input,
+                com.google.protobuf.ExtensionRegistryLite extensionRegistry)
                 throws java.io.IOException {
-            return com.google.protobuf.GeneratedMessageV3.parseWithIOException(PARSER, input, extensionRegistry);
+            return com.google.protobuf.GeneratedMessageV3.parseWithIOException(
+                    PARSER, input, extensionRegistry);
         }
 
         @java.lang.Override
         public Builder newBuilderForType() {
             return newBuilder();
         }
+
         public static Builder newBuilder() {
             return DEFAULT_INSTANCE.toBuilder();
         }
-        public static Builder newBuilder(SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched prototype) {
+
+        public static Builder newBuilder(
+                SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched prototype) {
             return DEFAULT_INSTANCE.toBuilder().mergeFrom(prototype);
         }
+
         @java.lang.Override
         public Builder toBuilder() {
             return this == DEFAULT_INSTANCE ? new Builder() : new Builder().mergeFrom(this);
         }
 
         @java.lang.Override
-        protected Builder newBuilderForType(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
+        protected Builder newBuilderForType(
+                com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
             Builder builder = new Builder(parent);
             return builder;
         }
-        /**
-         * Protobuf type {@code io.specmesh.kafka.schema.UserInfoEnriched}
-         */
-        public static final class Builder extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
+        /** Protobuf type {@code io.specmesh.kafka.schema.UserInfoEnriched} */
+        public static final class Builder
+                extends com.google.protobuf.GeneratedMessageV3.Builder<Builder>
                 implements
-                    // @@protoc_insertion_point(builder_implements:io.specmesh.kafka.schema.UserInfoEnriched)
-                    SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnrichedOrBuilder {
+                // @@protoc_insertion_point(builder_implements:io.specmesh.kafka.schema.UserInfoEnriched)
+                SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnrichedOrBuilder {
             public static final com.google.protobuf.Descriptors.Descriptor getDescriptor() {
-                return SimpleSchemaDemoPublicUserInfoEnriched.internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor;
+                return SimpleSchemaDemoPublicUserInfoEnriched
+                        .internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor;
             }
 
             @java.lang.Override
-            protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable internalGetFieldAccessorTable() {
-                return SimpleSchemaDemoPublicUserInfoEnriched.internal_static_io_specmesh_kafka_schema_UserInfoEnriched_fieldAccessorTable
-                        .ensureFieldAccessorsInitialized(SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.class,
-                                SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.Builder.class);
+            protected com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+                    internalGetFieldAccessorTable() {
+                return SimpleSchemaDemoPublicUserInfoEnriched
+                        .internal_static_io_specmesh_kafka_schema_UserInfoEnriched_fieldAccessorTable
+                        .ensureFieldAccessorsInitialized(
+                                SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.class,
+                                SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.Builder
+                                        .class);
             }
 
             // Construct using
             // io.specmesh.kafka.SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.newBuilder()
-            private Builder() {
-
-            }
+            private Builder() {}
 
             private Builder(com.google.protobuf.GeneratedMessageV3.BuilderParent parent) {
                 super(parent);
-
             }
+
             @java.lang.Override
             public Builder clear() {
                 super.clear();
@@ -459,11 +493,13 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
 
             @java.lang.Override
             public com.google.protobuf.Descriptors.Descriptor getDescriptorForType() {
-                return SimpleSchemaDemoPublicUserInfoEnriched.internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor;
+                return SimpleSchemaDemoPublicUserInfoEnriched
+                        .internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor;
             }
 
             @java.lang.Override
-            public SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched getDefaultInstanceForType() {
+            public SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched
+                    getDefaultInstanceForType() {
                 return SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.getDefaultInstance();
             }
 
@@ -478,8 +514,8 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
 
             @java.lang.Override
             public SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched buildPartial() {
-                SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched result = new SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched(
-                        this);
+                SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched result =
+                        new SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched(this);
                 if (bitField0_ != 0) {
                     buildPartial0(result);
                 }
@@ -487,7 +523,8 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
                 return result;
             }
 
-            private void buildPartial0(SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched result) {
+            private void buildPartial0(
+                    SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched result) {
                 int from_bitField0_ = bitField0_;
                 if (((from_bitField0_ & 0x00000001) != 0)) {
                     result.fullName_ = fullName_;
@@ -507,41 +544,53 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             public Builder clone() {
                 return super.clone();
             }
+
             @java.lang.Override
-            public Builder setField(com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
+            public Builder setField(
+                    com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
                 return super.setField(field, value);
             }
+
             @java.lang.Override
             public Builder clearField(com.google.protobuf.Descriptors.FieldDescriptor field) {
                 return super.clearField(field);
             }
+
             @java.lang.Override
             public Builder clearOneof(com.google.protobuf.Descriptors.OneofDescriptor oneof) {
                 return super.clearOneof(oneof);
             }
+
             @java.lang.Override
-            public Builder setRepeatedField(com.google.protobuf.Descriptors.FieldDescriptor field, int index,
+            public Builder setRepeatedField(
+                    com.google.protobuf.Descriptors.FieldDescriptor field,
+                    int index,
                     java.lang.Object value) {
                 return super.setRepeatedField(field, index, value);
             }
+
             @java.lang.Override
-            public Builder addRepeatedField(com.google.protobuf.Descriptors.FieldDescriptor field,
-                    java.lang.Object value) {
+            public Builder addRepeatedField(
+                    com.google.protobuf.Descriptors.FieldDescriptor field, java.lang.Object value) {
                 return super.addRepeatedField(field, value);
             }
+
             @java.lang.Override
             public Builder mergeFrom(com.google.protobuf.Message other) {
                 if (other instanceof SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched) {
-                    return mergeFrom((SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched) other);
+                    return mergeFrom(
+                            (SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched) other);
                 } else {
                     super.mergeFrom(other);
                     return this;
                 }
             }
 
-            public Builder mergeFrom(SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched other) {
-                if (other == SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched.getDefaultInstance())
-                    return this;
+            public Builder mergeFrom(
+                    SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched other) {
+                if (other
+                        == SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched
+                                .getDefaultInstance()) return this;
                 if (!other.getFullName().isEmpty()) {
                     fullName_ = other.fullName_;
                     bitField0_ |= 0x00000001;
@@ -571,8 +620,10 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             }
 
             @java.lang.Override
-            public Builder mergeFrom(com.google.protobuf.CodedInputStream input,
-                    com.google.protobuf.ExtensionRegistryLite extensionRegistry) throws java.io.IOException {
+            public Builder mergeFrom(
+                    com.google.protobuf.CodedInputStream input,
+                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                    throws java.io.IOException {
                 if (extensionRegistry == null) {
                     throw new java.lang.NullPointerException();
                 }
@@ -581,35 +632,40 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
                     while (!done) {
                         int tag = input.readTag();
                         switch (tag) {
-                            case 0 :
+                            case 0:
                                 done = true;
                                 break;
-                            case 10 : {
-                                fullName_ = input.readStringRequireUtf8();
-                                bitField0_ |= 0x00000001;
-                                break;
-                            } // case 10
-                            case 18 : {
-                                email_ = input.readStringRequireUtf8();
-                                bitField0_ |= 0x00000002;
-                                break;
-                            } // case 18
-                            case 26 : {
-                                address_ = input.readStringRequireUtf8();
-                                bitField0_ |= 0x00000004;
-                                break;
-                            } // case 26
-                            case 32 : {
-                                age_ = input.readInt32();
-                                bitField0_ |= 0x00000008;
-                                break;
-                            } // case 32
-                            default : {
-                                if (!super.parseUnknownField(input, extensionRegistry, tag)) {
-                                    done = true; // was an endgroup tag
-                                }
-                                break;
-                            } // default:
+                            case 10:
+                                {
+                                    fullName_ = input.readStringRequireUtf8();
+                                    bitField0_ |= 0x00000001;
+                                    break;
+                                } // case 10
+                            case 18:
+                                {
+                                    email_ = input.readStringRequireUtf8();
+                                    bitField0_ |= 0x00000002;
+                                    break;
+                                } // case 18
+                            case 26:
+                                {
+                                    address_ = input.readStringRequireUtf8();
+                                    bitField0_ |= 0x00000004;
+                                    break;
+                                } // case 26
+                            case 32:
+                                {
+                                    age_ = input.readInt32();
+                                    bitField0_ |= 0x00000008;
+                                    break;
+                                } // case 32
+                            default:
+                                {
+                                    if (!super.parseUnknownField(input, extensionRegistry, tag)) {
+                                        done = true; // was an endgroup tag
+                                    }
+                                    break;
+                                } // default:
                         } // switch (tag)
                     } // while (!done)
                 } catch (com.google.protobuf.InvalidProtocolBufferException e) {
@@ -619,6 +675,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
                 } // finally
                 return this;
             }
+
             private int bitField0_;
 
             private java.lang.Object fullName_ = "";
@@ -646,8 +703,8 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             public com.google.protobuf.ByteString getFullNameBytes() {
                 java.lang.Object ref = fullName_;
                 if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString
-                            .copyFromUtf8((java.lang.String) ref);
+                    com.google.protobuf.ByteString b =
+                            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                     fullName_ = b;
                     return b;
                 } else {
@@ -657,8 +714,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             /**
              * <code>string fullName = 1;</code>
              *
-             * @param value
-             *            The fullName to set.
+             * @param value The fullName to set.
              * @return This builder for chaining.
              */
             public Builder setFullName(java.lang.String value) {
@@ -684,8 +740,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             /**
              * <code>string fullName = 1;</code>
              *
-             * @param value
-             *            The bytes for fullName to set.
+             * @param value The bytes for fullName to set.
              * @return This builder for chaining.
              */
             public Builder setFullNameBytes(com.google.protobuf.ByteString value) {
@@ -724,8 +779,8 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             public com.google.protobuf.ByteString getEmailBytes() {
                 java.lang.Object ref = email_;
                 if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString
-                            .copyFromUtf8((java.lang.String) ref);
+                    com.google.protobuf.ByteString b =
+                            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                     email_ = b;
                     return b;
                 } else {
@@ -735,8 +790,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             /**
              * <code>string email = 2;</code>
              *
-             * @param value
-             *            The email to set.
+             * @param value The email to set.
              * @return This builder for chaining.
              */
             public Builder setEmail(java.lang.String value) {
@@ -762,8 +816,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             /**
              * <code>string email = 2;</code>
              *
-             * @param value
-             *            The bytes for email to set.
+             * @param value The bytes for email to set.
              * @return This builder for chaining.
              */
             public Builder setEmailBytes(com.google.protobuf.ByteString value) {
@@ -802,8 +855,8 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             public com.google.protobuf.ByteString getAddressBytes() {
                 java.lang.Object ref = address_;
                 if (ref instanceof String) {
-                    com.google.protobuf.ByteString b = com.google.protobuf.ByteString
-                            .copyFromUtf8((java.lang.String) ref);
+                    com.google.protobuf.ByteString b =
+                            com.google.protobuf.ByteString.copyFromUtf8((java.lang.String) ref);
                     address_ = b;
                     return b;
                 } else {
@@ -813,8 +866,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             /**
              * <code>string address = 3;</code>
              *
-             * @param value
-             *            The address to set.
+             * @param value The address to set.
              * @return This builder for chaining.
              */
             public Builder setAddress(java.lang.String value) {
@@ -840,8 +892,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             /**
              * <code>string address = 3;</code>
              *
-             * @param value
-             *            The bytes for address to set.
+             * @param value The bytes for address to set.
              * @return This builder for chaining.
              */
             public Builder setAddressBytes(com.google.protobuf.ByteString value) {
@@ -868,8 +919,7 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             /**
              * <code>int32 age = 4;</code>
              *
-             * @param value
-             *            The age to set.
+             * @param value The age to set.
              * @return This builder for chaining.
              */
             public Builder setAge(int value) {
@@ -890,13 +940,16 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
                 onChanged();
                 return this;
             }
+
             @java.lang.Override
-            public final Builder setUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
+            public final Builder setUnknownFields(
+                    final com.google.protobuf.UnknownFieldSet unknownFields) {
                 return super.setUnknownFields(unknownFields);
             }
 
             @java.lang.Override
-            public final Builder mergeUnknownFields(final com.google.protobuf.UnknownFieldSet unknownFields) {
+            public final Builder mergeUnknownFields(
+                    final com.google.protobuf.UnknownFieldSet unknownFields) {
                 return super.mergeUnknownFields(unknownFields);
             }
 
@@ -904,7 +957,9 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         }
 
         // @@protoc_insertion_point(class_scope:io.specmesh.kafka.schema.UserInfoEnriched)
-        private static final SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched DEFAULT_INSTANCE;
+        private static final SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched
+                DEFAULT_INSTANCE;
+
         static {
             DEFAULT_INSTANCE = new SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched();
         }
@@ -913,25 +968,28 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
             return DEFAULT_INSTANCE;
         }
 
-        private static final com.google.protobuf.Parser<UserInfoEnriched> PARSER = new com.google.protobuf.AbstractParser<UserInfoEnriched>() {
-            @java.lang.Override
-            public UserInfoEnriched parsePartialFrom(com.google.protobuf.CodedInputStream input,
-                    com.google.protobuf.ExtensionRegistryLite extensionRegistry)
-                    throws com.google.protobuf.InvalidProtocolBufferException {
-                Builder builder = newBuilder();
-                try {
-                    builder.mergeFrom(input, extensionRegistry);
-                } catch (com.google.protobuf.InvalidProtocolBufferException e) {
-                    throw e.setUnfinishedMessage(builder.buildPartial());
-                } catch (com.google.protobuf.UninitializedMessageException e) {
-                    throw e.asInvalidProtocolBufferException().setUnfinishedMessage(builder.buildPartial());
-                } catch (java.io.IOException e) {
-                    throw new com.google.protobuf.InvalidProtocolBufferException(e)
-                            .setUnfinishedMessage(builder.buildPartial());
-                }
-                return builder.buildPartial();
-            }
-        };
+        private static final com.google.protobuf.Parser<UserInfoEnriched> PARSER =
+                new com.google.protobuf.AbstractParser<UserInfoEnriched>() {
+                    @java.lang.Override
+                    public UserInfoEnriched parsePartialFrom(
+                            com.google.protobuf.CodedInputStream input,
+                            com.google.protobuf.ExtensionRegistryLite extensionRegistry)
+                            throws com.google.protobuf.InvalidProtocolBufferException {
+                        Builder builder = newBuilder();
+                        try {
+                            builder.mergeFrom(input, extensionRegistry);
+                        } catch (com.google.protobuf.InvalidProtocolBufferException e) {
+                            throw e.setUnfinishedMessage(builder.buildPartial());
+                        } catch (com.google.protobuf.UninitializedMessageException e) {
+                            throw e.asInvalidProtocolBufferException()
+                                    .setUnfinishedMessage(builder.buildPartial());
+                        } catch (java.io.IOException e) {
+                            throw new com.google.protobuf.InvalidProtocolBufferException(e)
+                                    .setUnfinishedMessage(builder.buildPartial());
+                        }
+                        return builder.buildPartial();
+                    }
+                };
 
         public static com.google.protobuf.Parser<UserInfoEnriched> parser() {
             return PARSER;
@@ -946,28 +1004,38 @@ public final class SimpleSchemaDemoPublicUserInfoEnriched {
         public SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched getDefaultInstanceForType() {
             return DEFAULT_INSTANCE;
         }
-
     }
 
-    private static final com.google.protobuf.Descriptors.Descriptor internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor;
-    private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable internal_static_io_specmesh_kafka_schema_UserInfoEnriched_fieldAccessorTable;
+    private static final com.google.protobuf.Descriptors.Descriptor
+            internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor;
+    private static final com.google.protobuf.GeneratedMessageV3.FieldAccessorTable
+            internal_static_io_specmesh_kafka_schema_UserInfoEnriched_fieldAccessorTable;
 
     public static com.google.protobuf.Descriptors.FileDescriptor getDescriptor() {
         return descriptor;
     }
+
     private static com.google.protobuf.Descriptors.FileDescriptor descriptor;
+
     static {
         java.lang.String[] descriptorData = {
-                "\n3simple.schema_demo._public.user_info_e" + "nriched.proto\022\030io.specmesh.kafka.schema\""
-                        + "Q\n\020UserInfoEnriched\022\020\n\010fullName\030\001 \001(\t\022\r\n"
-                        + "\005email\030\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\013\n\003age\030\004 \001"
-                        + "(\005b\006proto3"};
-        descriptor = com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(descriptorData,
-                new com.google.protobuf.Descriptors.FileDescriptor[]{});
-        internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor = getDescriptor().getMessageTypes().get(0);
-        internal_static_io_specmesh_kafka_schema_UserInfoEnriched_fieldAccessorTable = new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
-                internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor,
-                new java.lang.String[]{"FullName", "Email", "Address", "Age",});
+            "\n3simple.schema_demo._public.user_info_e"
+                    + "nriched.proto\022\030io.specmesh.kafka.schema\""
+                    + "Q\n\020UserInfoEnriched\022\020\n\010fullName\030\001 \001(\t\022\r\n"
+                    + "\005email\030\002 \001(\t\022\017\n\007address\030\003 \001(\t\022\013\n\003age\030\004 \001"
+                    + "(\005b\006proto3"
+        };
+        descriptor =
+                com.google.protobuf.Descriptors.FileDescriptor.internalBuildGeneratedFileFrom(
+                        descriptorData, new com.google.protobuf.Descriptors.FileDescriptor[] {});
+        internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor =
+                getDescriptor().getMessageTypes().get(0);
+        internal_static_io_specmesh_kafka_schema_UserInfoEnriched_fieldAccessorTable =
+                new com.google.protobuf.GeneratedMessageV3.FieldAccessorTable(
+                        internal_static_io_specmesh_kafka_schema_UserInfoEnriched_descriptor,
+                        new java.lang.String[] {
+                            "FullName", "Email", "Address", "Age",
+                        });
     }
 
     // @@protoc_insertion_point(outer_class_scope)

--- a/kafka-test/src/test/java/simple/schema_demo/_public/user_checkout_value/UserCheckout.java
+++ b/kafka-test/src/test/java/simple/schema_demo/_public/user_checkout_value/UserCheckout.java
@@ -27,15 +27,15 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@JsonSchemaInject(strings = {
-        @JsonSchemaString(path = "javaType", value = "simple.schema_demo._public.user_checkout_value.UserCheckout")})
+@JsonSchemaInject(
+        strings = {
+            @JsonSchemaString(
+                    path = "javaType",
+                    value = "simple.schema_demo._public.user_checkout_value.UserCheckout")
+        })
 public class UserCheckout {
-    @JsonProperty
-    long id;
-    @JsonProperty
-    String name;
-    @JsonProperty
-    int price;
-    @JsonProperty
-    String systemDate;
+    @JsonProperty long id;
+    @JsonProperty String name;
+    @JsonProperty int price;
+    @JsonProperty String systemDate;
 }

--- a/kafka-test/src/test/java/simple/schema_demo/_public/user_signed_up_value/UserSignedUp.java
+++ b/kafka-test/src/test/java/simple/schema_demo/_public/user_signed_up_value/UserSignedUp.java
@@ -28,5 +28,4 @@ public class UserSignedUp {
     String fullName;
     String email;
     int age;
-
 }

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -31,29 +31,23 @@ import org.apache.kafka.clients.producer.ProducerConfig;
 import org.apache.kafka.streams.StreamsConfig;
 import org.jetbrains.annotations.NotNull;
 
-/**
- * Factory for Kafka clients
- */
+/** Factory for Kafka clients */
 public final class Clients {
-    private Clients() {
-    }
+    private Clients() {}
 
     /**
      * Create a Kafka producer
      *
-     * @param keyClass
-     *            the type of the key
-     * @param valueClass
-     *            the type of the value
-     * @param producerProperties
-     *            the properties
-     * @param <K>
-     *            the type of the key
-     * @param <V>
-     *            the type of the value
+     * @param keyClass the type of the key
+     * @param valueClass the type of the value
+     * @param producerProperties the properties
+     * @param <K> the type of the key
+     * @param <V> the type of the value
      * @return the producer
      */
-    public static <K, V> KafkaProducer<K, V> producer(final Class<K> keyClass, final Class<V> valueClass,
+    public static <K, V> KafkaProducer<K, V> producer(
+            final Class<K> keyClass,
+            final Class<V> valueClass,
             final Map<String, Object> producerProperties) {
         return new KafkaProducer<>(producerProperties);
     }
@@ -61,106 +55,125 @@ public final class Clients {
     /**
      * Create a map of producer properties with sensible defaults.
      *
-     * @param domainId
-     *            the domain id, used to scope resource names.
-     * @param serviceId
-     *            the name of the service
-     * @param bootstrapServers
-     *            bootstrap servers config
-     * @param schemaRegistryUrl
-     *            url of schema registry
-     * @param keySerializerClass
-     *            type of key serializer
-     * @param valueSerializerClass
-     *            type of value serializer
-     * @param acksAll
-     *            require acks from all replicas?
-     * @param providedProperties
-     *            additional props
+     * @param domainId the domain id, used to scope resource names.
+     * @param serviceId the name of the service
+     * @param bootstrapServers bootstrap servers config
+     * @param schemaRegistryUrl url of schema registry
+     * @param keySerializerClass type of key serializer
+     * @param valueSerializerClass type of value serializer
+     * @param acksAll require acks from all replicas?
+     * @param providedProperties additional props
      * @return props
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     @NotNull
-    public static Map<String, Object> producerProperties(final String domainId, final String serviceId,
-            final String bootstrapServers, final String schemaRegistryUrl, final Class<?> keySerializerClass,
-            final Class<?> valueSerializerClass, final boolean acksAll, final Map<String, Object> providedProperties) {
-        return mergeMaps(getClientProperties(domainId, bootstrapServers),
-                Map.of(AdminClientConfig.CLIENT_ID_CONFIG, domainId + "." + serviceId + ".producer",
-                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass.getCanonicalName(),
-                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass.getCanonicalName(),
-                        ProducerConfig.ACKS_CONFIG, acksAll ? "all" : "1",
-                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl,
+    public static Map<String, Object> producerProperties(
+            final String domainId,
+            final String serviceId,
+            final String bootstrapServers,
+            final String schemaRegistryUrl,
+            final Class<?> keySerializerClass,
+            final Class<?> valueSerializerClass,
+            final boolean acksAll,
+            final Map<String, Object> providedProperties) {
+        return mergeMaps(
+                getClientProperties(domainId, bootstrapServers),
+                Map.of(
+                        AdminClientConfig.CLIENT_ID_CONFIG,
+                        domainId + "." + serviceId + ".producer",
+                        ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG,
+                        keySerializerClass.getCanonicalName(),
+                        ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG,
+                        valueSerializerClass.getCanonicalName(),
+                        ProducerConfig.ACKS_CONFIG,
+                        acksAll ? "all" : "1",
+                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                        schemaRegistryUrl,
                         // AUTO-REG should be false to allow schemas to be published by controlled
                         // processes
-                        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, "false",
-                        // schema-reflect MUST be true when writing Java objects (otherwise you send a
+                        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS,
+                        "false",
+                        // schema-reflect MUST be true when writing Java objects (otherwise you send
+                        // a
                         // datum-container instead of a Pojo)
-                        KafkaAvroSerializerConfig.SCHEMA_REFLECTION_CONFIG, "true",
-                        KafkaAvroSerializerConfig.USE_LATEST_VERSION, "true"),
+                        KafkaAvroSerializerConfig.SCHEMA_REFLECTION_CONFIG,
+                        "true",
+                        KafkaAvroSerializerConfig.USE_LATEST_VERSION,
+                        "true"),
                 providedProperties);
     }
 
     /**
      * Create props for KStream app with sensible defaults.
      *
-     * @param domainId
-     *            the domain id, used to scope resource names.
-     * @param serviceId
-     *            the name of the service
-     * @param bootstrapServers
-     *            bootstrap servers config
-     * @param schemaRegistryUrl
-     *            url of schema registry
-     * @param keySerdeClass
-     *            type of key serde
-     * @param valueSerdeClass
-     *            type of value serde
-     * @param acksAll
-     *            require acks from all replicas?
-     * @param providedProperties
-     *            additional props
+     * @param domainId the domain id, used to scope resource names.
+     * @param serviceId the name of the service
+     * @param bootstrapServers bootstrap servers config
+     * @param schemaRegistryUrl url of schema registry
+     * @param keySerdeClass type of key serde
+     * @param valueSerdeClass type of value serde
+     * @param acksAll require acks from all replicas?
+     * @param providedProperties additional props
      * @return the streams properties.
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     @NotNull
-    public static Map<String, Object> kstreamsProperties(final String domainId, final String serviceId,
-            final String bootstrapServers, final String schemaRegistryUrl, final Class<?> keySerdeClass,
-            final Class<?> valueSerdeClass, final boolean acksAll, final Map<String, Object> providedProperties) {
+    public static Map<String, Object> kstreamsProperties(
+            final String domainId,
+            final String serviceId,
+            final String bootstrapServers,
+            final String schemaRegistryUrl,
+            final Class<?> keySerdeClass,
+            final Class<?> valueSerdeClass,
+            final boolean acksAll,
+            final Map<String, Object> providedProperties) {
 
-        return mergeMaps(getClientProperties(domainId, bootstrapServers), Map.of(StreamsConfig.APPLICATION_ID_CONFIG,
-                domainId + "." + serviceId, StreamsConfig.CLIENT_ID_CONFIG, domainId + "." + serviceId + ".client",
-                StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, keySerdeClass.getName(),
-                StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, valueSerdeClass.getName(),
-                // Records should be flushed every 10 seconds. This is less than the default
-                // in order to keep this example interactive.
-                StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000, ProducerConfig.ACKS_CONFIG, acksAll ? "all" : "1",
-                AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl,
-                // AUTO-REG should be false to allow schemas to be published by controlled
-                // processes
-                AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, "false",
-                // schema-reflect MUST be true when writing Java objects
-                // (otherwise you send a datum-container (avro) or dynamic record (proto)
-                // instead of a Pojo)
-                KafkaAvroSerializerConfig.SCHEMA_REFLECTION_CONFIG, "true",
-                KafkaAvroSerializerConfig.USE_LATEST_VERSION, "true"), providedProperties);
+        return mergeMaps(
+                getClientProperties(domainId, bootstrapServers),
+                Map.of(
+                        StreamsConfig.APPLICATION_ID_CONFIG,
+                        domainId + "." + serviceId,
+                        StreamsConfig.CLIENT_ID_CONFIG,
+                        domainId + "." + serviceId + ".client",
+                        StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG,
+                        keySerdeClass.getName(),
+                        StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG,
+                        valueSerdeClass.getName(),
+                        // Records should be flushed every 10 seconds. This is less than the default
+                        // in order to keep this example interactive.
+                        StreamsConfig.COMMIT_INTERVAL_MS_CONFIG,
+                        10 * 1000,
+                        ProducerConfig.ACKS_CONFIG,
+                        acksAll ? "all" : "1",
+                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                        schemaRegistryUrl,
+                        // AUTO-REG should be false to allow schemas to be published by controlled
+                        // processes
+                        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS,
+                        "false",
+                        // schema-reflect MUST be true when writing Java objects
+                        // (otherwise you send a datum-container (avro) or dynamic record (proto)
+                        // instead of a Pojo)
+                        KafkaAvroSerializerConfig.SCHEMA_REFLECTION_CONFIG,
+                        "true",
+                        KafkaAvroSerializerConfig.USE_LATEST_VERSION,
+                        "true"),
+                providedProperties);
     }
 
     /**
      * Create a Kafka consumer
      *
-     * @param keyClass
-     *            the type of the key
-     * @param valueClass
-     *            the type of the value
-     * @param consumerProperties
-     *            the properties
-     * @param <K>
-     *            the type of the key
-     * @param <V>
-     *            the type of the value
+     * @param keyClass the type of the key
+     * @param valueClass the type of the value
+     * @param consumerProperties the properties
+     * @param <K> the type of the key
+     * @param <V> the type of the value
      * @return the producer
      */
-    public static <K, V> KafkaConsumer<K, V> consumer(final Class<K> keyClass, final Class<V> valueClass,
+    public static <K, V> KafkaConsumer<K, V> consumer(
+            final Class<K> keyClass,
+            final Class<V> valueClass,
             final Map<String, Object> consumerProperties) {
         return new KafkaConsumer<>(consumerProperties);
     }
@@ -168,42 +181,49 @@ public final class Clients {
     /**
      * Create a map of consumer properties with sensible defaults.
      *
-     * @param domainId
-     *            the domain id, used to scope resource names.
-     * @param serviceId
-     *            the name of the service
-     * @param bootstrapServers
-     *            bootstrap servers config
-     * @param schemaRegistryUrl
-     *            url of schema registry
-     * @param keyDeserializerClass
-     *            type of key deserializer
-     * @param valueDeserializerClass
-     *            type of value deserializer
-     * @param autoOffsetResetEarliest
-     *            reset to earliest offset if no stored offsets?
-     * @param providedProperties
-     *            additional props
+     * @param domainId the domain id, used to scope resource names.
+     * @param serviceId the name of the service
+     * @param bootstrapServers bootstrap servers config
+     * @param schemaRegistryUrl url of schema registry
+     * @param keyDeserializerClass type of key deserializer
+     * @param valueDeserializerClass type of value deserializer
+     * @param autoOffsetResetEarliest reset to earliest offset if no stored offsets?
+     * @param providedProperties additional props
      * @return props
      */
     @SuppressWarnings("checkstyle:ParameterNumber")
     @NotNull
-    public static Map<String, Object> consumerProperties(final String domainId, final String serviceId,
-            final String bootstrapServers, final String schemaRegistryUrl, final Class<?> keyDeserializerClass,
-            final Class<?> valueDeserializerClass, final boolean autoOffsetResetEarliest,
+    public static Map<String, Object> consumerProperties(
+            final String domainId,
+            final String serviceId,
+            final String bootstrapServers,
+            final String schemaRegistryUrl,
+            final Class<?> keyDeserializerClass,
+            final Class<?> valueDeserializerClass,
+            final boolean autoOffsetResetEarliest,
             final Map<String, Object> providedProperties) {
-        return mergeMaps(getClientProperties(domainId, bootstrapServers),
-                Map.of(ConsumerConfig.CLIENT_ID_CONFIG, domainId + "." + serviceId + ".consumer",
-                        ConsumerConfig.GROUP_ID_CONFIG, domainId + "." + serviceId + ".consumer-group",
-                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, autoOffsetResetEarliest ? "earliest" : "latest",
-                        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializerClass.getCanonicalName(),
-                        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG, valueDeserializerClass.getCanonicalName(),
-                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG, schemaRegistryUrl,
-                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, "true"),
+        return mergeMaps(
+                getClientProperties(domainId, bootstrapServers),
+                Map.of(
+                        ConsumerConfig.CLIENT_ID_CONFIG,
+                        domainId + "." + serviceId + ".consumer",
+                        ConsumerConfig.GROUP_ID_CONFIG,
+                        domainId + "." + serviceId + ".consumer-group",
+                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                        autoOffsetResetEarliest ? "earliest" : "latest",
+                        ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG,
+                        keyDeserializerClass.getCanonicalName(),
+                        ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
+                        valueDeserializerClass.getCanonicalName(),
+                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                        schemaRegistryUrl,
+                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG,
+                        "true"),
                 providedProperties);
     }
 
-    private static Properties getClientProperties(final String domainId, final String bootstrapServers) {
+    private static Properties getClientProperties(
+            final String domainId, final String bootstrapServers) {
         final Properties adminClientProperties = new Properties();
         adminClientProperties.put(AdminClientConfig.CLIENT_ID_CONFIG, domainId);
         adminClientProperties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
@@ -213,8 +233,7 @@ public final class Clients {
     /**
      * Merges Maps
      *
-     * @param manyMaps
-     *            - maps to merge
+     * @param manyMaps - maps to merge
      * @return merged maps
      */
     @SuppressWarnings({"rawtypes", "unchecked"})
@@ -223,5 +242,4 @@ public final class Clients {
         Arrays.stream(manyMaps).forEach(mutableMap::putAll);
         return mutableMap;
     }
-
 }

--- a/kafka/src/main/java/io/specmesh/kafka/Provisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Provisioner.java
@@ -39,26 +39,20 @@ import org.apache.kafka.clients.admin.AdminClientConfig;
 import org.apache.kafka.clients.admin.TopicListing;
 import org.apache.kafka.common.acl.AclBinding;
 
-/**
- * Provisions Kafka and SR resources
- */
+/** Provisions Kafka and SR resources */
 public final class Provisioner {
 
     private static final int REQUEST_TIMEOUT = 10;
 
-    private Provisioner() {
-    }
+    private Provisioner() {}
 
     /**
      * Provision topics in the Kafka cluster.
      *
-     * @param apiSpec
-     *            the api spec.
-     * @param adminClient
-     *            admin client for the Kafka cluster.
+     * @param apiSpec the api spec.
+     * @param adminClient admin client for the Kafka cluster.
      * @return number of topics created
-     * @throws ProvisioningException
-     *             on provision failure
+     * @throws ProvisioningException on provision failure
      */
     public static int provisionTopics(final KafkaApiSpec apiSpec, final AdminClient adminClient)
             throws ProvisioningException {
@@ -67,17 +61,28 @@ public final class Provisioner {
 
         final List<String> existingTopics;
         try {
-            existingTopics = adminClient.listTopics().listings().get(REQUEST_TIMEOUT, TimeUnit.SECONDS).stream()
-                    .map(TopicListing::name).collect(Collectors.toList());
+            existingTopics =
+                    adminClient
+                            .listTopics()
+                            .listings()
+                            .get(REQUEST_TIMEOUT, TimeUnit.SECONDS)
+                            .stream()
+                            .map(TopicListing::name)
+                            .collect(Collectors.toList());
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new ProvisioningException(e);
         }
 
-        final var newTopicsToCreate = domainTopics.stream()
-                .filter(newTopic -> !existingTopics.contains(newTopic.name())).collect(Collectors.toList());
+        final var newTopicsToCreate =
+                domainTopics.stream()
+                        .filter(newTopic -> !existingTopics.contains(newTopic.name()))
+                        .collect(Collectors.toList());
 
         try {
-            adminClient.createTopics(newTopicsToCreate).all().get(REQUEST_TIMEOUT, TimeUnit.SECONDS);
+            adminClient
+                    .createTopics(newTopicsToCreate)
+                    .all()
+                    .get(REQUEST_TIMEOUT, TimeUnit.SECONDS);
         } catch (InterruptedException | ExecutionException | TimeoutException e) {
             throw new ProvisioningException(e);
         }
@@ -87,48 +92,46 @@ public final class Provisioner {
     /**
      * Provision schemas to Schema Registry
      *
-     * @param apiSpec
-     *            the api spec
-     * @param baseResourcePath
-     *            the path under which external schemas are stored.
-     * @param schemaRegistryClient
-     *            the client for the schema registry
+     * @param apiSpec the api spec
+     * @param baseResourcePath the path under which external schemas are stored.
+     * @param schemaRegistryClient the client for the schema registry
      */
-    public static void provisionSchemas(final KafkaApiSpec apiSpec, final String baseResourcePath,
+    public static void provisionSchemas(
+            final KafkaApiSpec apiSpec,
+            final String baseResourcePath,
             final SchemaRegistryClient schemaRegistryClient) {
 
         final var domainTopics = apiSpec.listDomainOwnedTopics();
 
-        domainTopics.forEach((topic -> {
+        domainTopics.forEach(
+                (topic -> {
+                    final var schemaInfo = apiSpec.schemaInfoForTopic(topic.name());
+                    final var schemaRef = schemaInfo.schemaRef();
+                    final String schemaContent;
+                    try {
+                        schemaContent =
+                                readString(Paths.get(baseResourcePath + "/" + schemaRef), UTF_8);
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                    final ParsedSchema someSchema =
+                            getSchema(topic.name(), schemaRef, baseResourcePath, schemaContent);
 
-            final var schemaInfo = apiSpec.schemaInfoForTopic(topic.name());
-            final var schemaRef = schemaInfo.schemaRef();
-            final String schemaContent;
-            try {
-                schemaContent = readString(Paths.get(baseResourcePath + "/" + schemaRef), UTF_8);
-            } catch (IOException e) {
-                throw new RuntimeException(e);
-            }
-            final ParsedSchema someSchema = getSchema(topic.name(), schemaRef, baseResourcePath, schemaContent);
-
-            // register the schema against the topic (subject)
-            try {
-                schemaRegistryClient.register(topic.name() + "-value", someSchema);
-            } catch (IOException | RestClientException e) {
-                throw new RuntimeException(e);
-            }
-        }));
+                    // register the schema against the topic (subject)
+                    try {
+                        schemaRegistryClient.register(topic.name() + "-value", someSchema);
+                    } catch (IOException | RestClientException e) {
+                        throw new RuntimeException(e);
+                    }
+                }));
     }
 
     /**
      * Provision acls in the Kafka cluster
      *
-     * @param apiSpec
-     *            the api spec.
-     * @param adminClient
-     *            th admin client for the cluster.
-     * @throws ProvisioningException
-     *             on interrupt
+     * @param apiSpec the api spec.
+     * @param adminClient th admin client for the cluster.
+     * @throws ProvisioningException on interrupt
      */
     public static void provisionAcls(final KafkaApiSpec apiSpec, final AdminClient adminClient)
             throws ProvisioningException {
@@ -140,7 +143,10 @@ public final class Provisioner {
         }
     }
 
-    static ParsedSchema getSchema(final String topicName, final String schemaRef, final String path,
+    static ParsedSchema getSchema(
+            final String topicName,
+            final String schemaRef,
+            final String path,
             final String content) {
 
         if (schemaRef.endsWith(".avsc")) {
@@ -158,60 +164,60 @@ public final class Provisioner {
     /**
      * Provision Topics, ACLS and schemas
      *
-     * @param apiSpec
-     *            given spec
-     * @param schemaResources
-     *            schema path
-     * @param adminClient
-     *            kafka admin client
-     * @param schemaRegistryClient
-     *            sr client
-     * @throws ProvisioningException
-     *             when cant provision resources
+     * @param apiSpec given spec
+     * @param schemaResources schema path
+     * @param adminClient kafka admin client
+     * @param schemaRegistryClient sr client
+     * @throws ProvisioningException when cant provision resources
      */
-    public static void provision(final KafkaApiSpec apiSpec, final String schemaResources,
-            final AdminClient adminClient, final SchemaRegistryClient schemaRegistryClient)
+    public static void provision(
+            final KafkaApiSpec apiSpec,
+            final String schemaResources,
+            final AdminClient adminClient,
+            final SchemaRegistryClient schemaRegistryClient)
             throws ProvisioningException {
         provisionTopics(apiSpec, adminClient);
         provisionSchemas(apiSpec, schemaResources, schemaRegistryClient);
         provisionAcls(apiSpec, adminClient);
-
     }
 
     /**
      * setup sasl_plain auth creds
      *
-     * @param principle
-     *            user name
-     * @param secret
-     *            secret
+     * @param principle user name
+     * @param secret secret
      * @return client creds map
      */
-    public static Map<String, Object> clientAuthProperties(final String principle, final String secret) {
-        return Map.of("sasl.mechanism", "PLAIN", AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT",
-                "sasl.jaas.config", String.format("org.apache.kafka.common.security.plain.PlainLoginModule required "
-                        + "username=\"%s\" password=\"%s\";", principle, secret));
-
+    public static Map<String, Object> clientAuthProperties(
+            final String principle, final String secret) {
+        return Map.of(
+                "sasl.mechanism",
+                "PLAIN",
+                AdminClientConfig.SECURITY_PROTOCOL_CONFIG,
+                "SASL_PLAINTEXT",
+                "sasl.jaas.config",
+                String.format(
+                        "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                                + "username=\"%s\" password=\"%s\";",
+                        principle, secret));
     }
 
     /**
      * Configure environment for SASL_PLAIN auth with 2 sets of users
      *
-     * @param domainUser
-     *            owner user
-     * @param domainSecret
-     *            their secret
-     * @param otherDomainUser
-     *            other user
-     * @param otherDomainSecret
-     *            their secret
-     * @param otherConfig
-     *            other config needed for the env map
+     * @param domainUser owner user
+     * @param domainSecret their secret
+     * @param otherDomainUser other user
+     * @param otherDomainSecret their secret
+     * @param otherConfig other config needed for the env map
      * @return env map for broker
-     *
      */
-    public static Map<String, String> testAuthorizerConfig(final String domainUser, final String domainSecret,
-            final String otherDomainUser, final String otherDomainSecret, final Map<String, String> otherConfig) {
+    public static Map<String, String> testAuthorizerConfig(
+            final String domainUser,
+            final String domainSecret,
+            final String otherDomainUser,
+            final String otherDomainSecret,
+            final Map<String, String> otherConfig) {
         final Map<String, String> env = new LinkedHashMap<>();
         // must be 'true' for cluster metadata init - otherwise needs better sec config
         env.put("KAFKA_ALLOW_EVERYONE_IF_NO_ACL_FOUND", "true");
@@ -219,30 +225,35 @@ public final class Provisioner {
         env.put("KAFKA_SUPER_USERS", "User:OnlySuperUser");
         env.put("KAFKA_SASL_ENABLED_MECHANISMS", "PLAIN,SASL_PLAINTEXT");
 
-        env.put("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT");
+        env.put(
+                "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+                "BROKER:PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT");
         env.put("KAFKA_LISTENER_NAME_PLAINTEXT_SASL_ENABLED_MECHANISMS", "PLAIN");
-        env.put("KAFKA_LISTENER_NAME_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG",
+        env.put(
+                "KAFKA_LISTENER_NAME_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG",
                 "org.apache.kafka.common.security.plain.PlainLoginModule required "
                         + "username=\"admin\" password=\"admin-secret\" user_admin=\"admin-secret\" "
                         + String.format("user_%s=\"%s\" ", domainUser, domainSecret /* secret */)
-                        + String.format("user_%s=\"%s\";", otherDomainUser, otherDomainSecret) /* secret */);
+                        + String.format(
+                                "user_%s=\"%s\";",
+                                otherDomainUser, otherDomainSecret) /* secret */);
 
-        env.put("KAFKA_SASL_JAAS_CONFIG", "org.apache.kafka.common.security.plain.PlainLoginModule required "
-                + "username=\"admin\" " + "password=\"admin-secret\";");
+        env.put(
+                "KAFKA_SASL_JAAS_CONFIG",
+                "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                        + "username=\"admin\" "
+                        + "password=\"admin-secret\";");
         env.putAll(otherConfig);
         return env;
     }
 
-    /**
-     * Provisioning failures
-     */
+    /** Provisioning failures */
     public static class ProvisioningException extends Exception {
 
         /**
          * Provisioning failures
          *
-         * @param e
-         *            exception to cause the failure
+         * @param e exception to cause the failure
          */
         public ProvisioningException(final Exception e) {
             super(e);

--- a/kafka/src/main/java/io/specmesh/kafka/schema/JsonSchemas.java
+++ b/kafka/src/main/java/io/specmesh/kafka/schema/JsonSchemas.java
@@ -30,25 +30,21 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.apache.commons.io.IOUtils;
 
-/**
- * Util class for working with Json schemas.
- */
+/** Util class for working with Json schemas. */
 public final class JsonSchemas {
 
     private static final Path SCHEMA_DIRECTORY = Paths.get("schema");
 
-    private static final ObjectMapper yamlMapper = new ObjectMapper(
-            new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES));
+    private static final ObjectMapper yamlMapper =
+            new ObjectMapper(new YAMLFactory().enable(YAMLGenerator.Feature.MINIMIZE_QUOTES));
     private static final ObjectMapper jsonWriter = new ObjectMapper();
 
-    private JsonSchemas() {
-    }
+    private JsonSchemas() {}
 
     /**
      * Load a schema from the classpath.
      *
-     * @param schemaFile
-     *            the path to the schema.
+     * @param schemaFile the path to the schema.
      * @return the schema.
      */
     public static JsonSchema loadFromClasspath(final String schemaFile) {
@@ -58,21 +54,22 @@ public final class JsonSchemas {
     /**
      * Load a schema from the classpath.
      *
-     * @param schemaFile
-     *            the path to the schema.
+     * @param schemaFile the path to the schema.
      * @return the schema.
      */
     public static JsonSchema loadFromClasspath(final Path schemaFile) {
         final String path = File.separator + SCHEMA_DIRECTORY.resolve(schemaFile);
         final URL resource = JsonSchemas.class.getResource(path);
         if (resource == null) {
-            throw new RuntimeException("Failed to load schema resource: " + path + ". Resource not found");
+            throw new RuntimeException(
+                    "Failed to load schema resource: " + path + ". Resource not found");
         }
 
         try {
             return new JsonSchema(yamlToJson(loadYamlFromUrl(resource)));
         } catch (final Exception e) {
-            throw new RuntimeException("Failed to convert schema resource: " + path + ". " + e.getMessage(), e);
+            throw new RuntimeException(
+                    "Failed to convert schema resource: " + path + ". " + e.getMessage(), e);
         }
     }
 
@@ -84,11 +81,9 @@ public final class JsonSchemas {
     /**
      * Convert a YAML into JSON.
      *
-     * @param yaml
-     *            the YAML to convert
+     * @param yaml the YAML to convert
      * @return the JSON
-     * @throws IOException
-     *             on invalid YAML
+     * @throws IOException on invalid YAML
      */
     public static String yamlToJson(final String yaml) throws IOException {
         final Object obj = yamlMapper.readValue(yaml, Object.class);

--- a/kafka/src/main/java/io/specmesh/kafka/schema/RegisteredSchema.java
+++ b/kafka/src/main/java/io/specmesh/kafka/schema/RegisteredSchema.java
@@ -26,10 +26,7 @@ import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
-/**
- * Pojo for holding data about a schema that is registered with the schema
- * registry.
- */
+/** Pojo for holding data about a schema that is registered with the schema registry. */
 @Value
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/kafka/src/main/java/io/specmesh/kafka/schema/SrSchemaManager.java
+++ b/kafka/src/main/java/io/specmesh/kafka/schema/SrSchemaManager.java
@@ -23,17 +23,14 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.json.JsonSchema;
 import java.nio.file.Path;
 
-/**
- * Wrapper around the {@link SchemaRegistryClient}
- */
+/** Wrapper around the {@link SchemaRegistryClient} */
 public class SrSchemaManager {
     private final SchemaRegistryClient schemaRegistry;
 
     /**
      * SR client wrapper
      *
-     * @param schemaRegistry
-     *            the client
+     * @param schemaRegistry the client
      */
     public SrSchemaManager(final SchemaRegistryClient schemaRegistry) {
         this.schemaRegistry = requireNonNull(schemaRegistry, "schemaRegistry");
@@ -42,10 +39,8 @@ public class SrSchemaManager {
     /**
      * Load a schema from the classpath into the local schema cache.
      *
-     * @param schemaFile
-     *            the path to the schema file
-     * @param subject
-     *            the subject under which to store it
+     * @param schemaFile the path to the schema file
+     * @param subject the subject under which to store it
      * @return the registered schema
      */
     public RegisteredSchema loadFromClasspath(final Path schemaFile, final String subject) {
@@ -62,15 +57,16 @@ public class SrSchemaManager {
     /**
      * Load the latest version of a schema into the local schema cache.
      *
-     * @param subject
-     *            the schema subject to load.
+     * @param subject the schema subject to load.
      * @return the registered schema
      */
     public RegisteredSchema loadLatest(final String subject) {
         try {
-            final SchemaMetadata latestSchemaMetadata = schemaRegistry.getLatestSchemaMetadata(subject);
+            final SchemaMetadata latestSchemaMetadata =
+                    schemaRegistry.getLatestSchemaMetadata(subject);
             final int id = latestSchemaMetadata.getId();
-            return new RegisteredSchema(subject, new JsonSchema(latestSchemaMetadata.getSchema()), id);
+            return new RegisteredSchema(
+                    subject, new JsonSchema(latestSchemaMetadata.getSchema()), id);
         } catch (final Exception e) {
             throw new RuntimeException(subject, e);
         }
@@ -79,10 +75,8 @@ public class SrSchemaManager {
     /**
      * Load a specific version of a schema into the local schema cache.
      *
-     * @param subject
-     *            the schema subject
-     * @param schemaId
-     *            the unique schema id.
+     * @param subject the schema subject
+     * @param schemaId the unique schema id.
      * @return the registered schema.
      */
     public RegisteredSchema loadById(final String subject, final int schemaId) {
@@ -96,10 +90,8 @@ public class SrSchemaManager {
     /**
      * Register a schema with the schema registry from a file in the classpath.
      *
-     * @param schemaFile
-     *            the path to the schema file
-     * @param subject
-     *            the subject under which to register it
+     * @param schemaFile the path to the schema file
+     * @param subject the subject under which to register it
      * @return the registered schema.
      */
     public RegisteredSchema registerFromClasspath(final Path schemaFile, final String subject) {

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
@@ -60,8 +60,7 @@ public class KafkaAPISpecFunctionalTest {
     public static final String SOME_OTHER_DOMAIN_ROOT = ".some.other.domain.root";
 
     // CHECKSTYLE_RULES.OFF: VisibilityModifier
-    @Container
-    public static final KafkaContainer kafka = getKafkaContainer();
+    @Container public static final KafkaContainer kafka = getKafkaContainer();
 
     public KafkaAPISpecFunctionalTest() {
         System.out.println("createAllTheThings BROKER URL:" + kafka.getBootstrapServers());
@@ -89,14 +88,19 @@ public class KafkaAPISpecFunctionalTest {
 
         final KafkaProducer<Long, String> domainProducer = getDomainProducer(apiSpec.id());
 
-        domainProducer.send(new ProducerRecord<>(publicTopic.name(), 100L, "got value")).get(WAIT, TimeUnit.SECONDS);
+        domainProducer
+                .send(new ProducerRecord<>(publicTopic.name(), 100L, "got value"))
+                .get(WAIT, TimeUnit.SECONDS);
 
-        domainProducer.send(new ProducerRecord<>(protectedTopic.name(), 200L, "got value")).get(WAIT, TimeUnit.SECONDS);
+        domainProducer
+                .send(new ProducerRecord<>(protectedTopic.name(), 200L, "got value"))
+                .get(WAIT, TimeUnit.SECONDS);
 
-        domainProducer.send(new ProducerRecord<>(privateTopic.name(), 300L, "got value")).get(WAIT, TimeUnit.SECONDS);
+        domainProducer
+                .send(new ProducerRecord<>(privateTopic.name(), 300L, "got value"))
+                .get(WAIT, TimeUnit.SECONDS);
 
         domainProducer.close();
-
     }
 
     @Order(2)
@@ -111,8 +115,8 @@ public class KafkaAPISpecFunctionalTest {
         final KafkaConsumer<Long, String> domainConsumer = getDomainConsumer(apiSpec.id());
 
         domainConsumer.subscribe(Collections.singleton(publicTopic.name()));
-        final ConsumerRecords<Long, String> records = domainConsumer
-                .poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
+        final ConsumerRecords<Long, String> records =
+                domainConsumer.poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
 
         domainConsumer.close();
 
@@ -130,8 +134,8 @@ public class KafkaAPISpecFunctionalTest {
         final KafkaConsumer<Long, String> domainConsumer = getDomainConsumer(apiSpec.id());
 
         domainConsumer.subscribe(Collections.singleton(protectedTopic.name()));
-        final ConsumerRecords<Long, String> records = domainConsumer
-                .poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
+        final ConsumerRecords<Long, String> records =
+                domainConsumer.poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
 
         domainConsumer.close();
 
@@ -149,8 +153,8 @@ public class KafkaAPISpecFunctionalTest {
         final KafkaConsumer<Long, String> domainConsumer = getDomainConsumer(apiSpec.id());
 
         domainConsumer.subscribe(Collections.singleton(protectedTopic.name()));
-        final ConsumerRecords<Long, String> records = domainConsumer
-                .poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
+        final ConsumerRecords<Long, String> records =
+                domainConsumer.poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
         domainConsumer.close();
 
         assertThat("Didnt get Record", records.count(), is(1));
@@ -167,8 +171,8 @@ public class KafkaAPISpecFunctionalTest {
 
         final KafkaConsumer<Long, String> foreignConsumer = getDomainConsumer(FOREIGN_DOMAIN);
         foreignConsumer.subscribe(Collections.singleton(publicTopic.name()));
-        final ConsumerRecords<Long, String> consumerRecords = foreignConsumer
-                .poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
+        final ConsumerRecords<Long, String> consumerRecords =
+                foreignConsumer.poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
         foreignConsumer.close();
 
         assertThat("Didnt get Record", consumerRecords.count(), is(1));
@@ -186,9 +190,14 @@ public class KafkaAPISpecFunctionalTest {
         final KafkaConsumer<Long, String> foreignConsumer = getDomainConsumer(FOREIGN_DOMAIN);
         foreignConsumer.subscribe(Collections.singleton(protectedTopic.name()));
 
-        final TopicAuthorizationException throwable = assertThrows(TopicAuthorizationException.class,
-                () -> foreignConsumer.poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit())));
-        assertThat(throwable.toString(),
+        final TopicAuthorizationException throwable =
+                assertThrows(
+                        TopicAuthorizationException.class,
+                        () ->
+                                foreignConsumer.poll(
+                                        Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit())));
+        assertThat(
+                throwable.toString(),
                 containsString(
                         "org.apache.kafka.common.errors.TopicAuthorizationException: Not authorized to access topics: "
                                 + "[london.hammersmith.olympia.bigdatalondon._protected.retail.subway.food.purchase]"));
@@ -203,16 +212,18 @@ public class KafkaAPISpecFunctionalTest {
 
         assertThat(newTopic.name(), containsString("._protected."));
 
-        final KafkaConsumer<Long, String> foreignConsumer = getDomainConsumer(SOME_OTHER_DOMAIN_ROOT);
+        final KafkaConsumer<Long, String> foreignConsumer =
+                getDomainConsumer(SOME_OTHER_DOMAIN_ROOT);
         foreignConsumer.subscribe(Collections.singleton(newTopic.name()));
-        final ConsumerRecords<Long, String> consumerRecords = foreignConsumer
-                .poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
+        final ConsumerRecords<Long, String> consumerRecords =
+                foreignConsumer.poll(Duration.of(WAIT, TimeUnit.SECONDS.toChronoUnit()));
         foreignConsumer.close();
 
         assertThat("Didnt get Record", consumerRecords.count(), is(1));
     }
 
-    private Properties cloneProperties(final Properties adminClientProperties, final Map<String, String> entries) {
+    private Properties cloneProperties(
+            final Properties adminClientProperties, final Map<String, String> entries) {
         final Properties results = new Properties();
         results.putAll(adminClientProperties);
         results.putAll(entries);
@@ -221,8 +232,11 @@ public class KafkaAPISpecFunctionalTest {
 
     private static ApiSpec getAPISpecFromResource() {
         try {
-            return new AsyncApiParser().loadResource(KafkaAPISpecFunctionalTest.class.getClassLoader()
-                    .getResourceAsStream("apispec-functional-test-app.yaml"));
+            return new AsyncApiParser()
+                    .loadResource(
+                            KafkaAPISpecFunctionalTest.class
+                                    .getClassLoader()
+                                    .getResourceAsStream("apispec-functional-test-app.yaml"));
         } catch (Throwable t) {
             throw new RuntimeException("Failed to load test resource", t);
         }
@@ -230,31 +244,50 @@ public class KafkaAPISpecFunctionalTest {
 
     private KafkaProducer<Long, String> getDomainProducer(final String domainId) {
         return new KafkaProducer<>(
-                cloneProperties(getClientProperties(), Map.of(AdminClientConfig.CLIENT_ID_CONFIG,
-                        domainId + ".producer", "sasl.jaas.config",
-                        String.format("org.apache.kafka.common.security.plain.PlainLoginModule required "
-                                + "   username=\"%s\" " + "   password=\"%s-secret\";", domainId, domainId))),
-                Serdes.Long().serializer(), Serdes.String().serializer());
+                cloneProperties(
+                        getClientProperties(),
+                        Map.of(
+                                AdminClientConfig.CLIENT_ID_CONFIG,
+                                domainId + ".producer",
+                                "sasl.jaas.config",
+                                String.format(
+                                        "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                                                + "   username=\"%s\" "
+                                                + "   password=\"%s-secret\";",
+                                        domainId, domainId))),
+                Serdes.Long().serializer(),
+                Serdes.String().serializer());
     }
 
     private KafkaConsumer<Long, String> getDomainConsumer(final String domainId) {
         return new KafkaConsumer<>(
-                cloneProperties(getClientProperties(),
-                        Map.of(ConsumerConfig.CLIENT_ID_CONFIG, domainId + ".consumer", ConsumerConfig.GROUP_ID_CONFIG,
-                                domainId + ".consumer-group", ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest",
+                cloneProperties(
+                        getClientProperties(),
+                        Map.of(
+                                ConsumerConfig.CLIENT_ID_CONFIG,
+                                domainId + ".consumer",
+                                ConsumerConfig.GROUP_ID_CONFIG,
+                                domainId + ".consumer-group",
+                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                                "earliest",
                                 "sasl.jaas.config",
-                                String.format("org.apache.kafka.common.security.plain.PlainLoginModule required "
-                                        + "   username=\"%s\" password=\"%s-secret\";", domainId, domainId))),
-                Serdes.Long().deserializer(), Serdes.String().deserializer());
+                                String.format(
+                                        "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                                                + "   username=\"%s\" password=\"%s-secret\";",
+                                        domainId, domainId))),
+                Serdes.Long().deserializer(),
+                Serdes.String().deserializer());
     }
 
     private static Properties getClientProperties() {
         final Properties adminClientProperties = new Properties();
         adminClientProperties.put(AdminClientConfig.CLIENT_ID_CONFIG, apiSpec.id());
-        adminClientProperties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        adminClientProperties.put(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
         adminClientProperties.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
         adminClientProperties.put("sasl.mechanism", "PLAIN");
-        adminClientProperties.put("sasl.jaas.config",
+        adminClientProperties.put(
+                "sasl.jaas.config",
                 "org.apache.kafka.common.security.plain.PlainLoginModule required "
                         + "   username=\"admin\" password=\"admin-secret\";");
         return adminClientProperties;
@@ -268,18 +301,29 @@ public class KafkaAPISpecFunctionalTest {
         env.put("KAFKA_SUPER_USERS", "User:OnlySuperUser");
         env.put("KAFKA_SASL_ENABLED_MECHANISMS", "PLAIN,SASL_PLAINTEXT");
 
-        env.put("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT");
+        env.put(
+                "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+                "BROKER:PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT");
         env.put("KAFKA_LISTENER_NAME_PLAINTEXT_SASL_ENABLED_MECHANISMS", "PLAIN");
-        env.put("KAFKA_LISTENER_NAME_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG",
-                "org.apache.kafka.common.security.plain.PlainLoginModule required " + "username=\"admin\" "
-                        + "password=\"admin-secret\" " + "user_admin=\"admin-secret\" "
+        env.put(
+                "KAFKA_LISTENER_NAME_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG",
+                "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                        + "username=\"admin\" "
+                        + "password=\"admin-secret\" "
+                        + "user_admin=\"admin-secret\" "
                         + String.format("user_%s=\"%s-secret\" ", apiSpec.id(), apiSpec.id())
                         + String.format("user_%s=\"%s-secret\" ", FOREIGN_DOMAIN, FOREIGN_DOMAIN)
-                        + String.format("user_%s=\"%s-secret\";", SOME_OTHER_DOMAIN_ROOT, SOME_OTHER_DOMAIN_ROOT));
+                        + String.format(
+                                "user_%s=\"%s-secret\";",
+                                SOME_OTHER_DOMAIN_ROOT, SOME_OTHER_DOMAIN_ROOT));
 
-        env.put("KAFKA_SASL_JAAS_CONFIG", "org.apache.kafka.common.security.plain.PlainLoginModule required "
-                + "username=\"admin\" " + "password=\"admin-secret\";");
-        return new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.2.2")).withStartupAttempts(3)
+        env.put(
+                "KAFKA_SASL_JAAS_CONFIG",
+                "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                        + "username=\"admin\" "
+                        + "password=\"admin-secret\";");
+        return new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.2.2"))
+                .withStartupAttempts(3)
                 .withEnv(env);
     }
 

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
@@ -46,11 +46,14 @@ public class KafkaAPISpecTest {
 
         assertThat(acls, iterableWithSize(6));
 
-        assertThat("Protected ACL was not created", acls.get(0).toString(),
-                is("(pattern=ResourcePattern(resourceType=TOPIC, "
-                        + "name=london.hammersmith.olympia.bigdatalondon._protected.retail.subway.food.purchase, "
-                        + "patternType=PREFIXED), entry=(principal=User:.some.other.domain.root, host=*, operation=READ, "
-                        + "permissionType=ALLOW))"));
+        assertThat(
+                "Protected ACL was not created",
+                acls.get(0).toString(),
+                is(
+                        "(pattern=ResourcePattern(resourceType=TOPIC, "
+                                + "name=london.hammersmith.olympia.bigdatalondon._protected.retail.subway.food.purchase, "
+                                + "patternType=PREFIXED), entry=(principal=User:.some.other.domain.root, host=*, operation=READ, "
+                                + "permissionType=ALLOW))"));
         // For adminClient.createAcls(acls);
     }
 
@@ -65,10 +68,12 @@ public class KafkaAPISpecTest {
     private ApiSpec getAPISpecFromResource() {
         try {
             return new AsyncApiParser()
-                    .loadResource(getClass().getClassLoader().getResourceAsStream("bigdatalondon-api.yaml"));
+                    .loadResource(
+                            getClass()
+                                    .getClassLoader()
+                                    .getResourceAsStream("bigdatalondon-api.yaml"));
         } catch (Throwable t) {
             throw new RuntimeException("Failed to load test resource", t);
         }
     }
-
 }

--- a/kafka/src/test/java/io/specmesh/kafka/SASLPlainPrincipleTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/SASLPlainPrincipleTest.java
@@ -54,8 +54,7 @@ public class SASLPlainPrincipleTest {
     public static final String PRIVATE_LIGHT_EVENTS = ".private.light.events";
     public static final String FOREIGN_DOMAIN = "london.hammersmith.transport";
     // CHECKSTYLE_RULES.OFF: VisibilityModifier
-    @Container
-    public static final KafkaContainer kafka = getKafkaContainer();
+    @Container public static final KafkaContainer kafka = getKafkaContainer();
 
     private static KafkaContainer getKafkaContainer() {
         final Map<String, String> env = new LinkedHashMap<>();
@@ -64,22 +63,37 @@ public class SASLPlainPrincipleTest {
         env.put("KAFKA_SUPER_USERS", "User:OnlySuperUser");
         env.put("KAFKA_SASL_ENABLED_MECHANISMS", "PLAIN,SASL_PLAINTEXT");
 
-        env.put("KAFKA_LISTENER_SECURITY_PROTOCOL_MAP", "BROKER:PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT");
+        env.put(
+                "KAFKA_LISTENER_SECURITY_PROTOCOL_MAP",
+                "BROKER:PLAINTEXT,PLAINTEXT:SASL_PLAINTEXT");
         env.put("KAFKA_LISTENER_NAME_PLAINTEXT_SASL_ENABLED_MECHANISMS", "PLAIN");
-        env.put("KAFKA_LISTENER_NAME_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG",
-                "org.apache.kafka.common.security.plain.PlainLoginModule required " + "username=\"admin\" "
-                        + "password=\"admin-secret\" " + "user_admin=\"admin-secret\" "
+        env.put(
+                "KAFKA_LISTENER_NAME_PLAINTEXT_PLAIN_SASL_JAAS_CONFIG",
+                "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                        + "username=\"admin\" "
+                        + "password=\"admin-secret\" "
+                        + "user_admin=\"admin-secret\" "
                         + String.format("user_%s=\"%s-secret\" ", DOMAIN_ROOT, DOMAIN_ROOT)
-                        + String.format("user_%s_producer=\"%s_producer-secret\" ", DOMAIN_ROOT, DOMAIN_ROOT)
-                        + String.format("user_%s_consumer=\"%s_consumer-secret\" ", DOMAIN_ROOT, DOMAIN_ROOT)
-                        + String.format("user_%s_producer=\"%s_producer-secret\" ", FOREIGN_DOMAIN, FOREIGN_DOMAIN)
-                        + String.format("user_%s_consumer=\"%s_consumer-secret\";", FOREIGN_DOMAIN, FOREIGN_DOMAIN)
+                        + String.format(
+                                "user_%s_producer=\"%s_producer-secret\" ",
+                                DOMAIN_ROOT, DOMAIN_ROOT)
+                        + String.format(
+                                "user_%s_consumer=\"%s_consumer-secret\" ",
+                                DOMAIN_ROOT, DOMAIN_ROOT)
+                        + String.format(
+                                "user_%s_producer=\"%s_producer-secret\" ",
+                                FOREIGN_DOMAIN, FOREIGN_DOMAIN)
+                        + String.format(
+                                "user_%s_consumer=\"%s_consumer-secret\";",
+                                FOREIGN_DOMAIN, FOREIGN_DOMAIN));
 
-        );
-
-        env.put("KAFKA_SASL_JAAS_CONFIG", "org.apache.kafka.common.security.plain.PlainLoginModule required "
-                + "username=\"admin\" " + "password=\"admin-secret\";");
-        return new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1")).withStartupAttempts(3)
+        env.put(
+                "KAFKA_SASL_JAAS_CONFIG",
+                "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                        + "username=\"admin\" "
+                        + "password=\"admin-secret\";");
+        return new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:6.2.1"))
+                .withStartupAttempts(3)
                 .withEnv(env);
     }
 
@@ -93,75 +107,125 @@ public class SASLPlainPrincipleTest {
 
         final Properties adminClientProperties = new Properties();
         adminClientProperties.put(AdminClientConfig.CLIENT_ID_CONFIG, DOMAIN_ROOT);
-        adminClientProperties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
+        adminClientProperties.put(
+                AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, kafka.getBootstrapServers());
         adminClientProperties.put(AdminClientConfig.SECURITY_PROTOCOL_CONFIG, "SASL_PLAINTEXT");
         adminClientProperties.put("sasl.mechanism", "PLAIN");
-        adminClientProperties.put("sasl.jaas.config",
+        adminClientProperties.put(
+                "sasl.jaas.config",
                 "org.apache.kafka.common.security.plain.PlainLoginModule required "
                         + "   username=\"admin\" password=\"admin-secret\";");
 
         adminClient = AdminClient.create(adminClientProperties);
-        CreateTopicsResult topics = adminClient.createTopics(
-                Sets.newHashSet(new NewTopic(DOMAIN_ROOT + PUBLIC_LIGHT_MEASURED, 1, Short.parseShort("1")),
-                        new NewTopic(DOMAIN_ROOT + PRIVATE_LIGHT_EVENTS, 1, Short.parseShort("1")),
-                        new NewTopic(".london.hammersmith.transport.public.tube", 1, Short.parseShort("1"))));
+        CreateTopicsResult topics =
+                adminClient.createTopics(
+                        Sets.newHashSet(
+                                new NewTopic(
+                                        DOMAIN_ROOT + PUBLIC_LIGHT_MEASURED,
+                                        1,
+                                        Short.parseShort("1")),
+                                new NewTopic(
+                                        DOMAIN_ROOT + PRIVATE_LIGHT_EVENTS,
+                                        1,
+                                        Short.parseShort("1")),
+                                new NewTopic(
+                                        ".london.hammersmith.transport.public.tube",
+                                        1,
+                                        Short.parseShort("1"))));
 
-        topics.values().values().forEach(f -> {
-            try {
-                f.get();
-            } catch (ExecutionException | InterruptedException | RuntimeException e) {
-                throw new RuntimeException(e);
-            }
-        });
+        topics.values()
+                .values()
+                .forEach(
+                        f -> {
+                            try {
+                                f.get();
+                            } catch (ExecutionException
+                                    | InterruptedException
+                                    | RuntimeException e) {
+                                throw new RuntimeException(e);
+                            }
+                        });
 
-        domainProducer = new KafkaProducer<>(
-                cloneProperties(adminClientProperties,
-                        Map.of(AdminClientConfig.CLIENT_ID_CONFIG, DOMAIN_ROOT + ".producer", "sasl.jaas.config",
-                                String.format("org.apache.kafka.common.security.plain.PlainLoginModule required "
-                                        + "   username=\"%s_producer\" " + "   password=\"%s_producer-secret\";",
-                                        DOMAIN_ROOT, DOMAIN_ROOT))),
-                Serdes.Long().serializer(), Serdes.String().serializer());
+        domainProducer =
+                new KafkaProducer<>(
+                        cloneProperties(
+                                adminClientProperties,
+                                Map.of(
+                                        AdminClientConfig.CLIENT_ID_CONFIG,
+                                        DOMAIN_ROOT + ".producer",
+                                        "sasl.jaas.config",
+                                        String.format(
+                                                "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                                                        + "   username=\"%s_producer\" "
+                                                        + "   password=\"%s_producer-secret\";",
+                                                DOMAIN_ROOT, DOMAIN_ROOT))),
+                        Serdes.Long().serializer(),
+                        Serdes.String().serializer());
 
-        domainConsumer = new KafkaConsumer<>(
-                cloneProperties(adminClientProperties,
-                        Map.of(ConsumerConfig.CLIENT_ID_CONFIG, DOMAIN_ROOT + ".consumer",
-                                ConsumerConfig.GROUP_ID_CONFIG, DOMAIN_ROOT + ".consumer-group",
-                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest", "sasl.jaas.config",
-                                String.format("org.apache.kafka.common.security.plain.PlainLoginModule required "
-                                        + "   username=\"%s_consumer\" " + "   password=\"%s_consumer-secret\";",
-                                        DOMAIN_ROOT, DOMAIN_ROOT))),
-                Serdes.Long().deserializer(), Serdes.String().deserializer());
+        domainConsumer =
+                new KafkaConsumer<>(
+                        cloneProperties(
+                                adminClientProperties,
+                                Map.of(
+                                        ConsumerConfig.CLIENT_ID_CONFIG,
+                                        DOMAIN_ROOT + ".consumer",
+                                        ConsumerConfig.GROUP_ID_CONFIG,
+                                        DOMAIN_ROOT + ".consumer-group",
+                                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                                        "earliest",
+                                        "sasl.jaas.config",
+                                        String.format(
+                                                "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                                                        + "   username=\"%s_consumer\" "
+                                                        + "   password=\"%s_consumer-secret\";",
+                                                DOMAIN_ROOT, DOMAIN_ROOT))),
+                        Serdes.Long().deserializer(),
+                        Serdes.String().deserializer());
 
-        foreignConsumer = new KafkaConsumer<>(
-                cloneProperties(adminClientProperties,
-                        Map.of(ConsumerConfig.CLIENT_ID_CONFIG, FOREIGN_DOMAIN + ".consumer",
-                                ConsumerConfig.GROUP_ID_CONFIG, FOREIGN_DOMAIN + ".consumer-group",
-                                ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest", "sasl.jaas.config",
-                                String.format("org.apache.kafka.common.security.plain.PlainLoginModule required "
-                                        + "   username=\"%s_consumer\" " + "   password=\"%s_consumer-secret\";",
-                                        FOREIGN_DOMAIN, FOREIGN_DOMAIN))),
-                Serdes.Long().deserializer(), Serdes.String().deserializer());
+        foreignConsumer =
+                new KafkaConsumer<>(
+                        cloneProperties(
+                                adminClientProperties,
+                                Map.of(
+                                        ConsumerConfig.CLIENT_ID_CONFIG,
+                                        FOREIGN_DOMAIN + ".consumer",
+                                        ConsumerConfig.GROUP_ID_CONFIG,
+                                        FOREIGN_DOMAIN + ".consumer-group",
+                                        ConsumerConfig.AUTO_OFFSET_RESET_CONFIG,
+                                        "earliest",
+                                        "sasl.jaas.config",
+                                        String.format(
+                                                "org.apache.kafka.common.security.plain.PlainLoginModule required "
+                                                        + "   username=\"%s_consumer\" "
+                                                        + "   password=\"%s_consumer-secret\";",
+                                                FOREIGN_DOMAIN, FOREIGN_DOMAIN))),
+                        Serdes.Long().deserializer(),
+                        Serdes.String().deserializer());
     }
 
     @SuppressWarnings("unchecked")
     @Test
     public void shouldPubSubStuff() throws Exception {
 
-        domainProducer.send(new ProducerRecord(DOMAIN_ROOT + PUBLIC_LIGHT_MEASURED, 100L, "got value")).get();
+        domainProducer
+                .send(new ProducerRecord(DOMAIN_ROOT + PUBLIC_LIGHT_MEASURED, 100L, "got value"))
+                .get();
 
         domainConsumer.subscribe(Collections.singleton(DOMAIN_ROOT + PUBLIC_LIGHT_MEASURED));
-        ConsumerRecords<Long, String> poll = domainConsumer.poll(Duration.of(30, TimeUnit.SECONDS.toChronoUnit()));
+        ConsumerRecords<Long, String> poll =
+                domainConsumer.poll(Duration.of(30, TimeUnit.SECONDS.toChronoUnit()));
 
         assertThat("Didnt get Record", poll.count(), is(1));
 
         foreignConsumer.subscribe(Collections.singleton(DOMAIN_ROOT + PUBLIC_LIGHT_MEASURED));
-        ConsumerRecords<Long, String> pollForeign = foreignConsumer
-                .poll(Duration.of(30, TimeUnit.SECONDS.toChronoUnit()));
+        ConsumerRecords<Long, String> pollForeign =
+                foreignConsumer.poll(Duration.of(30, TimeUnit.SECONDS.toChronoUnit()));
 
         assertThat("Didnt get Record", pollForeign.count(), is(1));
     }
 
-    private Properties cloneProperties(Properties adminClientProperties, Map<String, String> entries) {
+    private Properties cloneProperties(
+            Properties adminClientProperties, Map<String, String> entries) {
         Properties results = new Properties();
         results.putAll(adminClientProperties);
         results.putAll(entries);

--- a/kafka/src/test/java/io/specmesh/kafka/schema/SrSchemaManagerTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/schema/SrSchemaManagerTest.java
@@ -49,17 +49,27 @@ class SrSchemaManagerTest {
 
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
-    private final MockSchemaRegistryClient schemaRegistryClient = new MockSchemaRegistryClient(
-            List.of(new AvroSchemaProvider(), new JsonSchemaProvider()));
+    private final MockSchemaRegistryClient schemaRegistryClient =
+            new MockSchemaRegistryClient(
+                    List.of(new AvroSchemaProvider(), new JsonSchemaProvider()));
     private final SrSchemaManager srSchemaManager = new SrSchemaManager(schemaRegistryClient);
 
     @Test
     public void shouldLoadJsonSchemaThenSerializeAndDeseralize() throws Exception {
 
         final var topicSubject = "simple.schema_demo._public.user_checkout";
-        final var schemaContent = JsonSchemas.yamlToJson(Files.readString(
-                Path.of(Objects.requireNonNull(getClass().getResource("/schema/" + topicSubject + ".yml")).toURI()),
-                UTF_8));
+        final var schemaContent =
+                JsonSchemas.yamlToJson(
+                        Files.readString(
+                                Path.of(
+                                        Objects.requireNonNull(
+                                                        getClass()
+                                                                .getResource(
+                                                                        "/schema/"
+                                                                                + topicSubject
+                                                                                + ".yml"))
+                                                .toURI()),
+                                UTF_8));
 
         final var jsonSchema = new JsonSchema(schemaContent);
 
@@ -71,15 +81,25 @@ class SrSchemaManagerTest {
 
         final var userCheckout = new UserCheckout(100L, "joe bloggs", 100, "now");
 
-        final Map<String, ?> props = Map.of(KafkaJsonSchemaSerializerConfig.AUTO_REGISTER_SCHEMAS, "false",
-                // schema-reflect MUST be true when writing Java objects (otherwise you send a
-                // datum-container instead of a Pogo)
-                KafkaJsonSchemaSerializerConfig.SCHEMA_REFLECTION_CONFIG, "true",
-                KafkaJsonSchemaSerializerConfig.USE_LATEST_VERSION, "true",
-                KafkaJsonSchemaSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://",
-                KafkaJsonSchemaSerializerConfig.FAIL_INVALID_SCHEMA, true,
-                KafkaJsonSchemaSerializerConfig.WRITE_DATES_AS_ISO8601, true,
-                KafkaJsonDeserializerConfig.JSON_VALUE_TYPE, UserCheckout.class.getName());
+        final Map<String, ?> props =
+                Map.of(
+                        KafkaJsonSchemaSerializerConfig.AUTO_REGISTER_SCHEMAS,
+                        "false",
+                        // schema-reflect MUST be true when writing Java objects (otherwise you send
+                        // a
+                        // datum-container instead of a Pogo)
+                        KafkaJsonSchemaSerializerConfig.SCHEMA_REFLECTION_CONFIG,
+                        "true",
+                        KafkaJsonSchemaSerializerConfig.USE_LATEST_VERSION,
+                        "true",
+                        KafkaJsonSchemaSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                        "mock://",
+                        KafkaJsonSchemaSerializerConfig.FAIL_INVALID_SCHEMA,
+                        true,
+                        KafkaJsonSchemaSerializerConfig.WRITE_DATES_AS_ISO8601,
+                        true,
+                        KafkaJsonDeserializerConfig.JSON_VALUE_TYPE,
+                        UserCheckout.class.getName());
         final var serializer = new KafkaJsonSchemaSerializer(schemaRegistryClient, props);
 
         final byte[] bytess = serializer.serialize(topicSubject, userCheckout);
@@ -94,9 +114,17 @@ class SrSchemaManagerTest {
     public void shouldLoadAvroSchemaThenSerializeAndDeseralizeWithReflection() throws Exception {
 
         final var topicSubject = "simple.schema_demo._public.user_signed_up";
-        final var schemaContent = Files.readString(
-                Path.of(Objects.requireNonNull(getClass().getResource("/schema/" + topicSubject + ".avsc")).toURI()),
-                UTF_8);
+        final var schemaContent =
+                Files.readString(
+                        Path.of(
+                                Objects.requireNonNull(
+                                                getClass()
+                                                        .getResource(
+                                                                "/schema/"
+                                                                        + topicSubject
+                                                                        + ".avsc"))
+                                        .toURI()),
+                        UTF_8);
 
         final var avroSchema = new AvroSchema(schemaContent);
 
@@ -106,18 +134,27 @@ class SrSchemaManagerTest {
 
         final UserSignedUp signedUp = new UserSignedUp("joe bloggs", "bloggy@wasmail.com", 100);
 
-        final Map<String, ?> props = Map.of(KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS, "false",
-                // schema-reflect MUST be true when writing Java objects (otherwise you send a
-                // datum-container instead of a Pogo)
-                KafkaAvroSerializerConfig.SCHEMA_REFLECTION_CONFIG, "true",
-                KafkaAvroSerializerConfig.USE_LATEST_VERSION, "true",
-                KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG, "mock://");
+        final Map<String, ?> props =
+                Map.of(
+                        KafkaAvroSerializerConfig.AUTO_REGISTER_SCHEMAS,
+                        "false",
+                        // schema-reflect MUST be true when writing Java objects (otherwise you send
+                        // a
+                        // datum-container instead of a Pogo)
+                        KafkaAvroSerializerConfig.SCHEMA_REFLECTION_CONFIG,
+                        "true",
+                        KafkaAvroSerializerConfig.USE_LATEST_VERSION,
+                        "true",
+                        KafkaAvroSerializerConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                        "mock://");
         final KafkaAvroSerializer serializer = new KafkaAvroSerializer(schemaRegistryClient, props);
 
         final byte[] bytess = serializer.serialize(topicSubject, signedUp);
 
-        final KafkaAvroDeserializer deserializer = new KafkaAvroDeserializer(schemaRegistryClient, props);
-        final UserSignedUp deserialize = (UserSignedUp) deserializer.deserialize(topicSubject, bytess);
+        final KafkaAvroDeserializer deserializer =
+                new KafkaAvroDeserializer(schemaRegistryClient, props);
+        final UserSignedUp deserialize =
+                (UserSignedUp) deserializer.deserialize(topicSubject, bytess);
 
         assertThat(deserialize, is(signedUp));
     }
@@ -206,13 +243,20 @@ class SrSchemaManagerTest {
 
     public static JsonSchema loadSchemaFromClasspath(final String schemaFile) {
         try {
-            return new JsonSchema(yamlToJson(Files.readString(Path
-                    .of(Objects.requireNonNull(RegisteredSchema.class.getResource("/schema/" + schemaFile)).toURI()),
-                    UTF_8)));
+            return new JsonSchema(
+                    yamlToJson(
+                            Files.readString(
+                                    Path.of(
+                                            Objects.requireNonNull(
+                                                            RegisteredSchema.class.getResource(
+                                                                    "/schema/" + schemaFile))
+                                                    .toURI()),
+                                    UTF_8)));
         } catch (final Exception e) {
             throw new AssertionError("Failed to load schemaFile: " + schemaFile, e);
         }
     }
+
     public static String yamlToJson(final String yaml) throws IOException {
         final ObjectMapper yamlReader = new ObjectMapper(new YAMLFactory());
         final Object obj = yamlReader.readValue(yaml, Object.class);

--- a/kafka/src/test/java/simple/schema_demo/_public/user_checkout_value/UserCheckout.java
+++ b/kafka/src/test/java/simple/schema_demo/_public/user_checkout_value/UserCheckout.java
@@ -27,15 +27,15 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-@JsonSchemaInject(strings = {
-        @JsonSchemaString(path = "javaType", value = "simple.schema_demo._public.user_checkout_value.UserCheckout")})
+@JsonSchemaInject(
+        strings = {
+            @JsonSchemaString(
+                    path = "javaType",
+                    value = "simple.schema_demo._public.user_checkout_value.UserCheckout")
+        })
 public class UserCheckout {
-    @JsonProperty
-    long id;
-    @JsonProperty
-    String name;
-    @JsonProperty
-    int price;
-    @JsonProperty
-    String systemDate;
+    @JsonProperty long id;
+    @JsonProperty String name;
+    @JsonProperty int price;
+    @JsonProperty String systemDate;
 }

--- a/kafka/src/test/java/simple/schema_demo/_public/user_signed_up_value/UserSignedUp.java
+++ b/kafka/src/test/java/simple/schema_demo/_public/user_signed_up_value/UserSignedUp.java
@@ -28,5 +28,4 @@ public class UserSignedUp {
     String fullName;
     String email;
     int age;
-
 }

--- a/parser/src/main/java/io/specmesh/apiparser/AsyncApiParser.java
+++ b/parser/src/main/java/io/specmesh/apiparser/AsyncApiParser.java
@@ -23,19 +23,15 @@ import io.specmesh.apiparser.model.ApiSpec;
 import java.io.IOException;
 import java.io.InputStream;
 
-/**
- * The parser
- */
+/** The parser */
 public class AsyncApiParser {
 
     /**
      * Parse an {@link ApiSpec} from the supplied {@code inputStream}.
      *
-     * @param inputStream
-     *            stream containing the spec.
+     * @param inputStream stream containing the spec.
      * @return the api spec
-     * @throws IOException
-     *             on error
+     * @throws IOException on error
      */
     public final ApiSpec loadResource(final InputStream inputStream) throws IOException {
         if (inputStream == null || inputStream.available() == 0) {
@@ -43,5 +39,4 @@ public class AsyncApiParser {
         }
         return new ObjectMapper(new YAMLFactory()).readValue(inputStream, ApiSpec.class);
     }
-
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/ApiSpec.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/ApiSpec.java
@@ -28,9 +28,7 @@ import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
-/**
- * Pojo representing the api spec
- */
+/** Pojo representing the api spec */
 @Value
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -38,17 +36,13 @@ import lombok.experimental.Accessors;
 @SuppressFBWarnings
 public class ApiSpec {
     private static final char DELIMITER = System.getProperty("DELIMITER", ".").charAt(0);
-    @JsonProperty
-    private String id;
+    @JsonProperty private String id;
 
-    @JsonProperty
-    private String version;
+    @JsonProperty private String version;
 
-    @JsonProperty
-    private String asyncapi;
+    @JsonProperty private String asyncapi;
 
-    @JsonProperty
-    private Map<String, Channel> channels;
+    @JsonProperty private Map<String, Channel> channels;
 
     /**
      * @return unique spec id
@@ -68,8 +62,13 @@ public class ApiSpec {
      * @return channels
      */
     public Map<String, Channel> channels() {
-        return channels.entrySet().stream().collect(Collectors.toMap(e -> getCanonical(id(), e.getKey()),
-                e -> e.getValue(), (k, v) -> k, LinkedHashMap::new));
+        return channels.entrySet().stream()
+                .collect(
+                        Collectors.toMap(
+                                e -> getCanonical(id(), e.getKey()),
+                                e -> e.getValue(),
+                                (k, v) -> k,
+                                LinkedHashMap::new));
     }
 
     private String getCanonical(final String id, final String channelName) {

--- a/parser/src/main/java/io/specmesh/apiparser/model/Bindings.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Bindings.java
@@ -24,16 +24,12 @@ import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
-/**
- * Pojo representing a binding
- */
+/** Pojo representing a binding */
 @Value
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class Bindings {
 
-    @JsonProperty
-    KafkaBinding kafka;
-
+    @JsonProperty KafkaBinding kafka;
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/Channel.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Channel.java
@@ -24,25 +24,18 @@ import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
-/**
- * Pojo representing a channel
- */
+/** Pojo representing a channel */
 @Value
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class Channel {
 
-    @JsonProperty
-    String description;
+    @JsonProperty String description;
 
-    @JsonProperty
-    Bindings bindings;
+    @JsonProperty Bindings bindings;
 
-    @JsonProperty
-    Operation publish;
+    @JsonProperty Operation publish;
 
-    @JsonProperty
-    Operation subscribe;
-
+    @JsonProperty Operation subscribe;
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
@@ -35,9 +35,7 @@ import lombok.experimental.Accessors;
  * - <a href="https://github.com/projectlombok/lombok/issues/1347">...</a>
  */
 
-/**
- * Pojo representing a Kafka binding
- */
+/** Pojo representing a Kafka binding */
 @Value
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -51,29 +49,21 @@ public class KafkaBinding {
     @JsonProperty
     private List<String> envs = Collections.EMPTY_LIST;
 
-    @JsonProperty
-    private int partitions;
+    @JsonProperty private int partitions;
 
-    @JsonProperty
-    private int replicas;
+    @JsonProperty private int replicas;
 
-    @JsonProperty
-    private int retention;
+    @JsonProperty private int retention;
 
-    @JsonProperty
-    private Map<String, String> configs = Collections.emptyMap();
+    @JsonProperty private Map<String, String> configs = Collections.emptyMap();
 
-    @JsonProperty
-    private String groupId;
+    @JsonProperty private String groupId;
 
-    @JsonProperty
-    private String schemaIdLocation;
+    @JsonProperty private String schemaIdLocation;
 
-    @JsonProperty
-    private String schemaLookupStrategy;
+    @JsonProperty private String schemaLookupStrategy;
 
-    @JsonProperty
-    private String bindingVersion;
+    @JsonProperty private String bindingVersion;
 
     /**
      * @return configs
@@ -88,7 +78,6 @@ public class KafkaBinding {
     }
 
     /**
-     *
      * @return number of topic partitions
      */
     public int partitions() {
@@ -96,7 +85,6 @@ public class KafkaBinding {
     }
 
     /**
-     *
      * @return number of topic replicas
      */
     public int replicas() {
@@ -104,7 +92,6 @@ public class KafkaBinding {
     }
 
     /**
-     *
      * @return message retention in ms.
      */
     public int retention() {

--- a/parser/src/main/java/io/specmesh/apiparser/model/Message.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Message.java
@@ -31,9 +31,8 @@ import lombok.experimental.Accessors;
 /**
  * Pojo representing a Message.
  *
- * @see <a href=
- *      "https://www.asyncapi.com/docs/reference/specification/v2.4.0#messageObject">spec
- *      docs</a>
+ * @see <a href= "https://www.asyncapi.com/docs/reference/specification/v2.4.0#messageObject">spec
+ *     docs</a>
  */
 @Value
 @Accessors(fluent = true)
@@ -42,44 +41,31 @@ import lombok.experimental.Accessors;
 @SuppressFBWarnings
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class Message {
-    @JsonProperty
-    private String messageId;
+    @JsonProperty private String messageId;
 
-    @JsonProperty
-    private Map headers = Collections.EMPTY_MAP;
+    @JsonProperty private Map headers = Collections.EMPTY_MAP;
 
-    @JsonProperty
-    private Map payload = Collections.EMPTY_MAP;
+    @JsonProperty private Map payload = Collections.EMPTY_MAP;
 
-    @JsonProperty
-    private Map correlationId = Collections.EMPTY_MAP;
+    @JsonProperty private Map correlationId = Collections.EMPTY_MAP;
 
-    @JsonProperty
-    private String schemaFormat;
+    @JsonProperty private String schemaFormat;
 
-    @JsonProperty
-    private String contentType;
+    @JsonProperty private String contentType;
 
-    @JsonProperty
-    private String name;
+    @JsonProperty private String name;
 
-    @JsonProperty
-    private String title;
+    @JsonProperty private String title;
 
-    @JsonProperty
-    private String summary;
+    @JsonProperty private String summary;
 
-    @JsonProperty
-    private String description;
+    @JsonProperty private String description;
 
-    @JsonProperty
-    private List<Tag> tags = Collections.EMPTY_LIST;
+    @JsonProperty private List<Tag> tags = Collections.EMPTY_LIST;
 
-    @JsonProperty
-    private Bindings bindings;
+    @JsonProperty private Bindings bindings;
 
-    @JsonProperty
-    private Map traits = Collections.EMPTY_MAP;
+    @JsonProperty private Map traits = Collections.EMPTY_MAP;
 
     /**
      * @return the location of the schema

--- a/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
@@ -32,9 +32,9 @@ import lombok.experimental.Accessors;
  * Pojo representing a Message.
  *
  * @see <a href=
- *      "https://www.asyncapi.com/docs/reference/specification/v2.4.0#operationObject">operationObject</a>
+ *     "https://www.asyncapi.com/docs/reference/specification/v2.4.0#operationObject">operationObject</a>
  * @see <a href=
- *      "https://www.asyncapi.com/docs/reference/specification/v2.4.0#messageTraitObject">messageTraitObject</a>
+ *     "https://www.asyncapi.com/docs/reference/specification/v2.4.0#messageTraitObject">messageTraitObject</a>
  */
 @Value
 @Accessors(fluent = true)
@@ -43,28 +43,22 @@ import lombok.experimental.Accessors;
 @SuppressFBWarnings
 @SuppressWarnings({"unchecked", "rawtypes"})
 public class Operation {
-    @JsonProperty
-    private String operationId;
+    @JsonProperty private String operationId;
 
-    @JsonProperty
-    private String summary;
+    @JsonProperty private String summary;
 
-    @JsonProperty
-    private String description;
+    @JsonProperty private String description;
 
     @SuppressWarnings({"rawtypes", "unchecked"})
     @JsonProperty
     private List<Tag> tags = Collections.EMPTY_LIST;
 
-    @JsonProperty
-    private Bindings bindings;
+    @JsonProperty private Bindings bindings;
 
     // https://www.asyncapi.com/docs/reference/specification/v2.4.0#operationTraitObject
-    @JsonProperty
-    private Map traits = Collections.EMPTY_MAP;
+    @JsonProperty private Map traits = Collections.EMPTY_MAP;
 
-    @JsonProperty
-    private Message message;
+    @JsonProperty private Message message;
 
     /**
      * @return schema info
@@ -73,8 +67,11 @@ public class Operation {
         if (message.bindings() == null) {
             throw new IllegalStateException("Bindings not found for operation: " + operationId);
         }
-        return new SchemaInfo(message().schemaRef(), message().schemaFormat(),
-                message.bindings().kafka().schemaIdLocation(), message().contentType(),
+        return new SchemaInfo(
+                message().schemaRef(),
+                message().schemaFormat(),
+                message.bindings().kafka().schemaIdLocation(),
+                message().contentType(),
                 message.bindings().kafka().schemaLookupStrategy());
     }
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/SchemaInfo.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/SchemaInfo.java
@@ -20,9 +20,7 @@ package io.specmesh.apiparser.model;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
-/**
- * Pojo representing a schmea
- */
+/** Pojo representing a schmea */
 @Value
 @Accessors(fluent = true)
 public class SchemaInfo {
@@ -33,19 +31,18 @@ public class SchemaInfo {
     private String schemaLookupStrategy;
 
     /**
-     * @param schemaRef
-     *            location of schema
-     * @param schemaFormat
-     *            format of schema
-     * @param schemaIdLocation
-     *            header || payload
-     * @param contentType
-     *            content type of schema
-     * @param schemaLookupStrategy
-     *            schema lookup strategy
+     * @param schemaRef location of schema
+     * @param schemaFormat format of schema
+     * @param schemaIdLocation header || payload
+     * @param contentType content type of schema
+     * @param schemaLookupStrategy schema lookup strategy
      */
-    public SchemaInfo(final String schemaRef, final String schemaFormat, final String schemaIdLocation,
-            final String contentType, final String schemaLookupStrategy) {
+    public SchemaInfo(
+            final String schemaRef,
+            final String schemaFormat,
+            final String schemaIdLocation,
+            final String contentType,
+            final String schemaLookupStrategy) {
         this.schemaRef = schemaRef;
         this.schemaFormat = schemaFormat;
         this.schemaIdLocation = schemaIdLocation;

--- a/parser/src/main/java/io/specmesh/apiparser/model/Tag.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Tag.java
@@ -24,17 +24,13 @@ import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
-/**
- * Pojo representing a tag
- */
+/** Pojo representing a tag */
 @Value
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
 public class Tag {
-    @JsonProperty
-    String name;
+    @JsonProperty String name;
 
-    @JsonProperty
-    String description;
+    @JsonProperty String description;
 }

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
@@ -40,9 +40,13 @@ public class AsyncApiParserTest {
     public void shouldReturnCanonicalChannelNames() {
         final Map<String, Channel> channelsMap = apiSpec.channels();
         assertThat(channelsMap.size(), is(2));
-        assertThat("Should have assembled id + channelname", channelsMap.keySet(),
+        assertThat(
+                "Should have assembled id + channelname",
+                channelsMap.keySet(),
                 hasItem("simple.streetlights.public.light.measured"));
-        assertThat("Should use absolute path", channelsMap.keySet(),
+        assertThat(
+                "Should use absolute path",
+                channelsMap.keySet(),
                 hasItem("london.hammersmith.transport.public.tube"));
     }
 
@@ -50,53 +54,74 @@ public class AsyncApiParserTest {
     public void shouldReturnKafkaBindingsForCreation() {
         final Map<String, Channel> channelsMap = apiSpec.channels();
         assertThat(channelsMap.size(), is(2));
-        assertThat("Should have assembled id + channelname", channelsMap.keySet(),
+        assertThat(
+                "Should have assembled id + channelname",
+                channelsMap.keySet(),
                 hasItem("simple.streetlights.public.light.measured"));
 
-        final Bindings producerBindings = channelsMap.get("simple.streetlights.public.light.measured").bindings();
+        final Bindings producerBindings =
+                channelsMap.get("simple.streetlights.public.light.measured").bindings();
         assertThat(producerBindings.kafka().partitions(), is(3));
         assertThat(producerBindings.kafka().replicas(), is(1));
         assertThat(producerBindings.kafka().retention(), is(1));
 
-        assertThat("Should use absolute path", channelsMap.keySet(),
+        assertThat(
+                "Should use absolute path",
+                channelsMap.keySet(),
                 hasItem("london.hammersmith.transport.public.tube"));
-
     }
 
     @Test
     public void shouldReturnOperationTags() {
         final Map<String, Channel> channelsMap = apiSpec.channels();
         assertThat(channelsMap.size(), is(2));
-        assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(),
+        assertThat(
+                "Should have assembled 'id + channelname'",
+                channelsMap.keySet(),
                 hasItem("simple.streetlights.public.light.measured"));
 
-        final Bindings producerBindings = channelsMap.get("simple.streetlights.public.light.measured").bindings();
+        final Bindings producerBindings =
+                channelsMap.get("simple.streetlights.public.light.measured").bindings();
         assertThat(producerBindings.kafka().configs().size(), is(2));
-        assertThat(producerBindings.kafka().configs().keySet(), is(Set.of("cleanup.policy", "retention.ms")));
+        assertThat(
+                producerBindings.kafka().configs().keySet(),
+                is(Set.of("cleanup.policy", "retention.ms")));
         assertThat(producerBindings.kafka().envs().size(), is(2));
 
-        assertThat(channelsMap.values().iterator().next().publish().message().tags(), Matchers.iterableWithSize(2));
+        assertThat(
+                channelsMap.values().iterator().next().publish().message().tags(),
+                Matchers.iterableWithSize(2));
     }
 
     @Test
     public void shouldReturnProducerMessageSchema() {
         final Map<String, Channel> channelsMap = apiSpec.channels();
         assertThat(channelsMap.size(), is(2));
-        assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(),
+        assertThat(
+                "Should have assembled 'id + channelname'",
+                channelsMap.keySet(),
                 hasItem("simple.streetlights.public.light.measured"));
 
-        final Bindings producerBindings = channelsMap.get("simple.streetlights.public.light.measured").bindings();
+        final Bindings producerBindings =
+                channelsMap.get("simple.streetlights.public.light.measured").bindings();
         assertThat(producerBindings.kafka().configs().size(), is(2));
-        assertThat(producerBindings.kafka().configs().keySet(), is(Set.of("cleanup.policy", "retention.ms")));
+        assertThat(
+                producerBindings.kafka().configs().keySet(),
+                is(Set.of("cleanup.policy", "retention.ms")));
         assertThat(producerBindings.kafka().envs().size(), is(2));
 
-        assertThat(channelsMap.values().iterator().next().publish().message().tags(), Matchers.iterableWithSize(2));
+        assertThat(
+                channelsMap.values().iterator().next().publish().message().tags(),
+                Matchers.iterableWithSize(2));
     }
 
     private ApiSpec getAPISpecFromResource() {
         try {
             return new AsyncApiParser()
-                    .loadResource(getClass().getClassLoader().getResourceAsStream("test-streetlights-simple-api.yaml"));
+                    .loadResource(
+                            getClass()
+                                    .getClassLoader()
+                                    .getResourceAsStream("test-streetlights-simple-api.yaml"));
         } catch (Throwable t) {
             throw new RuntimeException("Failed to load test resource", t);
         }

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
@@ -33,13 +33,18 @@ public class AsyncApiSchemaParserTest {
     public void shouldReturnProducerMessageSchema() {
         final Map<String, Channel> channelsMap = apiSpec.channels();
         assertThat(channelsMap.size(), is(2));
-        assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(),
+        assertThat(
+                "Should have assembled 'id + channelname'",
+                channelsMap.keySet(),
                 hasItem("simple.schema-demo.public.user.signed"));
 
-        final Operation publish = channelsMap.get("simple.schema-demo.public.user.signed").publish();
+        final Operation publish =
+                channelsMap.get("simple.schema-demo.public.user.signed").publish();
         assertThat(publish.message().schemaRef(), is("simple_schema_demo_user-signedup.avsc"));
 
-        assertThat(publish.message().schemaFormat(), is("application/vnd.apache.avro+json;version=1.9.0"));
+        assertThat(
+                publish.message().schemaFormat(),
+                is("application/vnd.apache.avro+json;version=1.9.0"));
         assertThat(publish.message().contentType(), is("application/octet-stream"));
         assertThat(publish.message().bindings().kafka().schemaIdLocation(), is("payload"));
         assertThat(publish.schemaInfo().schemaIdLocation(), is("payload"));
@@ -49,12 +54,19 @@ public class AsyncApiSchemaParserTest {
     public void shouldReturnSubscriberMessageSchema() {
         final Map<String, Channel> channelsMap = apiSpec.channels();
         assertThat(channelsMap.size(), is(2));
-        assertThat("Should have assembled 'id + channelname'", channelsMap.keySet(),
+        assertThat(
+                "Should have assembled 'id + channelname'",
+                channelsMap.keySet(),
                 hasItem("london.hammersmith.transport.public.tube"));
 
-        final Operation subscribe = channelsMap.get("london.hammersmith.transport.public.tube").subscribe();
-        assertThat(subscribe.message().schemaRef(), is("london_hammersmith_transport_public_passenger.avsc"));
-        assertThat(subscribe.message().schemaFormat(), is("application/vnd.apache.avro+json;version=1.9.0"));
+        final Operation subscribe =
+                channelsMap.get("london.hammersmith.transport.public.tube").subscribe();
+        assertThat(
+                subscribe.message().schemaRef(),
+                is("london_hammersmith_transport_public_passenger.avsc"));
+        assertThat(
+                subscribe.message().schemaFormat(),
+                is("application/vnd.apache.avro+json;version=1.9.0"));
         assertThat(subscribe.message().contentType(), is("application/octet-stream"));
         assertThat(subscribe.message().bindings().kafka().schemaIdLocation(), is("header"));
     }
@@ -62,7 +74,10 @@ public class AsyncApiSchemaParserTest {
     private ApiSpec getAPISpecFromResource() {
         try {
             return new AsyncApiParser()
-                    .loadResource(getClass().getClassLoader().getResourceAsStream("simple_schema_demo-api.yaml"));
+                    .loadResource(
+                            getClass()
+                                    .getClassLoader()
+                                    .getResourceAsStream("simple_schema_demo-api.yaml"));
         } catch (Throwable t) {
             throw new RuntimeException("Failed to load test resource", t);
         }


### PR DESCRIPTION
...as `eclipse()` format was reformatting code in javadoc comments and putting TAB characters in them, causing Checkstyle to fail. This was happening even though `indentWithSpaces()` was configured.  Couldn't find a way around this issue.

The issue was it would format:

```java
/**
 * Example.
 * 
 * <pre>{@code
 *     @RegisterExtension
 *     private static final KafkaEnvironment KAFKA_ENV = DockerKafkaEnvironment.builder()
 *             .withContainerStartUpAttempts(4).build();
 * }
 * </pre>
```

To:

```java
 *
 * <pre>
 * {
 * 	&#64;code
 * 	&#64;RegisterExtension
 * 	private static final KafkaEnvironment KAFKA_ENV = DockerKafkaEnvironment.builder()
 * 			.withContainerStartUpAttempts(4).build();
 * }
 * </pre>
```

And, importantly, the whitespace before `.withContainerStartUpAttempts` is TAB characters.

I've used `googleJavaFormat("1.15.0").aosp()` for several years without running into issues.


### Reviewer checklist
- [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
- [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended