### PR TITLE
Bug: `KafkaEnvironment` should extend `org.junit.jupiter.api.extension.Extension`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -161,13 +161,13 @@ subprojects {
     spotbugs {
         tasks.spotbugsMain {
             reports.create("html") {
-                isEnabled = true
+                required.set(true)
                 setStylesheet("fancy-hist.xsl")
             }
         }
         tasks.spotbugsTest {
             reports.create("html") {
-                isEnabled = true
+                required.set(true)
                 setStylesheet("fancy-hist.xsl")
             }
         }

--- a/kafka-test/src/main/java/io/specmesh/kafka/KafkaEnvironment.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/KafkaEnvironment.java
@@ -18,13 +18,14 @@ package io.specmesh.kafka;
 
 
 import org.apache.kafka.clients.admin.Admin;
+import org.junit.jupiter.api.extension.Extension;
 
 /**
  * A Kafka environment.
  *
  * <p>Consisting of a single Kafka cluster, and the associated Schema Registry.
  */
-public interface KafkaEnvironment {
+public interface KafkaEnvironment extends Extension {
 
     /**
      * @return Connection string for connecting to the Kafka cluster.

--- a/kafka-test/src/main/java/io/specmesh/test/TestSpecLoader.java
+++ b/kafka-test/src/main/java/io/specmesh/test/TestSpecLoader.java
@@ -19,7 +19,9 @@ package io.specmesh.test;
 
 import io.specmesh.apiparser.AsyncApiParser;
 import io.specmesh.kafka.KafkaApiSpec;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 
 /** Util class for use in tests to load ApiSpecs. */
 public final class TestSpecLoader {
@@ -44,11 +46,13 @@ public final class TestSpecLoader {
      * @return returns the loaded spec.
      */
     public static KafkaApiSpec loadFromClassPath(final String spec, final ClassLoader classLoader) {
-        try {
-            return new KafkaApiSpec(
-                    new AsyncApiParser().loadResource(classLoader.getResourceAsStream(spec)));
+        try (InputStream s = classLoader.getResourceAsStream(spec)) {
+            if (s == null) {
+                throw new FileNotFoundException("Resource not found: " + spec);
+            }
+            return new KafkaApiSpec(new AsyncApiParser().loadResource(s));
         } catch (IOException e) {
-            throw new RuntimeException("Failed to load api spec", e);
+            throw new RuntimeException("Failed to load api spec: " + spec, e);
         }
     }
 }

--- a/parser/src/test/java/io/specmesh/apiparser/TestSpecLoader.java
+++ b/parser/src/test/java/io/specmesh/apiparser/TestSpecLoader.java
@@ -18,7 +18,9 @@ package io.specmesh.apiparser;
 
 
 import io.specmesh.apiparser.model.ApiSpec;
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.io.InputStream;
 
 /** Util class for use in tests to load ApiSpecs. */
 public final class TestSpecLoader {
@@ -43,10 +45,13 @@ public final class TestSpecLoader {
      * @return returns the loaded spec.
      */
     public static ApiSpec loadFromClassPath(final String spec, final ClassLoader classLoader) {
-        try {
-            return new AsyncApiParser().loadResource(classLoader.getResourceAsStream(spec));
+        try (InputStream s = classLoader.getResourceAsStream(spec)) {
+            if (s == null) {
+                throw new FileNotFoundException("Resource not found: " + spec);
+            }
+            return new AsyncApiParser().loadResource(s);
         } catch (IOException e) {
-            throw new RuntimeException("Failed to load api spec", e);
+            throw new RuntimeException("Failed to load api spec: " + spec, e);
         }
     }
 }


### PR DESCRIPTION
`org.junit.jupiter.api.extension.Extension` is a marker interface for Junit5 extensions. (Everything works without it, but IntelliJ highlights usage as possibly incorrect).

Snuck in a few other unrelated minors.

### Reviewer checklist
- [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
- [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended