### PR TITLE
#84 - adding capability to track production and consumption

### DIFF
--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -36,4 +36,10 @@ dependencies {
     testImplementation("org.testcontainers:testcontainers:$testcontainersVersion")
     testImplementation("org.testcontainers:kafka:$testcontainersVersion")
 
+    compileOnly("org.projectlombok:lombok:$lombokVersion")
+    annotationProcessor("org.projectlombok:lombok:$lombokVersion")
+    testCompileOnly("org.projectlombok:lombok:$lombokVersion")
+    testAnnotationProcessor("org.projectlombok:lombok:$lombokVersion")
+
+
 }

--- a/cli/src/main/java/io/specmesh/cli/ProvisionCommand.java
+++ b/cli/src/main/java/io/specmesh/cli/ProvisionCommand.java
@@ -1,0 +1,156 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.cli;
+
+import static picocli.CommandLine.Command;
+
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import io.specmesh.apiparser.AsyncApiParser;
+import io.specmesh.kafka.KafkaApiSpec;
+import io.specmesh.kafka.provision.Provisioner;
+import io.specmesh.kafka.provision.Status;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import picocli.CommandLine.Option;
+
+/** SpecMesh Kafka Provisioner */
+@Command(
+        name = "provision",
+        description =
+                "Apply the provided specification to provision kafka resources and permissions on"
+                        + " the cluster")
+public class ProvisionCommand implements Callable<Status> {
+
+    @Option(
+            names = {"-bs", "--bootstrap-server"},
+            description = "Kafka bootstrap server url")
+    private String brokerUrl = "";
+
+    @Option(
+            names = {"-sr", "--srUrl"},
+            description = "schemaRegistryUrl")
+    private String schemaRegistryUrl;
+
+    @Option(
+            names = {"-srKey", "--srApiKey"},
+            description = "srApiKey for schema registry")
+    private String srApiKey;
+
+    @Option(
+            names = {"-srSecret", "--srApiSecret"},
+            description = "srApiSecret for schema secret")
+    private String srApiSecret;
+
+    @Option(
+            names = {"-schemaPath", "--schemaPath"},
+            description = "schemaPath where the set of referenced schemas will be loaded")
+    private String schemaPath;
+
+    @Option(
+            names = {"-spec", "--spec"},
+            description = "specmesh specification file")
+    private String spec;
+
+    @Option(
+            names = {"-u", "--username"},
+            description = "username or api key for the cluster connection")
+    private String username;
+
+    @Option(
+            names = {"-p", "--secret"},
+            description = "secret credential for the cluster connection")
+    private String secret;
+
+    @Option(
+            names = {"-d", "--dry-run"},
+            description =
+                    "Compares the cluster against the spec, outputting proposed changes if"
+                        + " compatible.If the spec incompatible with the cluster (not sure how it"
+                        + " could be) then will fail with a descriptive error message.A return"
+                        + " value of 0=indicates no changes needed; 1=changes needed; -1=not"
+                        + " compatible, blah blah")
+    private boolean dryRun;
+
+    @Override
+    public Status call() throws Exception {
+        return Provisioner.provision(
+                dryRun, specMeshSpec(), schemaPath, adminClient(), schemaRegistryClient());
+    }
+
+    private KafkaApiSpec specMeshSpec() {
+        return loadFromClassPath(spec, ProvisionCommand.class.getClassLoader());
+    }
+
+    private Optional<SchemaRegistryClient> schemaRegistryClient() {
+        if (schemaRegistryUrl != null) {
+            final Map<String, Object> properties = new HashMap<>();
+            if (srApiKey != null) {
+                properties.put(
+                        SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
+                properties.put(
+                        SchemaRegistryClientConfig.USER_INFO_CONFIG, srApiKey + ":" + srApiSecret);
+            }
+            return Optional.of(new CachedSchemaRegistryClient(schemaRegistryUrl, 5, properties));
+        } else {
+            return Optional.empty();
+        }
+    }
+
+    /**
+     * AdminClient access
+     *
+     * @return = adminClient
+     */
+    private Admin adminClient() {
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put(AdminClientConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
+        properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerUrl);
+        properties.putAll(Provisioner.clientSaslAuthProperties(username, secret));
+
+        return AdminClient.create(properties);
+    }
+
+    /**
+     * loads the spec from the classpath
+     *
+     * @param spec to load
+     * @param classLoader to use
+     * @return the loaded spec
+     */
+    private static KafkaApiSpec loadFromClassPath(
+            final String spec, final ClassLoader classLoader) {
+        try (InputStream s = classLoader.getResourceAsStream(spec)) {
+            if (s == null) {
+                throw new FileNotFoundException("API Spec resource not found: " + spec);
+            }
+            return new KafkaApiSpec(new AsyncApiParser().loadResource(s));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load API spec: " + spec, e);
+        }
+    }
+}

--- a/cli/src/main/java/io/specmesh/cli/SpecConsumptionCommand.java
+++ b/cli/src/main/java/io/specmesh/cli/SpecConsumptionCommand.java
@@ -18,58 +18,36 @@ package io.specmesh.cli;
 
 import static picocli.CommandLine.Command;
 
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.specmesh.apiparser.AsyncApiParser;
 import io.specmesh.kafka.KafkaApiSpec;
+import io.specmesh.kafka.admin.SmAdminClient;
+import io.specmesh.kafka.admin.SmAdminClient.ConsumerGroup;
 import io.specmesh.kafka.provision.Provisioner;
-import io.specmesh.kafka.provision.Status;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
+import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
 import picocli.CommandLine.Option;
 
-/** SpecMesh Kafka Provisioner */
+/** Spec consumers stats for those groups consuming topic data */
 @Command(
-        name = "provision",
-        description =
-                "Apply the provided specification to provision kafka resources and permissions on"
-                        + " the cluster")
-public class KafkaProvisionCommand implements Callable<Status> {
+        name = "consumption",
+        description = "Given a spec, break down the consumption volume against each of its topic")
+public class SpecConsumptionCommand implements Callable<Map<String, ConsumerGroup>> {
 
     @Option(
             names = {"-bs", "--bootstrap-server"},
             description = "Kafka bootstrap server url")
     private String brokerUrl = "";
-
-    @Option(
-            names = {"-sr", "--schemaRegistryUrl"},
-            description = "schemaRegistryUrl")
-    private String schemaRegistryUrl;
-
-    @Option(
-            names = {"-srKey", "--srApiKey"},
-            description = "srApiKey for schema registry")
-    private String srApiKey;
-
-    @Option(
-            names = {"-srSecret", "--srApiSecret"},
-            description = "srApiSecret for schema secret")
-    private String srApiSecret;
-
-    @Option(
-            names = {"-schemaPath", "--schemaPath"},
-            description = "schemaPath where the set of referenced schemas will be loaded")
-    private String schemaPath;
 
     @Option(
             names = {"-spec", "--spec"},
@@ -86,36 +64,31 @@ public class KafkaProvisionCommand implements Callable<Status> {
             description = "secret credential for the cluster connection")
     private String secret;
 
-    @Option(
-            names = {"-d", "--dry-run"},
-            description =
-                    "Compares the cluster against the spec, outputting proposed changes if"
-                        + " compatible.If the spec incompatible with the cluster (not sure how it"
-                        + " could be) then will fail with a descriptive error message.A return"
-                        + " value of 0=indicates no changes needed; 1=changes needed; -1=not"
-                        + " compatible, blah blah")
-    private boolean dryRun;
-
+    @SuppressWarnings("checkstyle:RegexpSingleline")
     @Override
-    public Status call() throws Exception {
-        return Provisioner.provision(
-                dryRun, specMeshSpec(), schemaPath, adminClient(), schemaRegistryClient());
+    public Map<String, ConsumerGroup> call() throws Exception {
+
+        final var client = SmAdminClient.create(adminClient());
+
+        final var apiSpec = specMeshSpec();
+        final var topics =
+                apiSpec.listDomainOwnedTopics().stream()
+                        .map(NewTopic::name)
+                        .collect(Collectors.toList());
+
+        final var results = new TreeMap<String, ConsumerGroup>();
+
+        topics.forEach(
+                topic -> {
+                    final var groups = client.groupsForTopicPrefix(topic);
+                    groups.forEach(
+                            group -> results.put(topic, group));
+                });
+        return results;
     }
 
     private KafkaApiSpec specMeshSpec() {
-        return loadFromClassPath(spec, KafkaProvisionCommand.class.getClassLoader());
-    }
-
-    private Optional<SchemaRegistryClient> schemaRegistryClient() {
-        if (schemaRegistryUrl != null) {
-            final Map<String, Object> properties = new HashMap<>();
-            properties.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
-            properties.put(
-                    SchemaRegistryClientConfig.USER_INFO_CONFIG, srApiKey + ":" + srApiSecret);
-            return Optional.of(new CachedSchemaRegistryClient(schemaRegistryUrl, 5, properties));
-        } else {
-            return Optional.empty();
-        }
+        return loadFromClassPath(spec, SpecConsumptionCommand.class.getClassLoader());
     }
 
     /**

--- a/cli/src/main/java/io/specmesh/cli/SpecConsumptionCommand.java
+++ b/cli/src/main/java/io/specmesh/cli/SpecConsumptionCommand.java
@@ -81,8 +81,7 @@ public class SpecConsumptionCommand implements Callable<Map<String, ConsumerGrou
         topics.forEach(
                 topic -> {
                     final var groups = client.groupsForTopicPrefix(topic);
-                    groups.forEach(
-                            group -> results.put(topic, group));
+                    groups.forEach(group -> results.put(topic, group));
                 });
         return results;
     }

--- a/cli/src/main/java/io/specmesh/cli/SpecStorageCommand.java
+++ b/cli/src/main/java/io/specmesh/cli/SpecStorageCommand.java
@@ -1,0 +1,129 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.cli;
+
+import static picocli.CommandLine.Command;
+
+import io.specmesh.apiparser.AsyncApiParser;
+import io.specmesh.kafka.KafkaApiSpec;
+import io.specmesh.kafka.admin.SmAdminClient;
+import io.specmesh.kafka.provision.Provisioner;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeMap;
+import java.util.UUID;
+import java.util.concurrent.Callable;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.AdminClient;
+import org.apache.kafka.clients.admin.AdminClientConfig;
+import org.apache.kafka.clients.admin.NewTopic;
+import picocli.CommandLine.Option;
+
+/** App storage requirements (bytes, offsets) for Spec topics */
+@Command(
+        name = "storageVolume",
+        description =
+                "Given a spec, break down the storage volume (including replication) against each"
+                        + " of its topic")
+public class SpecStorageCommand implements Callable<Map<String, Map<String, Long>>> {
+
+    @Option(
+            names = {"-bs", "--bootstrap-server"},
+            description = "Kafka bootstrap server url")
+    private String brokerUrl = "";
+
+    @Option(
+            names = {"-spec", "--spec"},
+            description = "specmesh specification file")
+    private String spec;
+
+    @Option(
+            names = {"-u", "--username"},
+            description = "username or api key for the cluster connection")
+    private String username;
+
+    @Option(
+            names = {"-p", "--secret"},
+            description = "secret credential for the cluster connection")
+    private String secret;
+
+    @Override
+    public Map<String, Map<String, Long>> call() throws Exception {
+
+        final var client = SmAdminClient.create(adminClient());
+
+        final var apiSpec = specMeshSpec();
+        final var topics =
+                apiSpec.listDomainOwnedTopics().stream()
+                        .map(NewTopic::name)
+                        .collect(Collectors.toList());
+
+        final var results = new TreeMap<String, Map<String, Long>>();
+
+        topics.forEach(
+                topic ->
+                        results.put(
+                                topic,
+                                Map.of(
+                                        "storage",
+                                        client.topicVolumeUsingLogDirs(topic),
+                                        "offset-total",
+                                        client.topicVolumeOffsets(topic))));
+        return results;
+    }
+
+    private KafkaApiSpec specMeshSpec() {
+        return loadFromClassPath(spec, SpecStorageCommand.class.getClassLoader());
+    }
+
+    /**
+     * AdminClient access
+     *
+     * @return = adminClient
+     */
+    private Admin adminClient() {
+        final Map<String, Object> properties = new HashMap<>();
+        properties.put(AdminClientConfig.CLIENT_ID_CONFIG, UUID.randomUUID().toString());
+        properties.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, brokerUrl);
+        properties.putAll(Provisioner.clientSaslAuthProperties(username, secret));
+
+        return AdminClient.create(properties);
+    }
+
+    /**
+     * loads the spec from the classpath
+     *
+     * @param spec to load
+     * @param classLoader to use
+     * @return the loaded spec
+     */
+    private static KafkaApiSpec loadFromClassPath(
+            final String spec, final ClassLoader classLoader) {
+        try (InputStream s = classLoader.getResourceAsStream(spec)) {
+            if (s == null) {
+                throw new FileNotFoundException("API Spec resource not found: " + spec);
+            }
+            return new KafkaApiSpec(new AsyncApiParser().loadResource(s));
+        } catch (IOException e) {
+            throw new RuntimeException("Failed to load API spec: " + spec, e);
+        }
+    }
+}

--- a/cli/src/test/java/io/specmesh/cli/ProvisionFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/ProvisionFunctionalTest.java
@@ -30,7 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import picocli.CommandLine;
 
-class CliFunctionalTest {
+class ProvisionFunctionalTest {
 
     private static final String OWNER_USER = "simple.schema_demo";
 
@@ -51,11 +51,11 @@ class CliFunctionalTest {
     @Test
     void shouldProvisionTopicsAndAclResourcesWithoutSchemas() throws Exception {
 
-        final KafkaProvisionCommand kafkaProvisionCommand = new KafkaProvisionCommand();
+        final ProvisionCommand provisionCommand = new ProvisionCommand();
 
         // Given:
         final CommandLine.ParseResult parseResult =
-                new CommandLine(kafkaProvisionCommand)
+                new CommandLine(provisionCommand)
                         .parseArgs(
                                 ("--bootstrap-server "
                                                 + KAFKA_ENV.kafkaBootstrapServers()
@@ -68,7 +68,7 @@ class CliFunctionalTest {
         assertThat(parseResult.matchedArgs().size(), is(4));
 
         // When:
-        final var status = kafkaProvisionCommand.call();
+        final var status = provisionCommand.call();
 
         // then: Verify status is correct
         final var topicProvisionStatus = status.topics();
@@ -81,7 +81,7 @@ class CliFunctionalTest {
                                 "simple.spec_demo._protected.purchased")));
 
         /*
-         * Lose sanity checks follow because we don't need to retest the tests that other tests test
+         * Loose sanity checks follow because we don't need to retest the tests that other tests test
          */
 
         // Then: check topic resources were created

--- a/cli/src/test/java/io/specmesh/cli/StorageConsumptionMetricsFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/StorageConsumptionMetricsFunctionalTest.java
@@ -71,7 +71,7 @@ class StorageConsumptionMetricsFunctionalTest {
             TestSpecLoader.loadFromClassPath("simple_schema_demo-api.yaml");
 
     @Test
-    void shouldPublishConsumerFromSpecAndReportMetrics() throws Exception {
+    void shouldGetStorageAndConsumptionMetrics() throws Exception {
 
         Provisioner.provision(
                 false,

--- a/cli/src/test/java/io/specmesh/cli/StorageConsumptionMetricsFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/StorageConsumptionMetricsFunctionalTest.java
@@ -1,0 +1,237 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.cli;
+
+import static io.specmesh.kafka.Clients.producerProperties;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.specmesh.kafka.Clients;
+import io.specmesh.kafka.DockerKafkaEnvironment;
+import io.specmesh.kafka.KafkaApiSpec;
+import io.specmesh.kafka.KafkaEnvironment;
+import io.specmesh.kafka.admin.SmAdminClient;
+import io.specmesh.kafka.provision.Provisioner;
+import io.specmesh.test.TestSpecLoader;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import picocli.CommandLine;
+import simple.schema_demo._public.user_signed_up_value.UserSignedUp;
+
+class StorageConsumptionMetricsFunctionalTest {
+
+    private static final String OWNER_USER = "simple.schema_demo";
+
+    @RegisterExtension
+    private static final KafkaEnvironment KAFKA_ENV =
+            DockerKafkaEnvironment.builder()
+                    .withSaslAuthentication(
+                            "admin", "admin-secret", OWNER_USER, OWNER_USER + "-secret")
+                    .withKafkaAcls()
+                    .build();
+
+    private static final KafkaApiSpec API_SPEC =
+            TestSpecLoader.loadFromClassPath("simple_schema_demo-api.yaml");
+
+    @Test
+    void shouldPublishConsumerFromSpecAndReportMetrics() throws Exception {
+
+        Provisioner.provision(
+                false,
+                API_SPEC,
+                "./build/resources/test",
+                KAFKA_ENV.adminClient(),
+                Optional.of(srClient()));
+
+        try (Admin adminClient = KAFKA_ENV.adminClient()) {
+            final var client = SmAdminClient.create(adminClient);
+
+            final String userSignedUpTopic = seedTopicData();
+
+            try (Consumer<Long, UserSignedUp> consumer =
+                    avroConsumer(userSignedUpTopic, OWNER_USER, "testGroup")) {
+                final var consumerRecords = consumer.poll(Duration.ofSeconds(10));
+                System.out.println("GOT:" + consumerRecords);
+
+                // VERIFY now check the positional info while the consumer is active
+                final var stats = client.groupsForTopicPrefix("simple");
+                System.out.println(stats);
+                assertThat(stats.get(0).offsetTotal(), is(10000L));
+
+                checkConsumptionStats();
+            }
+
+            final var storageCommand = new SpecStorageCommand();
+            final CommandLine.ParseResult parseResult =
+                    new CommandLine(storageCommand)
+                            .parseArgs(
+                                    ("--bootstrap-server "
+                                                    + KAFKA_ENV.kafkaBootstrapServers()
+                                                    + " --spec simple_schema_demo-api.yaml"
+                                                    + " --username admin"
+                                                    + " --secret admin-secret")
+                                            .split(" "));
+
+            assertThat(parseResult.matchedArgs().size(), is(4));
+            final var storage = storageCommand.call();
+
+            assertThat(storage.size(), is(API_SPEC.listDomainOwnedTopics().size()));
+
+            final var volume =
+                    (Map<String, Long>) storage.get("simple.schema_demo._public.user_signed_up");
+
+            assertThat(volume.get("storage"), is(1120000L));
+            assertThat(volume.get("offset-total"), is(10000L));
+        }
+    }
+
+    private static void checkConsumptionStats() throws Exception {
+        final var consumptionCommand = new SpecConsumptionCommand();
+        // Given:
+        final CommandLine.ParseResult parseResult =
+                new CommandLine(consumptionCommand)
+                        .parseArgs(
+                                ("--bootstrap-server "
+                                                + KAFKA_ENV.kafkaBootstrapServers()
+                                                + " --spec simple_schema_demo-api.yaml"
+                                                + " --username admin"
+                                                + " --secret admin-secret")
+                                        .split(" "));
+
+        assertThat(parseResult.matchedArgs().size(), is(4));
+
+        final var consumptionMap = consumptionCommand.call();
+
+        assertThat(consumptionMap.size(), is(1));
+        assertThat(
+                consumptionMap.keySet(), is(contains("simple.schema_demo._public.user_signed_up")));
+        assertThat(consumptionMap.values().iterator().next().offsetTotal(), is(10000L));
+    }
+
+    private static String seedTopicData()
+            throws InterruptedException, ExecutionException, TimeoutException {
+
+        final var sentRecord = new UserSignedUp("joe blogs", "blogy@twasmail.com", 100);
+        // write seed info
+        final var userSignedUpTopic = "simple.schema_demo._public.user_signed_up";
+        try (var producer = avroProducer(OWNER_USER)) {
+
+            for (int i = 0; i < 10000; i++) {
+                producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L + i, sentRecord))
+                        .get(60, TimeUnit.SECONDS);
+            }
+            producer.flush();
+        }
+        return userSignedUpTopic;
+    }
+
+    private Consumer<Long, UserSignedUp> avroConsumer(
+            final String topicName, final String userName, final String groupName) {
+        return consumer(
+                UserSignedUp.class,
+                topicName,
+                KafkaAvroDeserializer.class,
+                userName,
+                Map.of("group.id", groupName));
+    }
+
+    private static <V> Consumer<Long, V> consumer(
+            final Class<V> valueClass,
+            final String topicName,
+            final Class<?> valueDeserializer,
+            final String userName,
+            final Map<String, Object> additionalProps) {
+
+        final Map<String, Object> props =
+                Clients.consumerProperties(
+                        API_SPEC.id(),
+                        UUID.randomUUID().toString(),
+                        KAFKA_ENV.kafkaBootstrapServers(),
+                        KAFKA_ENV.schemeRegistryServer(),
+                        LongDeserializer.class,
+                        valueDeserializer,
+                        true,
+                        additionalProps);
+
+        props.putAll(Provisioner.clientSaslAuthProperties(userName, userName + "-secret"));
+        props.put(CommonClientConfigs.GROUP_ID_CONFIG, userName);
+
+        final KafkaConsumer<Long, V> consumer = Clients.consumer(Long.class, valueClass, props);
+        consumer.subscribe(List.of(topicName));
+        consumer.poll(Duration.ofSeconds(1));
+        return consumer;
+    }
+
+    private static Producer<Long, UserSignedUp> avroProducer(final String user) {
+        return producer(UserSignedUp.class, KafkaAvroSerializer.class, user, Map.of());
+    }
+
+    private static <V> Producer<Long, V> producer(
+            final Class<V> valueClass,
+            final Class<?> valueSerializer,
+            final String userName,
+            final Map<String, Object> additionalProps) {
+        final Map<String, Object> props =
+                producerProperties(
+                        API_SPEC.id(),
+                        UUID.randomUUID().toString(),
+                        KAFKA_ENV.kafkaBootstrapServers(),
+                        KAFKA_ENV.schemeRegistryServer(),
+                        LongSerializer.class,
+                        valueSerializer,
+                        false,
+                        additionalProps);
+
+        props.putAll(Provisioner.clientSaslAuthProperties(userName, userName + "-secret"));
+
+        return Clients.producer(Long.class, valueClass, props);
+    }
+
+    private static CachedSchemaRegistryClient srClient() {
+        return new CachedSchemaRegistryClient(
+                KAFKA_ENV.schemeRegistryServer(),
+                5,
+                List.of(
+                        new ProtobufSchemaProvider(),
+                        new AvroSchemaProvider(),
+                        new JsonSchemaProvider()),
+                Map.of());
+    }
+}

--- a/cli/src/test/java/simple/schema_demo/_public/user_checkout_value/UserCheckout.java
+++ b/cli/src/test/java/simple/schema_demo/_public/user_checkout_value/UserCheckout.java
@@ -1,0 +1,40 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package simple.schema_demo._public.user_checkout_value;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaInject;
+import com.kjetland.jackson.jsonSchema.annotations.JsonSchemaString;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonSchemaInject(
+        strings = {
+            @JsonSchemaString(
+                    path = "javaType",
+                    value = "simple.schema_demo._public.user_checkout_value.UserCheckout")
+        })
+public class UserCheckout {
+    @JsonProperty long id;
+    @JsonProperty String name;
+    @JsonProperty int price;
+    @JsonProperty String systemDate;
+}

--- a/cli/src/test/java/simple/schema_demo/_public/user_signed_up_value/UserSignedUp.java
+++ b/cli/src/test/java/simple/schema_demo/_public/user_signed_up_value/UserSignedUp.java
@@ -14,21 +14,17 @@
  * limitations under the License.
  */
 
-package io.specmesh.cli;
+package simple.schema_demo._public.user_signed_up_value;
 
-import picocli.CommandLine;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
-/** SpecMesh CLI client */
-public final class Main {
-    private Main() {}
-
-    /**
-     * Main cli
-     *
-     * @param args - set of CLI args for processing
-     */
-    public static void main(final String[] args) {
-
-        new CommandLine(new ProvisionCommand()).execute(args);
-    }
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserSignedUp {
+    String fullName;
+    String email;
+    int age;
 }

--- a/cli/src/test/resources/schema/simple.schema_demo._public.user_info.proto
+++ b/cli/src/test/resources/schema/simple.schema_demo._public.user_info.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package io.specmesh.kafka.schema;
+
+message UserInfo {
+  string fullName = 1;
+  string email = 2;
+  int32 age = 3;
+}

--- a/cli/src/test/resources/simple_schema_demo-api.yaml
+++ b/cli/src/test/resources/simple_schema_demo-api.yaml
@@ -91,33 +91,8 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/simple.schema_demo._public.user_info.proto"
-  # PRODUCER/OWNER build pipe will publish schema to SR
-  _public/user_info_enriched:
-    # publish bindings to instruct topic configuration per environment
-    bindings:
-      kafka:
-        envs:
-          - staging
-          - prod
-        partitions: 3
-        replicas: 1
-        retention: 1
-        configs:
-          cleanup.policy: delete
-
-    publish:
-      summary: User purchase confirmation with address
-      operationId: onUserCheckout
-      message:
-        bindings:
-          kafka:
-            schemaIdLocation: "payload"
-        schemaFormat: "application/json;version=1.9.0"
-        contentType: "application/json"
-        payload:
-          $ref: "/simple.schema_demo._public.user_info_enriched.proto"
-# SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
+          $ref: "/schema/simple.schema_demo._public.user_info.proto"
+  # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   /london/hammersmith/transport/_public/tube:
     subscribe:
       summary: Humans arriving in the borough

--- a/kafka/src/main/java/io/specmesh/kafka/admin/SimpleAdminClient.java
+++ b/kafka/src/main/java/io/specmesh/kafka/admin/SimpleAdminClient.java
@@ -1,0 +1,267 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.kafka.admin;
+
+import java.util.Collection;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import java.util.stream.Collectors;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.ConsumerGroupDescription;
+import org.apache.kafka.clients.admin.ConsumerGroupListing;
+import org.apache.kafka.clients.admin.MemberDescription;
+import org.apache.kafka.clients.admin.OffsetSpec;
+import org.apache.kafka.common.ConsumerGroupState;
+import org.apache.kafka.common.Node;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.TopicPartitionInfo;
+
+/**
+ * Simple client used to query storage and consumption values
+ */
+public class SimpleAdminClient implements SmAdminClient {
+
+    public static final long TIMEOUT = 300L;
+    private final Admin adminClient;
+
+    SimpleAdminClient(final Admin adminClient) {
+        this.adminClient = adminClient;
+    }
+
+
+    /**
+     * Get the groups for a topic prefix and their partition offsets
+     * @param topicPrefix to match against
+     * @return the list of groups
+     */
+    @Override
+    public List<ConsumerGroup> groupsForTopicPrefix(final String topicPrefix) {
+        try {
+            final var consumerGroups =
+                    adminClient.listConsumerGroups().all().get(TIMEOUT, TimeUnit.SECONDS);
+            final var groupDescriptions = groupsFor(topicPrefix, consumerGroups);
+
+            return groupDescriptions.stream()
+                    .map(
+                            groupDescription -> {
+                                final var groupBuilder = ConsumerGroup.builder();
+                                groupBuilder.id(groupDescription.groupId());
+                                groupBuilder.members(
+                                        groupDescription.members().stream()
+                                                .map(
+                                                        member ->
+                                                                Member.builder()
+                                                                        .id(member.consumerId())
+                                                                        .partitions(
+                                                                                partitions(member))
+                                                                        .host(member.host())
+                                                                        .clientId(member.clientId())
+                                                                        .build())
+                                                .collect(Collectors.toList()));
+                                final var group = groupBuilder.build();
+                                group.calculateTotalOffset();
+                                return group;
+                            })
+                    .collect(Collectors.toList());
+
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new ClientException("Failed to list consumer-groups for:" + topicPrefix, e);
+        }
+    }
+
+    /**
+     * Set of groups for a prefix
+     * @param topicPrefix to match against
+     * @param consumerGroups to filter from
+     * @return matched descriptions
+     */
+    private List<ConsumerGroupDescription> groupsFor(
+            final String topicPrefix, final Collection<ConsumerGroupListing> consumerGroups) {
+        return consumerGroups.stream()
+                .filter(
+                        listing ->
+                                !listing.isSimpleConsumerGroup()
+                                        && listing.state().isPresent()
+                                        && listing.state().get().equals(ConsumerGroupState.STABLE))
+                .map(
+                        group -> {
+                            try {
+                                return adminClient
+                                        .describeConsumerGroups(List.of(group.groupId()))
+                                        .all()
+                                        .get()
+                                        .values()
+                                        .iterator()
+                                        .next();
+                            } catch (InterruptedException | ExecutionException e) {
+                                throw new RuntimeException(e);
+                            }
+                        })
+                .filter(
+                        description ->
+                                !description.members().isEmpty()
+                                        && isConsumingFromTopicPrefix(description, topicPrefix))
+                .collect(Collectors.toList());
+    }
+
+    /**
+     * Build partition info for this member
+     *
+     * @param member to collect info for
+     * @return set of partition data
+     */
+    private List<Partition> partitions(final MemberDescription member) {
+        try {
+            final var partitions =
+                    adminClient
+                            .listOffsets(
+                                    member.assignment().topicPartitions().stream()
+                                            .collect(
+                                                    Collectors.toMap(
+                                                            tp -> tp, tp -> OffsetSpec.latest())))
+                            .all()
+                            .get(TIMEOUT, TimeUnit.SECONDS);
+            return partitions.entrySet().stream()
+                    .map(
+                            entry ->
+                                    Partition.builder()
+                                            .id(entry.getKey().partition())
+                                            .topic(entry.getKey().topic())
+                                            .offset(entry.getValue().offset())
+                                            .timestamp(entry.getValue().timestamp())
+                                            .build())
+                    .collect(Collectors.toList());
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new ClientException("Failed to list partitions for:" + member, e);
+        }
+    }
+
+    /**
+     * Check if a cgroup is consuming from a topic prefix
+     * @param groupDescription - group desc
+     * @param prefix to match againt
+     * @return true when it is
+     */
+    private boolean isConsumingFromTopicPrefix(
+            final ConsumerGroupDescription groupDescription, final String prefix) {
+        return groupDescription
+                .members()
+                .iterator()
+                .next()
+                .assignment()
+                .topicPartitions()
+                .iterator()
+                .next()
+                .topic()
+                .startsWith(prefix);
+    }
+
+    /**
+     * Retrieve topic volume in bytes
+     *
+     * @param topic to query
+     * @return total volume (including replica)
+     */
+    @Override
+    public long topicVolumeUsingLogDirs(final String topic) {
+        try {
+            final var brokers = brokerIds();
+            final var logDirsResult = adminClient.describeLogDirs(brokers);
+            final var logDirsByBroker =
+                    logDirsResult.allDescriptions().get(TIMEOUT, TimeUnit.SECONDS);
+
+            long totalSize = 0;
+
+            for (final var logDirs : logDirsByBroker.values()) {
+                for (final var logDirInfo : logDirs.values()) {
+                    for (final var replicaInfoEntry : logDirInfo.replicaInfos().entrySet()) {
+                        final var tp = replicaInfoEntry.getKey();
+                        if (topic.equals(tp.topic())) {
+                            totalSize += replicaInfoEntry.getValue().size();
+                        }
+                    }
+                }
+            }
+
+            return totalSize;
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new ClientException("Failed to get topicVolumeUsingLogDirs:" + topic, e);
+        }
+    }
+
+    /**
+     * List all brokerIds
+     * @return the set of brokerIds
+     */
+    @Override
+    public List<Integer> brokerIds() {
+        try {
+            return adminClient.describeCluster().nodes().get().stream()
+                    .mapToInt(Node::id)
+                    .boxed()
+                    .collect(Collectors.toList());
+        } catch (InterruptedException | ExecutionException e) {
+            throw new ClientException("Failed to describe cluster to get brokerIds", e);
+        }
+    }
+
+    /**
+     * Get topic offset total
+     *
+     * @param topic to query
+     * @return total offset count
+     */
+    @Override
+    public long topicVolumeOffsets(final String topic) {
+
+        try {
+            final var describeTopicsResult =
+                    adminClient.describeTopics(Collections.singleton(topic));
+            final var topicDescription =
+                    describeTopicsResult.allTopicNames().get(TIMEOUT, TimeUnit.SECONDS).get(topic);
+
+            // Get the start and end offsets for each partition
+            final Map<TopicPartition, OffsetSpec> endOffsetsQuery = new HashMap<>();
+            final Map<TopicPartition, OffsetSpec> startOffsetsQuery = new HashMap<>();
+            for (TopicPartitionInfo partitionInfo : topicDescription.partitions()) {
+                final var partition = new TopicPartition(topic, partitionInfo.partition());
+                endOffsetsQuery.put(partition, OffsetSpec.latest());
+                startOffsetsQuery.put(partition, OffsetSpec.earliest());
+            }
+
+            final var endOffsetsResult = adminClient.listOffsets(endOffsetsQuery);
+            final var startOffsetsResult = adminClient.listOffsets(startOffsetsQuery);
+
+            long totalVolume = 0;
+            for (TopicPartition partition : endOffsetsQuery.keySet()) {
+                final long endOffset = endOffsetsResult.partitionResult(partition).get().offset();
+                final long startOffset =
+                        startOffsetsResult.partitionResult(partition).get().offset();
+                totalVolume += endOffset - startOffset;
+            }
+
+            return totalVolume;
+        } catch (InterruptedException | ExecutionException | TimeoutException e) {
+            throw new ClientException("Failed to get topicVolumeOffsets for topic:" + topic, e);
+        }
+    }
+}

--- a/kafka/src/main/java/io/specmesh/kafka/admin/SimpleAdminClient.java
+++ b/kafka/src/main/java/io/specmesh/kafka/admin/SimpleAdminClient.java
@@ -35,9 +35,7 @@ import org.apache.kafka.common.Node;
 import org.apache.kafka.common.TopicPartition;
 import org.apache.kafka.common.TopicPartitionInfo;
 
-/**
- * Simple client used to query storage and consumption values
- */
+/** Simple client used to query storage and consumption values */
 public class SimpleAdminClient implements SmAdminClient {
 
     public static final long TIMEOUT = 300L;
@@ -47,9 +45,9 @@ public class SimpleAdminClient implements SmAdminClient {
         this.adminClient = adminClient;
     }
 
-
     /**
      * Get the groups for a topic prefix and their partition offsets
+     *
      * @param topicPrefix to match against
      * @return the list of groups
      */
@@ -90,6 +88,7 @@ public class SimpleAdminClient implements SmAdminClient {
 
     /**
      * Set of groups for a prefix
+     *
      * @param topicPrefix to match against
      * @param consumerGroups to filter from
      * @return matched descriptions
@@ -157,6 +156,7 @@ public class SimpleAdminClient implements SmAdminClient {
 
     /**
      * Check if a cgroup is consuming from a topic prefix
+     *
      * @param groupDescription - group desc
      * @param prefix to match againt
      * @return true when it is
@@ -210,6 +210,7 @@ public class SimpleAdminClient implements SmAdminClient {
 
     /**
      * List all brokerIds
+     *
      * @return the set of brokerIds
      */
     @Override

--- a/kafka/src/main/java/io/specmesh/kafka/admin/SmAdminClient.java
+++ b/kafka/src/main/java/io/specmesh/kafka/admin/SmAdminClient.java
@@ -1,0 +1,124 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.kafka.admin;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.EqualsAndHashCode;
+import lombok.NoArgsConstructor;
+import lombok.experimental.Accessors;
+import org.apache.kafka.clients.admin.Admin;
+
+import java.util.Collection;
+import java.util.List;
+
+/**
+ * SpecMesh simple admin client api
+ */
+public interface SmAdminClient {
+    /**
+     * Returns the set of consumer groups (and stats) for a topicPrefix)
+     * @param topicPrefix to query against
+     * @return matched groups
+     */
+    List<ConsumerGroup> groupsForTopicPrefix(String topicPrefix);
+
+    /**
+     * Report the volume of data in bytes for a topic
+     * @param topic to query against
+     * @return topic bytes
+     */
+    long topicVolumeUsingLogDirs(String topic);
+
+    /**
+     * Get the set of broker ids
+     * @return broker Ids list
+     */
+    List<Integer> brokerIds();
+
+    /**
+     * Get topic offset total
+     * @param topic to query against
+     * @return total offset count (number of records)
+     */
+    long topicVolumeOffsets(String topic);
+
+    static SmAdminClient create(final Admin client) {
+        return new SimpleAdminClient(client);
+    }
+
+    /**
+     * Report client level exceptions
+     */
+    class ClientException extends RuntimeException {
+
+        ClientException(final String msg, final Throwable cause) {
+            super(msg, cause);
+        }
+    }
+
+    @Builder
+    @Data
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Accessors(fluent = true)
+    @SuppressFBWarnings
+    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+    class ConsumerGroup {
+        @EqualsAndHashCode.Include private String id;
+        private List<Member> members;
+        private long offsetTotal;
+
+        public void calculateTotalOffset() {
+            members.forEach(
+                            member ->
+                                    member.partitions.forEach(
+                                            partition -> offsetTotal += partition.offset()));
+        }
+    }
+
+    @Builder
+    @Data
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Accessors(fluent = true)
+    @SuppressFBWarnings
+    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+    class Member {
+        @EqualsAndHashCode.Include private String id;
+        private String clientId;
+        private String host;
+        private Collection<Partition> partitions;
+    }
+
+    @Builder
+    @Data
+    @AllArgsConstructor(access = AccessLevel.PRIVATE)
+    @NoArgsConstructor(access = AccessLevel.PRIVATE)
+    @Accessors(fluent = true)
+    @SuppressFBWarnings
+    @EqualsAndHashCode(onlyExplicitlyIncluded = true)
+    class Partition {
+        @EqualsAndHashCode.Include private int id;
+        private String topic;
+        private long offset;
+        private long timestamp;
+    }
+}

--- a/kafka/src/main/java/io/specmesh/kafka/admin/SmAdminClient.java
+++ b/kafka/src/main/java/io/specmesh/kafka/admin/SmAdminClient.java
@@ -17,6 +17,8 @@
 package io.specmesh.kafka.admin;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.Collection;
+import java.util.List;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -26,15 +28,11 @@ import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 import org.apache.kafka.clients.admin.Admin;
 
-import java.util.Collection;
-import java.util.List;
-
-/**
- * SpecMesh simple admin client api
- */
+/** SpecMesh simple admin client api */
 public interface SmAdminClient {
     /**
      * Returns the set of consumer groups (and stats) for a topicPrefix)
+     *
      * @param topicPrefix to query against
      * @return matched groups
      */
@@ -42,6 +40,7 @@ public interface SmAdminClient {
 
     /**
      * Report the volume of data in bytes for a topic
+     *
      * @param topic to query against
      * @return topic bytes
      */
@@ -49,12 +48,14 @@ public interface SmAdminClient {
 
     /**
      * Get the set of broker ids
+     *
      * @return broker Ids list
      */
     List<Integer> brokerIds();
 
     /**
      * Get topic offset total
+     *
      * @param topic to query against
      * @return total offset count (number of records)
      */
@@ -64,9 +65,7 @@ public interface SmAdminClient {
         return new SimpleAdminClient(client);
     }
 
-    /**
-     * Report client level exceptions
-     */
+    /** Report client level exceptions */
     class ClientException extends RuntimeException {
 
         ClientException(final String msg, final Throwable cause) {
@@ -88,9 +87,9 @@ public interface SmAdminClient {
 
         public void calculateTotalOffset() {
             members.forEach(
-                            member ->
-                                    member.partitions.forEach(
-                                            partition -> offsetTotal += partition.offset()));
+                    member ->
+                            member.partitions.forEach(
+                                    partition -> offsetTotal += partition.offset()));
         }
     }
 

--- a/kafka/src/main/java/io/specmesh/kafka/provision/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/SchemaProvisioner.java
@@ -149,7 +149,7 @@ public final class SchemaProvisioner {
             schemaContent = Files.readString(schemaPath, StandardCharsets.UTF_8);
         } catch (IOException e) {
             throw new Provisioner.ProvisioningException(
-                    "Failed to read schema from: " + schemaPath, e);
+                    "Failed to readSchemaContent from:" + schemaPath, e);
         }
         return schemaContent;
     }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/SchemaWriters.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/SchemaWriters.java
@@ -96,7 +96,11 @@ public final class SchemaWriters {
                                     final var schemaId =
                                             client.register(schema.subject(), schema.getSchema());
                                     schema.state(UPDATED);
-                                    schema.messages("Updated with id: " + schemaId);
+                                    schema.messages(
+                                            "Subject:"
+                                                    + schema.subject()
+                                                    + " Updated with id: "
+                                                    + schemaId);
                                 } catch (IOException | RestClientException e) {
                                     schema.exception(
                                             new Provisioner.ProvisioningException(
@@ -141,7 +145,9 @@ public final class SchemaWriters {
                                             client.register(schema.subject(), schema.getSchema());
                                     client.updateCompatibility(schema.subject(), DEFAULT_EVOLUTION);
                                     schema.messages(
-                                            "Created with id: "
+                                            "Subject:"
+                                                    + schema.subject()
+                                                    + "Created with id: "
                                                     + schemaId
                                                     + ", evolution set to:"
                                                     + DEFAULT_EVOLUTION);

--- a/kafka/src/test/java/io/specmesh/kafka/admin/SimpleAdminClientTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/admin/SimpleAdminClientTest.java
@@ -1,0 +1,196 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.kafka.admin;
+
+import static io.specmesh.kafka.Clients.producerProperties;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import io.confluent.kafka.serializers.KafkaAvroDeserializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.specmesh.kafka.Clients;
+import io.specmesh.kafka.DockerKafkaEnvironment;
+import io.specmesh.kafka.KafkaApiSpec;
+import io.specmesh.kafka.KafkaEnvironment;
+import io.specmesh.kafka.provision.Provisioner;
+import io.specmesh.test.TestSpecLoader;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.kafka.clients.CommonClientConfigs;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.KafkaConsumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.clients.producer.ProducerRecord;
+import org.apache.kafka.common.serialization.LongDeserializer;
+import org.apache.kafka.common.serialization.LongSerializer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+import simple.schema_demo._public.user_signed_up_value.UserSignedUp;
+
+class SimpleAdminClientTest {
+
+    private static final String OWNER_USER = "simple.schema_demo";
+
+    @RegisterExtension
+    private static final KafkaEnvironment KAFKA_ENV =
+            DockerKafkaEnvironment.builder()
+                    .withSaslAuthentication(
+                            "admin", "admin-secret", OWNER_USER, OWNER_USER + "-secret")
+                    .withKafkaAcls(List.of())
+                    .build();
+
+    private static final KafkaApiSpec API_SPEC =
+            TestSpecLoader.loadFromClassPath("clientapi-functional-test-api.yaml");
+
+    @Test
+    @Order(1)
+    void shouldRecordStats() throws ExecutionException, InterruptedException, TimeoutException {
+
+        final var userSignedUpTopic = topicName("_public.user_signed_up");
+        final var sentRecord = new UserSignedUp("joe blogs", "blogy@twasmail.com", 100);
+
+        try (Admin adminClient = KAFKA_ENV.adminClient()) {
+            final var client = SmAdminClient.create(adminClient);
+            Provisioner.provision(
+                    false,
+                    API_SPEC,
+                    "./build/resources/test",
+                    adminClient,
+                    Optional.of(srClient()));
+
+            // write seed info
+            try (var producer = avroProducer(OWNER_USER)) {
+
+                for (int i = 0; i < 10000; i++) {
+                    producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L + i, sentRecord))
+                            .get(60, TimeUnit.SECONDS);
+                }
+                producer.flush();
+            }
+
+            try (Consumer<Long, UserSignedUp> consumer =
+                    avroConsumer(userSignedUpTopic, OWNER_USER, "testGroup")) {
+                final var consumerRecords = consumer.poll(Duration.ofSeconds(10));
+                System.out.println("GOT:" + consumerRecords);
+
+                // VERIFY now check the positional info while the consumer is active
+                final var stats = client.groupsForTopicPrefix("simple");
+                System.out.println(stats);
+                assertThat(stats.get(0).offsetTotal(), is(10000L));
+            }
+
+            final var bytesUsingLogDirs = client.topicVolumeUsingLogDirs(userSignedUpTopic);
+            assertThat(bytesUsingLogDirs, is(1120000L));
+            final var offsets = client.topicVolumeOffsets(userSignedUpTopic);
+
+            assertThat(offsets, is(10000L));
+        }
+    }
+
+    private Consumer<Long, UserSignedUp> avroConsumer(
+            final String topicName, final String userName, final String groupName) {
+        return consumer(
+                UserSignedUp.class,
+                topicName,
+                KafkaAvroDeserializer.class,
+                userName,
+                Map.of("group.id", groupName));
+    }
+
+    private static <V> Consumer<Long, V> consumer(
+            final Class<V> valueClass,
+            final String topicName,
+            final Class<?> valueDeserializer,
+            final String userName,
+            final Map<String, Object> additionalProps) {
+
+        final Map<String, Object> props =
+                Clients.consumerProperties(
+                        API_SPEC.id(),
+                        UUID.randomUUID().toString(),
+                        KAFKA_ENV.kafkaBootstrapServers(),
+                        KAFKA_ENV.schemeRegistryServer(),
+                        LongDeserializer.class,
+                        valueDeserializer,
+                        true,
+                        additionalProps);
+
+        props.putAll(Provisioner.clientSaslAuthProperties(userName, userName + "-secret"));
+        props.put(CommonClientConfigs.GROUP_ID_CONFIG, userName);
+
+        final KafkaConsumer<Long, V> consumer = Clients.consumer(Long.class, valueClass, props);
+        consumer.subscribe(List.of(topicName));
+        consumer.poll(Duration.ofSeconds(1));
+        return consumer;
+    }
+
+    private static Producer<Long, UserSignedUp> avroProducer(final String user) {
+        return producer(UserSignedUp.class, KafkaAvroSerializer.class, user, Map.of());
+    }
+
+    private static String topicName(final String topicSuffix) {
+        return API_SPEC.listDomainOwnedTopics().stream()
+                .filter(topic -> topic.name().endsWith(topicSuffix))
+                .findFirst()
+                .orElseThrow(() -> new AssertionError("Topic " + topicSuffix + " not found"))
+                .name();
+    }
+
+    private static <V> Producer<Long, V> producer(
+            final Class<V> valueClass,
+            final Class<?> valueSerializer,
+            final String userName,
+            final Map<String, Object> additionalProps) {
+        final Map<String, Object> props =
+                producerProperties(
+                        API_SPEC.id(),
+                        UUID.randomUUID().toString(),
+                        KAFKA_ENV.kafkaBootstrapServers(),
+                        KAFKA_ENV.schemeRegistryServer(),
+                        LongSerializer.class,
+                        valueSerializer,
+                        false,
+                        additionalProps);
+
+        props.putAll(Provisioner.clientSaslAuthProperties(userName, userName + "-secret"));
+
+        return Clients.producer(Long.class, valueClass, props);
+    }
+
+    private static CachedSchemaRegistryClient srClient() {
+        return new CachedSchemaRegistryClient(
+                KAFKA_ENV.schemeRegistryServer(),
+                5,
+                List.of(
+                        new ProtobufSchemaProvider(),
+                        new AvroSchemaProvider(),
+                        new JsonSchemaProvider()),
+                Map.of());
+    }
+}

--- a/kafka/src/test/resources/clientapi-functional-test-api.yaml
+++ b/kafka/src/test/resources/clientapi-functional-test-api.yaml
@@ -1,0 +1,69 @@
+asyncapi: '2.4.0'
+id: 'urn:simple:schema_demo'
+info:
+  title: Streetlights API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you
+    to remotely manage the city lights.
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+servers:
+  mosquitto:
+    url: mqtt://test.mosquitto.org
+    protocol: mqtt
+channels:
+  # PRODUCER/OWNER build pipe will publish schema to SR
+  _public/user_signed_up:
+    # publish bindings to instruct topic configuration per environment
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 10
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+          retention.ms: 3600000
+
+
+    publish:
+      summary: Inform about signup
+      operationId: onUserSignedUp
+      message:
+        bindings:
+          kafka:
+            schemaIdLocation: "payload"
+        schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
+        contentType: "application/octet-stream"
+        payload:
+          $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
+
+  _protected/user_info:
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 3
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+          retention.ms: 9900000
+
+    publish:
+      tags: [
+        name: "grant-access:.some.other.domain.acme-A"
+      ]
+      summary: User info confirmation
+      operationId: onUserCheckout
+      message:
+        bindings:
+          kafka:
+            schemaIdLocation: "payload"
+        schemaFormat: "application/json;version=1.9.0"
+        contentType: "application/json"
+        payload:
+          $ref: "/schema/simple.schema_demo._public.user_info.proto"

--- a/kafka/src/test/resources/schema/simple.schema_demo._public.user_info.proto
+++ b/kafka/src/test/resources/schema/simple.schema_demo._public.user_info.proto
@@ -1,0 +1,9 @@
+syntax = "proto3";
+
+package io.specmesh.kafka.schema;
+
+message UserInfo {
+  string fullName = 1;
+  string email = 2;
+  int32 age = 3;
+}


### PR DESCRIPTION
#84  - Introduce storage and consumption metrics on a per-spec basis. 

- break down consumption by group-id, including member-info and offset as well as total
- break down production to broker-storage bytes and total offset
the outputs can be used to build a chargeback model against