### PR TITLE
#165 - consolidate spec notations to use '.' everywhere

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Guides:
 
 ```yaml
 asyncapi: '2.5.0'
-id: 'urn:acme:lifestyle:onboarding'
+id: 'urn:acme.lifestyle.onboarding'
 info:
   title: ACME Lifestyle Onboarding
   version: '1.0.0'
@@ -32,7 +32,7 @@ info:
     The ACME lifestyle onboarding app that allows stuff - see this url for more detail.. etc
 
 channels:
-  _public/user_signed_up:
+  _public.user_signed_up:
     bindings:
       kafka:
         partitions: 3
@@ -46,18 +46,18 @@ channels:
         payload:
           $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
 
-  _private/user_checkout:
+  _private.user_checkout:
     publish:
       message:
         payload:
           $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
 
 
-  _protected/purchased:
+  _protected.purchased:
     publish:
       summary: Humans purchasing food - note - restricting access to other domain principals
       tags: [
-        name: "grant-access:.acme.finance.accounting"
+        name: "grant-access:acme.finance.accounting"
       ]
       message:
         name: Food Item

--- a/cli/README.md
+++ b/cli/README.md
@@ -125,7 +125,7 @@ This demonstrates `provision`ing a *spec* into a docker environment, with a netw
   } ],
   "schemas" : null,
   "acls" : [ {
-    "name" : "(pattern=ResourcePattern(resourceType=TOPIC, name=simple.spec_demo._protected.purchased, patternType=LITERAL), entry=(principal=User:.some.other.domain.root, host=*, operation=READ, permissionType=ALLOW))",
+    "name" : "(pattern=ResourcePattern(resourceType=TOPIC, name=simple.spec_demo._protected.purchased, patternType=LITERAL), entry=(principal=User:some.other.domain.root, host=*, operation=READ, permissionType=ALLOW))",
     "state" : "CREATED",
     "aclBinding" : {
       "pattern" : {
@@ -136,7 +136,7 @@ This demonstrates `provision`ing a *spec* into a docker environment, with a netw
       },
       "entry" : {
         "data" : {
-          "principal" : "User:.some.other.domain.root",
+          "principal" : "User:some.other.domain.root",
           "host" : "*",
           "operation" : "READ",
           "permissionType" : "ALLOW",
@@ -269,7 +269,7 @@ This demonstrates `provision`ing a *spec* into a docker environment, with a netw
     "exception" : null,
     "messages" : ""
   }, {
-    "name" : "(pattern=ResourcePattern(resourceType=TOPIC, name=simple.spec_demo._protected.purchased, patternType=LITERAL), entry=(principal=User:.some.other.domain.root, host=*, operation=DESCRIBE, permissionType=ALLOW))",
+    "name" : "(pattern=ResourcePattern(resourceType=TOPIC, name=simple.spec_demo._protected.purchased, patternType=LITERAL), entry=(principal=User:some.other.domain.root, host=*, operation=DESCRIBE, permissionType=ALLOW))",
     "state" : "CREATED",
     "aclBinding" : {
       "pattern" : {
@@ -280,7 +280,7 @@ This demonstrates `provision`ing a *spec* into a docker environment, with a netw
       },
       "entry" : {
         "data" : {
-          "principal" : "User:.some.other.domain.root",
+          "principal" : "User:some.other.domain.root",
           "host" : "*",
           "operation" : "DESCRIBE",
           "permissionType" : "ALLOW",
@@ -509,7 +509,7 @@ Build an incomplete spec from a running Cluster
 
 ```json
 {
-  "id": "urn:simple:spec_demo",
+  "id": "urn:simple.spec_demo",
   "version": "2023-05-06",
   "asyncapi": "2.5.0",
   "channels": {

--- a/cli/resources/simple_schema_demo-api.yaml
+++ b/cli/resources/simple_schema_demo-api.yaml
@@ -92,7 +92,7 @@ channels:
         payload:
           $ref: "/schema/simple.schema_demo._public.user_info.proto"
   # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
-  .london.hammersmith.transport._public/tube:
+  london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
       bindings:

--- a/cli/resources/simple_spec_demo-api.yaml
+++ b/cli/resources/simple_spec_demo-api.yaml
@@ -71,7 +71,7 @@ channels:
     publish:
       summary: Humans purchasing food - note - restricting access to other domain principal
       tags: [
-        name: "grant-access:.some.other.domain.root"
+        name: "grant-access:some.other.domain.root"
       ]
       message:
         name: Food Item
@@ -96,7 +96,7 @@ channels:
               description: Id of the human purchasing the food
 
   # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
-  .london.hammersmith.transport._public.tube:
+  london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
       bindings:

--- a/cli/src/test/resources/simple_spec_demo-api.yaml
+++ b/cli/src/test/resources/simple_spec_demo-api.yaml
@@ -71,7 +71,7 @@ channels:
       operationId: onUserPurchased
       summary: Humans purchasing food - note - restricting access to other domain principals
       tags: [
-        name: "grant-access:.some.other.domain.root"
+        name: "grant-access:some.other.domain.root"
       ]
       message:
         name: Food Item

--- a/kafka-test/src/test/resources/simple_schema_demo-api.yaml
+++ b/kafka-test/src/test/resources/simple_schema_demo-api.yaml
@@ -115,7 +115,7 @@ channels:
         payload:
           $ref: "/simple.schema_demo._public.user_info_enriched.proto"
 # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
-  .london.hammersmith.transport._public.tube:
+  london.hammersmith.transport._public.tube:
     subscribe:
       operationId: onTubeArrival
       summary: Humans arriving in the borough

--- a/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
+++ b/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
@@ -16,6 +16,10 @@
 
 package io.specmesh.kafka;
 
+import static io.specmesh.apiparser.model.ApiSpec.DELIMITER;
+import static io.specmesh.apiparser.model.ApiSpec.PRIVATE;
+import static io.specmesh.apiparser.model.ApiSpec.PROTECTED;
+import static io.specmesh.apiparser.model.ApiSpec.PUBLIC;
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.common.acl.AclOperation.CREATE;
 import static org.apache.kafka.common.acl.AclOperation.DESCRIBE;
@@ -53,13 +57,6 @@ import org.apache.kafka.common.resource.ResourceType;
 public class KafkaApiSpec {
 
     private static final String GRANT_ACCESS_TAG = "grant-access:";
-    public static final String DELIMITER = ".";
-    public static final String SPECMESH_PUBLIC = "specmesh.public";
-    public static final String PUBLIC = System.getProperty(SPECMESH_PUBLIC, "_public");
-    public static final String SPECMESH_PROTECTED = "specmesh.protected";
-    public static final String PROTECTED = System.getProperty(SPECMESH_PROTECTED, "_protected");
-    public static final String SPECMESH_PRIVATE = "specmesh.private";
-    public static final String PRIVATE = System.getProperty(SPECMESH_PRIVATE, "_private");
 
     private final ApiSpec apiSpec;
 

--- a/kafka/src/test/java/io/specmesh/kafka/CustomAclKafkaAPISpecTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/CustomAclKafkaAPISpecTest.java
@@ -19,6 +19,7 @@ package io.specmesh.kafka;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasItems;
 
+import io.specmesh.apiparser.model.ApiSpec;
 import io.specmesh.test.TestSpecLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -33,9 +34,9 @@ public class CustomAclKafkaAPISpecTest {
     @BeforeEach
     public void setUp() {
         // store original property value
-        System.setProperty(KafkaApiSpec.SPECMESH_PROTECTED, "zzprotected");
-        System.setProperty(KafkaApiSpec.SPECMESH_PUBLIC, "zzpublic");
-        System.setProperty(KafkaApiSpec.SPECMESH_PRIVATE, "zzprivate");
+        System.setProperty(ApiSpec.SPECMESH_PROTECTED, "zzprotected");
+        System.setProperty(ApiSpec.SPECMESH_PUBLIC, "zzpublic");
+        System.setProperty(ApiSpec.SPECMESH_PRIVATE, "zzprivate");
         kafkaApiSpec = TestSpecLoader.loadFromClassPath("customacl-bigdatalondon-api.yaml");
     }
 
@@ -53,13 +54,13 @@ public class CustomAclKafkaAPISpecTest {
         READ_PROTECTED_TOPICS(
                 "(pattern=ResourcePattern(resourceType=TOPIC,"
                     + " name=london.hammersmith.olympia.bigdatalondon.zzprotected.retail.subway.food.purchase,"
-                    + " patternType=LITERAL), entry=(principal=User:.some.other.domain.root,"
-                    + " host=*, operation=READ, permissionType=ALLOW))"),
+                    + " patternType=LITERAL), entry=(principal=User:some.other.domain.root, host=*,"
+                    + " operation=READ, permissionType=ALLOW))"),
         DESCRIBE_PROTECTED_TOPICS(
                 "(pattern=ResourcePattern(resourceType=TOPIC,"
                     + " name=london.hammersmith.olympia.bigdatalondon.zzprotected.retail.subway.food.purchase,"
-                    + " patternType=LITERAL), entry=(principal=User:.some.other.domain.root,"
-                    + " host=*, operation=DESCRIBE, permissionType=ALLOW))"),
+                    + " patternType=LITERAL), entry=(principal=User:some.other.domain.root, host=*,"
+                    + " operation=DESCRIBE, permissionType=ALLOW))"),
 
         CREATE_OWN_PRIVATE_TOPICS(
                 "(pattern=ResourcePattern(resourceType=TOPIC,"

--- a/kafka/src/test/java/io/specmesh/kafka/ExporterFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ExporterFunctionalTest.java
@@ -63,9 +63,9 @@ class ExporterFunctionalTest {
         /** The domain associated with the spec. */
         SELF(API_SPEC.id()),
         /** An unrelated domain. */
-        UNRELATED(".london.hammersmith.transport"),
+        UNRELATED("london.hammersmith.transport"),
         /** A domain granted access to the protected topic. */
-        LIMITED(".some.other.domain.root");
+        LIMITED("some.other.domain.root");
 
         final String domainId;
 

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
@@ -95,9 +95,9 @@ class KafkaAPISpecFunctionalTest {
         /** The domain associated with the spec. */
         SELF(API_SPEC.id()),
         /** An unrelated domain. */
-        UNRELATED(".london.hammersmith.transport"),
+        UNRELATED("london.hammersmith.transport"),
         /** A domain granted access to the protected topic. */
-        LIMITED(".some.other.domain.root");
+        LIMITED("some.other.domain.root");
 
         final String domainId;
 

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
@@ -51,13 +51,13 @@ public class KafkaAPISpecTest {
         READ_PROTECTED_TOPICS(
                 "(pattern=ResourcePattern(resourceType=TOPIC,"
                     + " name=london.hammersmith.olympia.bigdatalondon._protected.retail.subway.food.purchase,"
-                    + " patternType=LITERAL), entry=(principal=User:.some.other.domain.root,"
-                    + " host=*, operation=READ, permissionType=ALLOW))"),
+                    + " patternType=LITERAL), entry=(principal=User:some.other.domain.root, host=*,"
+                    + " operation=READ, permissionType=ALLOW))"),
         DESCRIBE_PROTECTED_TOPICS(
                 "(pattern=ResourcePattern(resourceType=TOPIC,"
                     + " name=london.hammersmith.olympia.bigdatalondon._protected.retail.subway.food.purchase,"
-                    + " patternType=LITERAL), entry=(principal=User:.some.other.domain.root,"
-                    + " host=*, operation=DESCRIBE, permissionType=ALLOW))"),
+                    + " patternType=LITERAL), entry=(principal=User:some.other.domain.root, host=*,"
+                    + " operation=DESCRIBE, permissionType=ALLOW))"),
         DESCRIBE_OWN_TOPICS(
                 "(pattern=ResourcePattern(resourceType=TOPIC,"
                         + " name=london.hammersmith.olympia.bigdatalondon,"

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
@@ -83,9 +83,9 @@ class ProvisionerFreshStartFunctionalTest {
         /** The domain associated with the spec. */
         SELF(API_SPEC.id()),
         /** An unrelated domain. */
-        UNRELATED(".london.hammersmith.transport"),
+        UNRELATED("london.hammersmith.transport"),
         /** A domain granted access to the protected topic. */
-        LIMITED(".some.other.domain.root");
+        LIMITED("some.other.domain.root");
 
         final String domainId;
 

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
@@ -82,9 +82,9 @@ class ProvisionerUpdatingFunctionalTest {
         /** The domain associated with the spec. */
         SELF(API_SPEC.id()),
         /** An unrelated domain. */
-        UNRELATED(".london.hammersmith.transport"),
+        UNRELATED("london.hammersmith.transport"),
         /** A domain granted access to the protected topic. */
-        LIMITED(".some.other.domain.root");
+        LIMITED("some.other.domain.root");
 
         final String domainId;
 

--- a/kafka/src/test/resources/apispec-functional-test-app.yaml
+++ b/kafka/src/test/resources/apispec-functional-test-app.yaml
@@ -64,7 +64,7 @@ channels:
     publish:
       summary: Humans purchasing food
       tags: [
-        name: "grant-access:.some.other.domain.root"
+        name: "grant-access:some.other.domain.root"
       ]
       message:
         name: Food Item
@@ -118,7 +118,7 @@ channels:
               description: Id of the human purchasing the food
 
 
-  .london.hammersmith.transport._public.tube:
+  london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
       message:

--- a/kafka/src/test/resources/bigdatalondon-api.yaml
+++ b/kafka/src/test/resources/bigdatalondon-api.yaml
@@ -64,7 +64,7 @@ channels:
     publish:
       summary: Humans purchasing food
       tags: [
-        name: "grant-access:.some.other.domain.root"
+        name: "grant-access:some.other.domain.root"
       ]
       message:
         name: Food Item
@@ -118,7 +118,7 @@ channels:
               description: Id of the human purchasing the food
 
 
-  .london.hammersmith.transport._public.tube:
+  london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
       message:

--- a/kafka/src/test/resources/clientapi-functional-test-api.yaml
+++ b/kafka/src/test/resources/clientapi-functional-test-api.yaml
@@ -55,7 +55,7 @@ channels:
 
     publish:
       tags: [
-        name: "grant-access:.some.other.domain.acme-A"
+        name: "grant-access:some.other.domain.acme-A"
       ]
       summary: User info confirmation
       operationId: onUserCheckout

--- a/kafka/src/test/resources/customacl-bigdatalondon-api.yaml
+++ b/kafka/src/test/resources/customacl-bigdatalondon-api.yaml
@@ -64,7 +64,7 @@ channels:
     publish:
       summary: Humans purchasing food
       tags: [
-        name: "grant-access:.some.other.domain.root"
+        name: "grant-access:some.other.domain.root"
       ]
       message:
         name: Food Item
@@ -118,7 +118,7 @@ channels:
               description: Id of the human purchasing the food
 
 
-  .london.hammersmith.transport._public.tube:
+  london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
       message:

--- a/kafka/src/test/resources/provisioner-functional-test-api.yaml
+++ b/kafka/src/test/resources/provisioner-functional-test-api.yaml
@@ -55,7 +55,7 @@ channels:
 
     publish:
       tags: [
-        name: "grant-access:.some.other.domain.acme-A"
+        name: "grant-access:some.other.domain.acme-A"
       ]
       summary: User info confirmation
       operationId: onUserCheckout

--- a/kafka/src/test/resources/provisioner-update-functional-test-api.yaml
+++ b/kafka/src/test/resources/provisioner-update-functional-test-api.yaml
@@ -53,8 +53,8 @@ channels:
 
     publish:
       tags: [
-        name: "grant-access:.some.other.domain.acme-A",
-        name: "grant-access:.some.other.domain.acme-B"
+        name: "grant-access:some.other.domain.acme-A",
+        name: "grant-access:some.other.domain.acme-B"
       ]
       summary: User info confirmation
       operationId: onUserCheckout

--- a/parser/src/main/java/io/specmesh/apiparser/model/ApiSpec.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/ApiSpec.java
@@ -39,7 +39,16 @@ import lombok.experimental.Accessors;
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @SuppressFBWarnings
 public class ApiSpec {
-    private static final char DELIMITER = System.getProperty("DELIMITER", ".").charAt(0);
+    public static final char DELIMITER = System.getProperty("DELIMITER", ".").charAt(0);
+    public static final String SPECMESH_PUBLIC = "specmesh.public";
+
+    public static final String PUBLIC = System.getProperty(SPECMESH_PUBLIC, "_public");
+
+    public static final String SPECMESH_PROTECTED = "specmesh.protected";
+    public static final String PROTECTED = System.getProperty(SPECMESH_PROTECTED, "_protected");
+    public static final String SPECMESH_PRIVATE = "specmesh.private";
+    public static final String PRIVATE = System.getProperty(SPECMESH_PRIVATE, "_private");
+
     @JsonProperty private String id;
 
     @JsonProperty private String version;
@@ -78,8 +87,13 @@ public class ApiSpec {
     private String getCanonical(final String id, final String channelName) {
         if (channelName.startsWith("/")) {
             return channelName.substring(1).replace('/', DELIMITER);
-        } else if (channelName.startsWith(".")) {
+        } else if (!(channelName.startsWith(PRIVATE)
+                || channelName.startsWith(PROTECTED)
+                || channelName.startsWith(PUBLIC))) {
             return channelName;
+        } else if (channelName.startsWith(id)) {
+            return channelName;
+
         } else {
             return id + DELIMITER + channelName.replace('/', DELIMITER);
         }

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
@@ -50,7 +50,7 @@ public class AsyncApiParserTest {
         assertThat(
                 "Should use absolute path",
                 channelsMap.keySet(),
-                hasItem(".london.hammersmith.transport._public.tube"));
+                hasItem("london.hammersmith.transport._public.tube"));
     }
 
     @Test
@@ -70,7 +70,7 @@ public class AsyncApiParserTest {
         assertThat(
                 "Should use absolute path",
                 channelsMap.keySet(),
-                hasItem(".london.hammersmith.transport._public.tube"));
+                hasItem("london.hammersmith.transport._public.tube"));
     }
 
     @Test

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
@@ -59,10 +59,10 @@ public class AsyncApiSchemaParserTest {
         assertThat(
                 "Should have assembled 'id + channelname'",
                 channelsMap.keySet(),
-                hasItem(".london.hammersmith.transport._public.tube"));
+                hasItem("london.hammersmith.transport._public.tube"));
 
         final Operation subscribe =
-                channelsMap.get(".london.hammersmith.transport._public.tube").subscribe();
+                channelsMap.get("london.hammersmith.transport._public.tube").subscribe();
         assertThat(
                 subscribe.message().schemaRef(),
                 is("london_hammersmith_transport_public_passenger.avsc"));

--- a/parser/src/test/resources/simple_schema_demo-api.yaml
+++ b/parser/src/test/resources/simple_schema_demo-api.yaml
@@ -40,7 +40,7 @@ channels:
           $ref: "simple_schema_demo_user-signedup.avsc"
 
 # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
-  .london.hammersmith.transport._public.tube:
+  london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
       bindings:

--- a/parser/src/test/resources/streetlights-simple-api.yaml
+++ b/parser/src/test/resources/streetlights-simple-api.yaml
@@ -35,7 +35,7 @@ channels:
               type: string
               format: date-time
               description: Date and time when the message was sent.
-  .london.hammersmith.transport.public.tube:
+  london.hammersmith.transport.public.tube:
     subscribe:
       summary: Humans arriving in the borough
       message:

--- a/parser/src/test/resources/test-streetlights-simple-api.yaml
+++ b/parser/src/test/resources/test-streetlights-simple-api.yaml
@@ -51,7 +51,7 @@ channels:
               type: string
               format: date-time
               description: Date and time when the message was sent.
-  .london.hammersmith.transport._public.tube:
+  london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
       bindings:


### PR DESCRIPTION
final updates - correcting use of non-domain owners and fixing docs