### PR TITLE
#186 - support ACL perms via tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,9 +105,33 @@ channels:
 {"simple.spec_demo._public.user_signed_up":{"id":"some.other.app","members":[{"id":"console-consumer-7f9d23c7-a627-41cd-ade9-3919164bc363","clientId":"console-consumer","host":"/172.30.0.3","partitions":[{"id":0,"topic":"simple.spec_demo._public.user_signed_up","offset":57,"timestamp":-1}]}],"offsetTotal":57}}
 ```
 
+## ACLs / Permissions
 
+Notice how `_private`, `_public` or `_protected` is prefixed to the channel. This keyword can be altered in the following ways:
+- it can be changed by passing the System.property as follows: `-Dspecmesh.public=everyone' -Dspecmesh.protected=some -Dspecmesh.private=mine`
+- instead of 'inlining' the permission on the channel name, for example `_public.myTopic` - the permission can be controlled via channel.operation.tags see below for an example.
 
-
+```yaml
+channels:
+  #  protected
+  retail.subway.food.purchase:
+    bindings:
+      kafka:
+    publish:
+      tags: [
+        name: "grant-access:some.other.domain.root"
+      ]
+```
+```yaml
+channels:
+  #  public
+  attendee:
+    bindings:
+    publish:
+      tags: [
+        name: "grant-access:_public"
+      ]
+```
 # Developer Notes
 
 1. Install the intellij checkstyle plugin and load the config from config/checkstyle.xml

--- a/kafka/src/main/java/io/specmesh/kafka/Exporter.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Exporter.java
@@ -20,6 +20,7 @@ import io.specmesh.apiparser.model.ApiSpec;
 import io.specmesh.apiparser.model.Bindings;
 import io.specmesh.apiparser.model.Channel;
 import io.specmesh.apiparser.model.KafkaBinding;
+import io.specmesh.apiparser.model.Operation;
 import io.specmesh.kafka.provision.TopicProvisioner.Topic;
 import io.specmesh.kafka.provision.TopicReaders;
 import io.specmesh.kafka.provision.TopicReaders.TopicsReaderBuilder;
@@ -85,6 +86,7 @@ public final class Exporter {
     private static Channel channel(final Topic topic) {
         return Channel.builder()
                 .bindings(Bindings.builder().kafka(kafkaBindings(topic)).build())
+                .publish(Operation.builder().build())
                 .build();
     }
 

--- a/kafka/src/test/resources/bigdatalondon-api-with-grant-access-acls.yaml
+++ b/kafka/src/test/resources/bigdatalondon-api-with-grant-access-acls.yaml
@@ -1,0 +1,143 @@
+asyncapi: '2.5.0'
+id: 'urn:london.hammersmith.olympia.bigdatalondon'
+
+info:
+  title: BigDataLondon API
+  version: '1.0.0'
+  description: |
+    Simple model of BigDataLondon as a Data Product
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+
+servers:
+  test:
+    url: test.mykafkacluster.org:8092
+    protocol: kafka-secure
+    description: Test broker
+
+channels:
+  #  public
+  attendee:
+    # publish bindings to instruct topic configuration per environment
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 10
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+    publish:
+      summary: Humans arriving
+      operationId: onHumansArriving
+      tags: [
+        name: "grant-access:_public"
+      ]
+      message:
+        name: Human
+        tags:
+          - name: "human"
+            description: "eats food"
+          - name: "big data london"
+            description: "eats food"
+        bindings:
+          kafka:
+            key:
+              type: string
+              enum: [ 'myKey' ]
+            schemaIdLocation: 'header'
+            bindingVersion: '0.3.0'
+        payload:
+          type: object
+          properties:
+            id:
+              type: integer
+              minimum: 0
+              description: Id of the human
+            age:
+              type: integer
+              minimum: 0
+              description: Age of the human
+  #  protected
+  retail.subway.food.purchase:
+    bindings:
+      kafka:
+        partitions: 3
+
+    publish:
+      summary: Humans purchasing food
+      tags: [
+        name: "grant-access:some.other.domain.root"
+      ]
+      message:
+        name: Food Item
+        tags: [
+          name: "human",
+          name: "purchase"
+        ]
+        payload:
+          type: object
+          properties:
+            id:
+              type: integer
+              minimum: 0
+              description: Id of the food
+            cost:
+              type: number
+              minimum: 0
+              description: GBP cost of the food item
+            human_id:
+              type: integer
+              minimum: 0
+              description: Id of the human purchasing the food
+
+  # private
+  retail.subway.customers:
+    bindings:
+      kafka:
+        partitions: 3
+
+    publish:
+      summary: Humans customers
+      message:
+        name: Food Item
+        tags: [
+          name: "human",
+          name: "customer"
+        ]
+        payload:
+          type: object
+          properties:
+            id:
+              type: integer
+              minimum: 0
+              description: Id of the food
+            cost:
+              type: number
+              minimum: 0
+              description: GBP cost of the food item
+            human_id:
+              type: integer
+              minimum: 0
+              description: Id of the human purchasing the food
+
+
+  # subscribing to another domains channel
+  paris.hammersmith.transport._public.tube:
+    subscribe:
+      summary: Humans arriving in the borough
+      message:
+        name: Human
+        payload:
+          type: object
+          properties:
+            id:
+              type: integer
+              minimum: 0
+              description: Id of the human
+            age:
+              type: integer
+              minimum: 0
+              description: Age of the human

--- a/parser/src/main/java/io/specmesh/apiparser/model/ApiSpec.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/ApiSpec.java
@@ -72,30 +72,31 @@ public class ApiSpec {
     }
 
     /**
-     * @return channels
+     * @return channels with names formatted using canonical path
      */
     public Map<String, Channel> channels() {
         return channels.entrySet().stream()
                 .collect(
                         Collectors.toMap(
-                                e -> getCanonical(id(), e.getKey()),
+                                e -> getCanonical(id(), e.getKey(), e.getValue().publish() != null),
                                 Map.Entry::getValue,
                                 (k, v) -> k,
                                 LinkedHashMap::new));
     }
 
-    private String getCanonical(final String id, final String channelName) {
+    private String getCanonical(final String id, final String channelName, final boolean publish) {
+        // legacy and deprecated
         if (channelName.startsWith("/")) {
             return channelName.substring(1).replace('/', DELIMITER);
-        } else if (!(channelName.startsWith(PRIVATE)
-                || channelName.startsWith(PROTECTED)
-                || channelName.startsWith(PUBLIC))) {
+        }
+        // should not occur unless subdomains are being used
+        if (channelName.startsWith(id)) {
             return channelName;
-        } else if (channelName.startsWith(id)) {
-            return channelName;
-
-        } else {
+        }
+        if (publish) {
             return id + DELIMITER + channelName.replace('/', DELIMITER);
+        } else {
+            return channelName;
         }
     }
 

--- a/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
@@ -89,6 +89,8 @@ public class Operation {
     }
 
     public boolean isSchemaRequired() {
-        return this.message().schemaRef() != null && this.message().schemaRef().length() > 0;
+        return this.message() != null
+                && this.message().schemaRef() != null
+                && this.message().schemaRef().length() > 0;
     }
 }


### PR DESCRIPTION
#186  - this is required when supporting acl controls that dont occur on the path. For example .some.domain._public.events can then be expressed as
.some.domain.events
and the _public grant is configured in the spec->channels->channel->public[tags -> grant-access: _public]