### PR TITLE
enhancement - #58 topic cleanup non-spec topic - part 1

### DIFF
--- a/cli/src/main/java/io/specmesh/cli/Provision.java
+++ b/cli/src/main/java/io/specmesh/cli/Provision.java
@@ -90,12 +90,21 @@ public class Provision implements Callable<Integer> {
     @Option(
             names = {"-dry", "--dry-run"},
             description =
-                    "Compares the cluster against the spec, outputting proposed changes if"
-                        + " compatible.If the spec incompatible with the cluster (not sure how it"
-                        + " could be) then will fail with a descriptive error message.A return"
-                        + " value of 0=indicates no changes needed; 1=changes needed; -1=not"
-                        + " compatible, blah blah")
+                    "Compares the cluster resources against the spec, outputting proposed changes"
+                        + " if compatible. If the spec incompatible with the cluster (not sure how"
+                        + " it could be) then will fail with a descriptive error message. A return"
+                        + " value of '0' = indicates no changes needed; '1' = changes needed; '-1'"
+                        + " not compatible")
     private boolean dryRun;
+
+    @Option(
+            names = {"-clean", "--clean-unspecified"},
+            description =
+                    "Compares the cluster resources against the spec, outputting proposed set of"
+                        + " resources that are unexpected (not specified). Use with '-dry-run' for"
+                        + " non-destructive checks. This operation will not create resources, it"
+                        + " will only remove unspecified resources")
+    private boolean cleanUnspecified;
 
     @Option(
             names = "-D",
@@ -113,6 +122,7 @@ public class Provision implements Callable<Integer> {
         final var status =
                 Provisioner.provision(
                         dryRun,
+                        cleanUnspecified,
                         specMeshSpec(),
                         schemaPath,
                         Clients.adminClient(brokerUrl, username, secret),

--- a/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
@@ -76,6 +76,7 @@ class StorageConsumptionFunctionalTest {
 
         Provisioner.provision(
                 false,
+                false,
                 API_SPEC,
                 "./build/resources/test",
                 KAFKA_ENV.adminClient(),

--- a/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
@@ -108,6 +108,7 @@ class ClientsFunctionalDemoTest {
                     new CachedSchemaRegistryClient(KAFKA_ENV.schemeRegistryServer(), 5);
             Provisioner.provision(
                     false,
+                    false,
                     API_SPEC,
                     "./build/resources/test",
                     adminClient,

--- a/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
@@ -32,6 +32,7 @@ public final class Provisioner {
      * Provision Topics, ACLS and schemas
      *
      * @param dryRun test or execute
+     * @param cleanUnspecified cleanup
      * @param apiSpec given spec
      * @param schemaResources schema path
      * @param adminClient kafka admin client
@@ -41,6 +42,7 @@ public final class Provisioner {
      */
     public static Status provision(
             final boolean dryRun,
+            final boolean cleanUnspecified,
             final KafkaApiSpec apiSpec,
             final String schemaResources,
             final Admin adminClient,
@@ -49,7 +51,10 @@ public final class Provisioner {
         apiSpec.apiSpec().validate();
 
         final var status =
-                Status.builder().topics(TopicProvisioner.provision(dryRun, apiSpec, adminClient));
+                Status.builder()
+                        .topics(
+                                TopicProvisioner.provision(
+                                        dryRun, cleanUnspecified, apiSpec, adminClient));
         schemaRegistryClient.ifPresent(
                 registryClient ->
                         status.schemas(

--- a/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
@@ -59,7 +59,11 @@ public final class Provisioner {
                 registryClient ->
                         status.schemas(
                                 SchemaProvisioner.provision(
-                                        dryRun, apiSpec, schemaResources, registryClient)));
+                                        dryRun,
+                                        cleanUnspecified,
+                                        apiSpec,
+                                        schemaResources,
+                                        registryClient)));
         status.acls(AclProvisioner.provision(dryRun, apiSpec, adminClient));
         return status.build();
     }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/SchemaChangeSetCalculators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/SchemaChangeSetCalculators.java
@@ -67,6 +67,24 @@ public final class SchemaChangeSetCalculators {
         }
     }
 
+    /** Return set of 'unspecific' (i.e. non-required) schemas */
+    public static class CleanUnspecifiedCalculator implements ChangeSetCalculator {
+
+        /**
+         * remove the required items from the existing.. the remainder are not specified
+         *
+         * @param existing - existing
+         * @param required - needed
+         * @return schemas that aren't specd
+         */
+        @Override
+        public Collection<Schema> calculate(
+                final Collection<Schema> existing, final Collection<Schema> required) {
+            existing.removeAll(required);
+            return existing;
+        }
+    }
+
     /** Returns those schemas to create and ignores existing */
     public static final class UpdateCalculator implements ChangeSetCalculator {
 
@@ -190,11 +208,18 @@ public final class SchemaChangeSetCalculators {
         /**
          * build it
          *
+         * @param cleanUnspecified - cleanup
          * @param client sr client
          * @return required calculator
          */
-        public ChangeSetCalculator build(final SchemaRegistryClient client) {
-            return new Collective(new UpdateCalculator(client), new CreateCalculator());
+        public ChangeSetCalculator build(
+                final boolean cleanUnspecified, final SchemaRegistryClient client) {
+            if (cleanUnspecified) {
+                return new CleanUnspecifiedCalculator();
+
+            } else {
+                return new Collective(new UpdateCalculator(client), new CreateCalculator());
+            }
         }
     }
 }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/SchemaProvisioner.java
@@ -16,8 +16,8 @@
 
 package io.specmesh.kafka.provision;
 
+import static io.specmesh.kafka.provision.Status.STATE.CREATE;
 import static io.specmesh.kafka.provision.Status.STATE.FAILED;
-import static io.specmesh.kafka.provision.Status.STATE.READ;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
@@ -52,6 +52,7 @@ public final class SchemaProvisioner {
      * Provision schemas to Schema Registry
      *
      * @param dryRun for mode of operation
+     * @param cleanUnspecified for cleanup operations
      * @param apiSpec the api spec
      * @param baseResourcePath the path under which external schemas are stored.
      * @param client the client for the schema registry
@@ -59,6 +60,7 @@ public final class SchemaProvisioner {
      */
     public static Collection<Schema> provision(
             final boolean dryRun,
+            final boolean cleanUnspecified,
             final KafkaApiSpec apiSpec,
             final String baseResourcePath,
             final SchemaRegistryClient client) {
@@ -74,21 +76,26 @@ public final class SchemaProvisioner {
                     "Required Schemas Failed to load:" + required);
         }
 
-        return writer(dryRun, client).write(calculator(client).calculate(existing, required));
+        return mutator(dryRun, cleanUnspecified, client)
+                .mutate(calculator(client, cleanUnspecified).calculate(existing, required));
     }
 
     /**
      * schema writer
      *
      * @param dryRun real or noops writer
+     * @param cleanUnspecified - clean unexpected resource
      * @param schemaRegistryClient - sr connection
      * @return writer instance
      */
-    private static SchemaWriters.SchemaWriter writer(
-            final boolean dryRun, final SchemaRegistryClient schemaRegistryClient) {
-        return SchemaWriters.builder()
+    private static SchemaMutators.SchemaMutator mutator(
+            final boolean dryRun,
+            final boolean cleanUnspecified,
+            final SchemaRegistryClient schemaRegistryClient) {
+        return SchemaMutators.builder()
                 .schemaRegistryClient(schemaRegistryClient)
                 .noop(dryRun)
+                .cleanUnspecified(cleanUnspecified)
                 .build();
     }
 
@@ -98,8 +105,8 @@ public final class SchemaProvisioner {
      * @return calculator
      */
     private static SchemaChangeSetCalculators.ChangeSetCalculator calculator(
-            final SchemaRegistryClient client) {
-        return SchemaChangeSetCalculators.builder().build(client);
+            final SchemaRegistryClient client, final boolean cleanUnspecified) {
+        return SchemaChangeSetCalculators.builder().build(cleanUnspecified, client);
     }
 
     /**
@@ -130,7 +137,7 @@ public final class SchemaProvisioner {
                                 schema.type(schemaInfo.schemaRef())
                                         .subject(schemaSubject)
                                         .payload(readSchemaContent(schemaPath));
-                                schema.state(READ);
+                                schema.state(CREATE);
 
                             } catch (Provisioner.ProvisioningException ex) {
                                 schema.state(FAILED);

--- a/kafka/src/main/java/io/specmesh/kafka/provision/SchemaReaders.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/SchemaReaders.java
@@ -104,33 +104,33 @@ public final class SchemaReaders {
      *
      * @return builder
      */
-    public static AclReaderBuilder builder() {
-        return AclReaderBuilder.builder();
+    public static SchemaReaderBuilder builder() {
+        return SchemaReaderBuilder.builder();
     }
 
     /** builder */
     @SuppressFBWarnings(
             value = "EI_EXPOSE_REP2",
             justification = "adminClient() passed as param to prevent API pollution")
-    public static final class AclReaderBuilder {
+    public static final class SchemaReaderBuilder {
 
-        private SchemaRegistryClient schemaRegistryClient;
+        private SchemaRegistryClient srClient;
 
         /** defensive */
-        private AclReaderBuilder() {}
+        private SchemaReaderBuilder() {}
 
         /**
          * main builder
          *
          * @return builder
          */
-        public static AclReaderBuilder builder() {
-            return new AclReaderBuilder();
+        public static SchemaReaderBuilder builder() {
+            return new SchemaReaderBuilder();
         }
 
-        public AclReaderBuilder schemaRegistryClient(
+        public SchemaReaderBuilder schemaRegistryClient(
                 final SchemaRegistryClient schemaRegistryClient) {
-            this.schemaRegistryClient = schemaRegistryClient;
+            this.srClient = schemaRegistryClient;
             return this;
         }
 
@@ -140,7 +140,7 @@ public final class SchemaReaders {
          * @return the specified reader impl
          */
         public SchemaReader build() {
-            return new SimpleSchemaReader(schemaRegistryClient);
+            return new SimpleSchemaReader(srClient);
         }
     }
 }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicChangeSetCalculators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicChangeSetCalculators.java
@@ -150,6 +150,22 @@ public class TopicChangeSetCalculators {
                     .collect(Collectors.toList());
         }
     }
+    /** Returns those topics to create and ignores existing topics */
+    public static final class UnspecifiedCalculator implements ChangeSetCalculator {
+
+        /**
+         * Calculate changes of topics that are unspecified
+         *
+         * @param existingTopics - existing
+         * @param requiredTopics - set of topics that should exist
+         * @return list of new topics with 'CREATE' flag
+         */
+        public Collection<Topic> calculate(
+                final Collection<Topic> existingTopics, final Collection<Topic> requiredTopics) {
+            existingTopics.removeAll(requiredTopics);
+            return existingTopics;
+        }
+    }
     /** Main API */
     interface ChangeSetCalculator {
         /**
@@ -182,10 +198,15 @@ public class TopicChangeSetCalculators {
         /**
          * build it
          *
+         * @param cleanUnspecified - to remove unspecified resources
          * @return required calculator
          */
-        public ChangeSetCalculator build() {
-            return new CollectiveCalculator(new CreateCalculator(), new UpdateCalculator());
+        public ChangeSetCalculator build(final boolean cleanUnspecified) {
+            if (cleanUnspecified) {
+                return new UnspecifiedCalculator();
+            } else {
+                return new CollectiveCalculator(new CreateCalculator(), new UpdateCalculator());
+            }
         }
     }
 }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicMutators.java
@@ -42,19 +42,19 @@ import org.apache.kafka.clients.admin.TopicDescription;
 import org.apache.kafka.common.config.ConfigResource;
 
 /** Write topics using provided input set */
-public class TopicWriters {
+public class TopicMutators {
 
-    /** Collection based */
-    public static final class CollectiveWriter implements TopicWriter {
+    /** collection based */
+    public static final class CollectiveMutator implements TopicMutator {
 
-        private final Stream<TopicWriter> writers;
+        private final Stream<TopicMutator> writers;
 
         /**
          * iterate over the writers
          *
          * @param writers to iterate
          */
-        private CollectiveWriter(final TopicWriter... writers) {
+        private CollectiveMutator(final TopicMutator... writers) {
             this.writers = Arrays.stream(writers);
         }
 
@@ -65,16 +65,16 @@ public class TopicWriters {
          * @return updated status
          */
         @Override
-        public Collection<Topic> write(final Collection<Topic> topics) {
+        public Collection<Topic> mutate(final Collection<Topic> topics) {
             return this.writers
-                    .map(writer -> writer.write(topics))
+                    .map(writer -> writer.mutate(topics))
                     .flatMap(Collection::stream)
                     .collect(Collectors.toList());
         }
     }
 
-    /** only handles update requests */
-    public static final class UpdateWriter implements TopicWriter {
+    /** updates */
+    public static final class UpdateMutator implements TopicMutator {
 
         private final Admin adminClient;
 
@@ -83,7 +83,7 @@ public class TopicWriters {
          *
          * @param adminClient - cluster connection
          */
-        UpdateWriter(final Admin adminClient) {
+        UpdateMutator(final Admin adminClient) {
             this.adminClient = adminClient;
         }
 
@@ -94,7 +94,7 @@ public class TopicWriters {
          * @return topics with updated flag
          * @throws ProvisioningException when things break
          */
-        public Collection<Topic> write(final Collection<Topic> topics)
+        public Collection<Topic> mutate(final Collection<Topic> topics)
                 throws ProvisioningException {
 
             final var topicsToUpdate =
@@ -200,8 +200,68 @@ public class TopicWriters {
         }
     }
 
-    /** creates the topic */
-    public static final class CreateWriter implements TopicWriter {
+    /** delete non-spec resources */
+    public static final class CleanUnspecifiedMutator implements TopicMutator {
+
+        private final boolean dryRun;
+        private final Admin adminClient;
+
+        /**
+         * Needs the admin client
+         *
+         * @param dryRun - test or execute flag
+         * @param adminClient - cluster connection
+         */
+        CleanUnspecifiedMutator(final boolean dryRun, final Admin adminClient) {
+            this.dryRun = dryRun;
+            this.adminClient = adminClient;
+        }
+
+        /**
+         * Remove topics that are not CREATE or UPSDATE (i.e. not in the spec)
+         *
+         * @param topics to write
+         * @return topics with updated flag
+         * @throws ProvisioningException when things break
+         */
+        public Collection<Topic> mutate(final Collection<Topic> topics)
+                throws ProvisioningException {
+
+            // spec topics will have CREATE or UPDATE status - remove the others (unwanted)
+            final var unwanted =
+                    topics.stream()
+                            .filter(
+                                    topic ->
+                                            !topic.state().equals(STATE.CREATE)
+                                                    && !topic.state().equals(STATE.UPDATE))
+                            .collect(Collectors.toList());
+
+            try {
+                if (!dryRun) {
+                    adminClient
+                            .deleteTopics(toTopicNames(unwanted))
+                            .all()
+                            .get(Provisioner.REQUEST_TIMEOUT, TimeUnit.SECONDS);
+                }
+            } catch (InterruptedException | ExecutionException | TimeoutException ex) {
+                throw new ProvisioningException("Failed to cleanup unwanted topics", ex);
+            }
+            return unwanted;
+        }
+
+        /**
+         * convert to names
+         *
+         * @param topicsToUpdate source list
+         * @return just the names
+         */
+        private List<String> toTopicNames(final List<Topic> topicsToUpdate) {
+            return topicsToUpdate.stream().map(Topic::name).collect(Collectors.toList());
+        }
+    }
+
+    /** creations */
+    public static final class CreateMutator implements TopicMutator {
 
         private final Admin adminClient;
 
@@ -210,7 +270,7 @@ public class TopicWriters {
          *
          * @param adminClient - cluster connection
          */
-        private CreateWriter(final Admin adminClient) {
+        private CreateMutator(final Admin adminClient) {
             this.adminClient = adminClient;
         }
 
@@ -221,7 +281,7 @@ public class TopicWriters {
          * @return topics with updated flag
          * @throws ProvisioningException when things break
          */
-        public Collection<Topic> write(final Collection<Topic> topics)
+        public Collection<Topic> mutate(final Collection<Topic> topics)
                 throws ProvisioningException {
 
             final var topicsToCreate =
@@ -266,8 +326,8 @@ public class TopicWriters {
         }
     }
 
-    /** Noop write that does nada */
-    public static final class NoopWriter implements TopicWriter {
+    /** Noopper that does nada */
+    public static final class NoopMutator implements TopicMutator {
         /**
          * Do nothing write
          *
@@ -275,33 +335,35 @@ public class TopicWriters {
          * @return unmodified list
          * @throws ProvisioningException when things go wrong
          */
-        public Collection<Topic> write(final Collection<Topic> topics)
+        public Collection<Topic> mutate(final Collection<Topic> topics)
                 throws ProvisioningException {
             return topics;
         }
     }
 
-    /** Interface for writing topics to kafka */
-    interface TopicWriter {
+    /** Interface for writing/mutating topics to kafka */
+    interface TopicMutator {
         /**
          * Api for writing
          *
-         * @param topics to write
+         * @param topics to do stuff against
          * @return updated state of topics written
          */
-        Collection<Topic> write(Collection<Topic> topics);
+        Collection<Topic> mutate(Collection<Topic> topics);
     }
 
-    /** TopicWriter builder */
+    /** TopicMutator builder */
     @SuppressFBWarnings(
             value = "EI_EXPOSE_REP2",
             justification = "adminClient() passed as param to prevent API pollution")
-    public static final class TopicWriterBuilder {
+    public static final class TopicMutatorBuilder {
         private Admin adminClient;
-        private boolean noopWriter;
+        private boolean noop;
+        private boolean cleanUnspecified;
+        private boolean dryRun;
 
         /** defensive */
-        private TopicWriterBuilder() {}
+        private TopicMutatorBuilder() {}
 
         /**
          * add the adminClient
@@ -309,19 +371,32 @@ public class TopicWriters {
          * @param adminClient - cluster connection
          * @return builder
          */
-        public TopicWriterBuilder adminClient(final Admin adminClient) {
+        public TopicMutatorBuilder adminClient(final Admin adminClient) {
             this.adminClient = adminClient;
             return this;
         }
 
         /**
-         * use a noop writer
+         * use a noop mutator
          *
          * @param dryRun - true is dry running
          * @return the builder
          */
-        public TopicWriterBuilder noopWriter(final boolean dryRun) {
-            this.noopWriter = dryRun;
+        public TopicMutatorBuilder noopMutator(final boolean dryRun) {
+            this.noop = dryRun;
+            return this;
+        }
+        /**
+         * use the delete mutator
+         *
+         * @param cleanUnspecified - to cleanup resources
+         * @param dryRun - test.validate the proposed operation
+         * @return the builder
+         */
+        public TopicMutatorBuilder cleanUnspecified(
+                final boolean cleanUnspecified, final boolean dryRun) {
+            this.cleanUnspecified = cleanUnspecified;
+            this.dryRun = dryRun;
             return this;
         }
 
@@ -330,21 +405,23 @@ public class TopicWriters {
          *
          * @return builder
          */
-        public static TopicWriterBuilder builder() {
-            return new TopicWriterBuilder();
+        public static TopicMutatorBuilder builder() {
+            return new TopicMutatorBuilder();
         }
 
         /**
          * build it
          *
-         * @return the specified topic writer impl
+         * @return the specified topic mutator impl
          */
-        public TopicWriter build() {
-            if (noopWriter) {
-                return new NoopWriter();
+        public TopicMutator build() {
+            if (cleanUnspecified) {
+                return new CleanUnspecifiedMutator(dryRun, adminClient);
+            } else if (noop) {
+                return new NoopMutator();
             } else {
-                return new CollectiveWriter(
-                        new CreateWriter(adminClient), new UpdateWriter(adminClient));
+                return new CollectiveMutator(
+                        new CreateMutator(adminClient), new UpdateMutator(adminClient));
             }
         }
     }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
@@ -69,9 +69,9 @@ public final class TopicProvisioner {
     /**
      * Gets a writer
      *
-     * @param dryRun             - to ignore writing to the cluster
+     * @param dryRun - to ignore writing to the cluster
      * @param cleanupUnspecified - remove set of unspec'd resources
-     * @param adminClient        - cluster connection
+     * @param adminClient - cluster connection
      * @return configured writer
      */
     private static TopicMutators.TopicMutator mutate(

--- a/kafka/src/test/java/io/specmesh/kafka/ExporterFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ExporterFunctionalTest.java
@@ -96,7 +96,7 @@ class ExporterFunctionalTest {
     @BeforeAll
     static void setUp() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
-            TopicProvisioner.provision(false, API_SPEC, adminClient);
+            TopicProvisioner.provision(false, false, API_SPEC, adminClient);
             AclProvisioner.provision(false, API_SPEC, adminClient);
         }
     }

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
@@ -128,7 +128,7 @@ class KafkaAPISpecFunctionalTest {
     @BeforeAll
     static void setUp() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
-            TopicProvisioner.provision(false, API_SPEC, adminClient);
+            TopicProvisioner.provision(false, false, API_SPEC, adminClient);
             AclProvisioner.provision(false, API_SPEC, adminClient);
         }
     }

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
@@ -196,7 +196,8 @@ class ProvisionerFreshStartFunctionalTest {
 
         final var srClient = srClient();
         final var changeset =
-                SchemaProvisioner.provision(true, API_SPEC, "./build/resources/test", srClient);
+                SchemaProvisioner.provision(
+                        true, false, API_SPEC, "./build/resources/test", srClient);
 
         // Verify - 11 created
         assertThat(
@@ -350,7 +351,8 @@ class ProvisionerFreshStartFunctionalTest {
 
         final var srClient = srClient();
         final var changeset =
-                SchemaProvisioner.provision(false, API_SPEC, "./build/resources/test", srClient);
+                SchemaProvisioner.provision(
+                        false, false, API_SPEC, "./build/resources/test", srClient);
 
         // Verify - 11 created
         assertThat(

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
@@ -113,7 +113,7 @@ class ProvisionerFreshStartFunctionalTest {
     void shouldDryRunTopicsFromEmptyCluster() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            final var changeset = TopicProvisioner.provision(true, API_SPEC, adminClient);
+            final var changeset = TopicProvisioner.provision(true, false, API_SPEC, adminClient);
 
             assertThat(
                     changeset.stream().map(Topic::name).collect(Collectors.toSet()),
@@ -225,7 +225,7 @@ class ProvisionerFreshStartFunctionalTest {
     void shouldProvisionTopicsFromEmptyCluster() throws ExecutionException, InterruptedException {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            final var changeSet = TopicProvisioner.provision(false, API_SPEC, adminClient);
+            final var changeSet = TopicProvisioner.provision(false, false, API_SPEC, adminClient);
 
             // Verify - changeset
             assertThat(

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
@@ -240,8 +240,7 @@ class ProvisionerUpdatingFunctionalTest {
 
     @Test
     @Order(6)
-    void shouldCleanupNonSpecTopicsIRL()
-            throws ExecutionException, InterruptedException {
+    void shouldCleanupNonSpecTopicsIRL() throws ExecutionException, InterruptedException {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
             assertThat(topicCount(adminClient), is(3L));

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
@@ -234,6 +234,7 @@ class ProvisionerUpdatingFunctionalTest {
                     TopicProvisioner.provision(true, true, API_SPEC, adminClient);
             // 'should.not.be' topic that should not be
             assertThat(unSpecifiedTopics, is(hasSize(1)));
+            assertThat(unSpecifiedTopics.iterator().next().state(), is(STATE.DELETE));
             assertThat(topicCount(adminClient), is(3L));
         }
     }
@@ -251,6 +252,7 @@ class ProvisionerUpdatingFunctionalTest {
 
             // 'should.not.be' topic that should not be
             assertThat(unSpecifiedTopics, is(hasSize(1)));
+            assertThat(unSpecifiedTopics.iterator().next().state(), is(STATE.DELETED));
 
             // 'should.not.be' topic was removed
             assertThat(topicCount(adminClient), is(2L));

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
@@ -26,28 +26,14 @@ import static org.apache.kafka.common.resource.ResourceType.CLUSTER;
 import static org.apache.kafka.common.resource.ResourceType.GROUP;
 import static org.apache.kafka.common.resource.ResourceType.TRANSACTIONAL_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.hasItem;
-import static org.hamcrest.Matchers.hasSize;
-import static org.hamcrest.Matchers.is;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
-import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
-import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
-import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.specmesh.kafka.provision.AclProvisioner;
-import io.specmesh.kafka.provision.SchemaProvisioner;
 import io.specmesh.kafka.provision.Status.STATE;
 import io.specmesh.kafka.provision.TopicProvisioner;
 import io.specmesh.kafka.provision.TopicProvisioner.Topic;
 import io.specmesh.test.TestSpecLoader;
-import java.io.IOException;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -59,6 +45,7 @@ import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.config.TopicConfig;
 import org.apache.kafka.common.resource.ResourcePattern;
+import org.hamcrest.Matchers;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
@@ -118,7 +105,6 @@ class ProvisionerUpdatingFunctionalTest {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
             TopicProvisioner.provision(false, false, API_SPEC, adminClient);
             AclProvisioner.provision(false, API_SPEC, adminClient);
-            SchemaProvisioner.provision(false, API_SPEC, "./build/resources/test", srClient());
         }
     }
 
@@ -133,11 +119,11 @@ class ProvisionerUpdatingFunctionalTest {
 
             assertThat(
                     dryRunChangeset.stream().map(Topic::name).collect(Collectors.toSet()),
-                    is(hasItem(USER_SIGNED_UP)));
+                    Matchers.is(Matchers.hasItem(USER_SIGNED_UP)));
 
             final var dryFirstUpdate = dryRunChangeset.iterator().next();
 
-            assertThat(dryFirstUpdate.state(), is(STATE.UPDATE));
+            assertThat(dryFirstUpdate.state(), Matchers.is(STATE.UPDATE));
 
             // REAL Test
             final var changeset =
@@ -145,56 +131,14 @@ class ProvisionerUpdatingFunctionalTest {
 
             final var change = changeset.iterator().next();
 
-            assertThat(change.name(), is(USER_SIGNED_UP));
-            assertThat(change.partitions(), is(99));
-            assertThat(change.messages(), is(containsString("partitions")));
-            assertThat(change.config().get(TopicConfig.RETENTION_MS_CONFIG), is("999000"));
-            assertThat(change.messages(), is(containsString(TopicConfig.RETENTION_MS_CONFIG)));
+            assertThat(change.name(), Matchers.is(USER_SIGNED_UP));
+            assertThat(change.partitions(), Matchers.is(99));
+            assertThat(change.messages(), Matchers.is(Matchers.containsString("partitions")));
+            assertThat(change.config().get(TopicConfig.RETENTION_MS_CONFIG), Matchers.is("999000"));
+            assertThat(
+                    change.messages(),
+                    Matchers.is(Matchers.containsString(TopicConfig.RETENTION_MS_CONFIG)));
         }
-    }
-
-    @Test
-    @Order(3)
-    void shouldPublishUpdatedSchemas() throws RestClientException, IOException {
-
-        final var srClient = srClient();
-        final var dryRunChangeset =
-                SchemaProvisioner.provision(
-                        true, API_UPDATE_SPEC, "./build/resources/test", srClient);
-
-        // Verify - the Update is proposed
-        assertThat(
-                dryRunChangeset.stream().filter(topic -> topic.state() == STATE.UPDATE).count(),
-                is(1L));
-
-        // Verify - should have 2 SR entries (1 was updated, 1 was from original spec)
-        final var allSubjects = srClient.getAllSubjects();
-
-        assertThat(allSubjects, is(hasSize(2)));
-
-        final var updateChangeset =
-                SchemaProvisioner.provision(
-                        false, API_UPDATE_SPEC, "./build/resources/test", srClient);
-
-        final var parsedSchemas =
-                srClient.getSchemas(updateChangeset.iterator().next().subject(), false, true);
-        // should now contain the address field
-        assertThat(parsedSchemas.get(0).canonicalString(), is(containsString("address")));
-
-        // Verify - 1 Update has been executed
-        assertThat(updateChangeset, is(hasSize(1)));
-
-        final var schemas = srClient.getSchemas("simple", false, false);
-
-        final var schemaNames =
-                schemas.stream().map(ParsedSchema::name).collect(Collectors.toSet());
-
-        assertThat(
-                schemaNames,
-                is(
-                        containsInAnyOrder(
-                                "io.specmesh.kafka.schema.UserInfo",
-                                "simple.provision_demo._public.user_signed_up_value.UserSignedUp")));
     }
 
     @Test
@@ -202,17 +146,17 @@ class ProvisionerUpdatingFunctionalTest {
     void shouldPublishUpdatedAcls() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
             final var dryRunAcls = AclProvisioner.provision(true, API_UPDATE_SPEC, adminClient);
-            assertThat(dryRunAcls, is(hasSize(2)));
+            assertThat(dryRunAcls, Matchers.is(Matchers.hasSize(2)));
             assertThat(
                     dryRunAcls.stream().filter(acl -> acl.state().equals(STATE.CREATE)).count(),
-                    is(2L));
+                    Matchers.is(2L));
 
             final var createdAcls = AclProvisioner.provision(false, API_UPDATE_SPEC, adminClient);
 
-            assertThat(createdAcls, is(hasSize(2)));
+            assertThat(createdAcls, Matchers.is(Matchers.hasSize(2)));
             assertThat(
                     createdAcls.stream().filter(acl -> acl.state().equals(STATE.CREATED)).count(),
-                    is(2L));
+                    Matchers.is(2L));
         }
     }
 
@@ -227,7 +171,7 @@ class ProvisionerUpdatingFunctionalTest {
                     .all()
                     .get(20, TimeUnit.SECONDS);
 
-            assertThat(topicCount(adminClient), is(3L));
+            assertThat(topicCount(adminClient), Matchers.is(3L));
 
             // create the unspecified topic
             final var unSpecifiedTopics =
@@ -244,7 +188,7 @@ class ProvisionerUpdatingFunctionalTest {
     void shouldCleanupNonSpecTopicsIRL() throws ExecutionException, InterruptedException {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            assertThat(topicCount(adminClient), is(3L));
+            assertThat(topicCount(adminClient), Matchers.is(3L));
 
             // create the unspecified topic
             final var unSpecifiedTopics =
@@ -255,7 +199,7 @@ class ProvisionerUpdatingFunctionalTest {
             assertThat(unSpecifiedTopics.iterator().next().state(), is(STATE.DELETED));
 
             // 'should.not.be' topic was removed
-            assertThat(topicCount(adminClient), is(2L));
+            assertThat(topicCount(adminClient), Matchers.is(2L));
         }
     }
 
@@ -264,17 +208,6 @@ class ProvisionerUpdatingFunctionalTest {
         return adminClient.listTopics().listings().get().stream()
                 .filter(t -> t.name().startsWith(API_SPEC.id()))
                 .count();
-    }
-
-    private static CachedSchemaRegistryClient srClient() {
-        return new CachedSchemaRegistryClient(
-                KAFKA_ENV.schemeRegistryServer(),
-                5,
-                List.of(
-                        new ProtobufSchemaProvider(),
-                        new AvroSchemaProvider(),
-                        new JsonSchemaProvider()),
-                Map.of());
     }
 
     private static Set<AclBinding> aclsForOtherDomain(final Domain domain) {

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerUpdatingFunctionalTest.java
@@ -26,6 +26,8 @@ import static org.apache.kafka.common.resource.ResourceType.CLUSTER;
 import static org.apache.kafka.common.resource.ResourceType.GROUP;
 import static org.apache.kafka.common.resource.ResourceType.TRANSACTIONAL_ID;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.specmesh.kafka.provision.AclProvisioner;
@@ -119,11 +121,11 @@ class ProvisionerUpdatingFunctionalTest {
 
             assertThat(
                     dryRunChangeset.stream().map(Topic::name).collect(Collectors.toSet()),
-                    Matchers.is(Matchers.hasItem(USER_SIGNED_UP)));
+                    is(Matchers.hasItem(USER_SIGNED_UP)));
 
             final var dryFirstUpdate = dryRunChangeset.iterator().next();
 
-            assertThat(dryFirstUpdate.state(), Matchers.is(STATE.UPDATE));
+            assertThat(dryFirstUpdate.state(), is(STATE.UPDATE));
 
             // REAL Test
             final var changeset =
@@ -131,13 +133,13 @@ class ProvisionerUpdatingFunctionalTest {
 
             final var change = changeset.iterator().next();
 
-            assertThat(change.name(), Matchers.is(USER_SIGNED_UP));
-            assertThat(change.partitions(), Matchers.is(99));
-            assertThat(change.messages(), Matchers.is(Matchers.containsString("partitions")));
-            assertThat(change.config().get(TopicConfig.RETENTION_MS_CONFIG), Matchers.is("999000"));
+            assertThat(change.name(), is(USER_SIGNED_UP));
+            assertThat(change.partitions(), is(99));
+            assertThat(change.messages(), is(Matchers.containsString("partitions")));
+            assertThat(change.config().get(TopicConfig.RETENTION_MS_CONFIG), is("999000"));
             assertThat(
                     change.messages(),
-                    Matchers.is(Matchers.containsString(TopicConfig.RETENTION_MS_CONFIG)));
+                    is(Matchers.containsString(TopicConfig.RETENTION_MS_CONFIG)));
         }
     }
 
@@ -146,17 +148,17 @@ class ProvisionerUpdatingFunctionalTest {
     void shouldPublishUpdatedAcls() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
             final var dryRunAcls = AclProvisioner.provision(true, API_UPDATE_SPEC, adminClient);
-            assertThat(dryRunAcls, Matchers.is(Matchers.hasSize(2)));
+            assertThat(dryRunAcls, is(hasSize(2)));
             assertThat(
                     dryRunAcls.stream().filter(acl -> acl.state().equals(STATE.CREATE)).count(),
-                    Matchers.is(2L));
+                    is(2L));
 
             final var createdAcls = AclProvisioner.provision(false, API_UPDATE_SPEC, adminClient);
 
-            assertThat(createdAcls, Matchers.is(Matchers.hasSize(2)));
+            assertThat(createdAcls, is(hasSize(2)));
             assertThat(
                     createdAcls.stream().filter(acl -> acl.state().equals(STATE.CREATED)).count(),
-                    Matchers.is(2L));
+                    is(2L));
         }
     }
 
@@ -171,7 +173,7 @@ class ProvisionerUpdatingFunctionalTest {
                     .all()
                     .get(20, TimeUnit.SECONDS);
 
-            assertThat(topicCount(adminClient), Matchers.is(3L));
+            assertThat(topicCount(adminClient), is(3L));
 
             // create the unspecified topic
             final var unSpecifiedTopics =
@@ -188,7 +190,7 @@ class ProvisionerUpdatingFunctionalTest {
     void shouldCleanupNonSpecTopicsIRL() throws ExecutionException, InterruptedException {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            assertThat(topicCount(adminClient), Matchers.is(3L));
+            assertThat(topicCount(adminClient), is(3L));
 
             // create the unspecified topic
             final var unSpecifiedTopics =
@@ -199,7 +201,7 @@ class ProvisionerUpdatingFunctionalTest {
             assertThat(unSpecifiedTopics.iterator().next().state(), is(STATE.DELETED));
 
             // 'should.not.be' topic was removed
-            assertThat(topicCount(adminClient), Matchers.is(2L));
+            assertThat(topicCount(adminClient), is(2L));
         }
     }
 

--- a/kafka/src/test/java/io/specmesh/kafka/SchemaProvisionerUpdateFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/SchemaProvisionerUpdateFunctionalTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.kafka;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
+import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
+import io.specmesh.kafka.provision.SchemaProvisioner;
+import io.specmesh.kafka.provision.SchemaProvisioner.Schema;
+import io.specmesh.kafka.provision.Status.STATE;
+import io.specmesh.test.TestSpecLoader;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestMethodOrder;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+/**
+ * Tests execution DryRuns and UPDATES where the provisioner-functional-test-api.yml is already
+ * provisioned
+ */
+@SuppressFBWarnings(
+        value = "IC_INIT_CIRCULARITY",
+        justification = "shouldHaveInitializedEnumsCorrectly() proves this is false positive")
+@TestMethodOrder(MethodOrderer.OrderAnnotation.class)
+class SchemaProvisionerUpdateFunctionalTest {
+
+    private static final KafkaApiSpec API_SPEC =
+            TestSpecLoader.loadFromClassPath("provisioner-functional-test-api.yaml");
+
+    private static final KafkaApiSpec API_UPDATE_SPEC =
+            TestSpecLoader.loadFromClassPath("provisioner-update-functional-test-api.yaml");
+
+    private enum Domain {
+        /** The domain associated with the spec. */
+        SELF(API_SPEC.id()),
+        /** An unrelated domain. */
+        UNRELATED("london.hammersmith.transport"),
+        /** A domain granted access to the protected topic. */
+        LIMITED("some.other.domain.root");
+
+        final String domainId;
+
+        Domain(final String name) {
+            this.domainId = name;
+        }
+    }
+
+    private static final String ADMIN_USER = "admin";
+
+    @RegisterExtension
+    private static final KafkaEnvironment KAFKA_ENV =
+            DockerKafkaEnvironment.builder()
+                    .withSaslAuthentication(
+                            ADMIN_USER,
+                            ADMIN_USER + "-secret",
+                            Domain.SELF.domainId,
+                            Domain.SELF.domainId + "-secret")
+                    .build();
+
+    /** setup for following update tests */
+    @Test
+    @Order(1)
+    void shouldProvisionExistingSpec() {
+        SchemaProvisioner.provision(false, false, API_SPEC, "./build/resources/test", srClient());
+    }
+
+    @Test
+    @Order(2)
+    void shouldPublishUpdatedSchemas() throws RestClientException, IOException {
+
+        final var srClient = srClient();
+        final var dryRunChangeset =
+                SchemaProvisioner.provision(
+                        true, false, API_UPDATE_SPEC, "./build/resources/test", srClient);
+
+        // Verify - the Update is proposed
+        assertThat(
+                dryRunChangeset.stream().filter(topic -> topic.state() == STATE.UPDATE).count(),
+                is(1L));
+
+        // Verify - should have 2 SR entries (1 was updated, 1 was from original spec)
+        final var allSubjects = srClient.getAllSubjects();
+
+        assertThat(allSubjects, is(hasSize(2)));
+
+        final var updateChangeset =
+                SchemaProvisioner.provision(
+                        false, false, API_UPDATE_SPEC, "./build/resources/test", srClient);
+
+        final var parsedSchemas =
+                srClient.getSchemas(updateChangeset.iterator().next().subject(), false, true);
+        // should now contain the address field
+        assertThat(parsedSchemas.get(0).canonicalString(), is(containsString("address")));
+
+        // Verify - 1 Update has been executed
+        assertThat(updateChangeset, is(hasSize(1)));
+
+        final var schemas = srClient.getSchemas("simple", false, false);
+
+        final var schemaNames =
+                schemas.stream().map(ParsedSchema::name).collect(Collectors.toSet());
+
+        assertThat(
+                schemaNames,
+                is(
+                        containsInAnyOrder(
+                                "io.specmesh.kafka.schema.UserInfo",
+                                "simple.provision_demo._public.user_signed_up_value.UserSignedUp")));
+    }
+
+    @Test
+    @Order(3)
+    void shouldRemoveUnspecdSchemas() throws RestClientException, IOException {
+
+        final var subject = "simple.provision_demo._public.NOT_user_signed_up-value";
+        final var schemaContent =
+                "{\n"
+                    + "  \"type\": \"record\",\n"
+                    + "  \"namespace\": \"simple.provision_demo._public.user_signed_up_value\",\n"
+                    + "  \"name\": \"UserSignedUp\",\n"
+                    + "  \"fields\": [\n"
+                    + "    {\"name\": \"fullName\", \"type\": \"string\"},\n"
+                    + "    {\"name\": \"age\", \"type\": \"int\"}\n"
+                    + "  ]\n"
+                    + "}";
+        final var schema =
+                Schema.builder()
+                        .subject(subject)
+                        .type("/schema/simple.provision_demo._public.user_signed_up.avsc")
+                        .payload(schemaContent)
+                        .state(STATE.READ)
+                        .build();
+
+        try (SchemaRegistryClient srClient = srClient()) {
+
+            // insert the bad schema
+            srClient.register(subject, schema.getSchema());
+
+            testDryRun(subject, srClient);
+            testCleanUnSpecSchemas(srClient);
+        }
+    }
+
+    private static void testCleanUnSpecSchemas(final SchemaRegistryClient srClient)
+            throws IOException, RestClientException {
+        final var cleanerSet2 =
+                SchemaProvisioner.provision(
+                        false, true, API_UPDATE_SPEC, "./build/resources/test", srClient());
+
+        // verify it was removed
+        assertThat(cleanerSet2.iterator().next().state(), is(STATE.DELETED));
+
+        final var allSchemasforSpec = srClient.getAllSubjectsByPrefix(API_SPEC.id());
+
+        // verify removal
+        assertThat(allSchemasforSpec, is(hasSize(2)));
+    }
+
+    private static void testDryRun(final String subject, final SchemaRegistryClient srClient)
+            throws IOException, RestClientException {
+        // test dry run
+        final var cleanerSet =
+                SchemaProvisioner.provision(
+                        true, true, API_UPDATE_SPEC, "./build/resources/test", srClient());
+
+        // verify dry run
+        assertThat(cleanerSet, is(hasSize(1)));
+        assertThat(
+                cleanerSet.stream().map(Schema::subject).collect(Collectors.toList()),
+                contains(subject));
+        // verify intent to DELETE
+        assertThat(cleanerSet.iterator().next().state(), is(STATE.DELETE));
+
+        final var allSchemasforId = srClient.getAllSubjectsByPrefix(API_SPEC.id());
+        assertThat(allSchemasforId, is(hasSize(3)));
+    }
+
+    private static SchemaRegistryClient srClient() {
+        return new CachedSchemaRegistryClient(
+                KAFKA_ENV.schemeRegistryServer(),
+                5,
+                List.of(
+                        new ProtobufSchemaProvider(),
+                        new AvroSchemaProvider(),
+                        new JsonSchemaProvider()),
+                Map.of());
+    }
+}

--- a/kafka/src/test/java/io/specmesh/kafka/admin/SimpleAdminClientTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/admin/SimpleAdminClientTest.java
@@ -79,6 +79,7 @@ class SimpleAdminClientTest {
             final var client = SmAdminClient.create(adminClient);
             Provisioner.provision(
                     false,
+                    false,
                     API_SPEC,
                     "./build/resources/test",
                     adminClient,

--- a/kafka/src/test/java/io/specmesh/kafka/provision/SchemaChangeSetCalculatorsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/SchemaChangeSetCalculatorsTest.java
@@ -69,7 +69,7 @@ class SchemaChangeSetCalculatorsTest {
                                 .payload(readFile("-v3-bad.avsc"))
                                 .build());
 
-        final var calculator = SchemaChangeSetCalculators.builder().build(client);
+        final var calculator = SchemaChangeSetCalculators.builder().build(false, client);
 
         final var schemas = calculator.calculate(existing, required);
         assertThat(schemas.iterator().next().state(), is(Status.STATE.FAILED));

--- a/kafka/src/test/java/io/specmesh/kafka/provision/TopicMutatorsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/TopicMutatorsTest.java
@@ -23,8 +23,8 @@ import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import io.specmesh.kafka.provision.TopicMutators.UpdateMutator;
 import io.specmesh.kafka.provision.TopicProvisioner.Topic;
-import io.specmesh.kafka.provision.TopicWriters.UpdateWriter;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -41,14 +41,15 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/** Fussy mutation tests */
 @ExtendWith(MockitoExtension.class)
-class TopicWritersTest {
+class TopicMutatorsTest {
 
     @Mock Admin client;
 
     @Test
     void shouldWriteUpdatesForRetentionChange() throws Exception {
-        final var topicWriter = new UpdateWriter(client);
+        final var topicWriter = new UpdateMutator(client);
 
         // Mock hell - crappy admin api
         final var topicDescriptionFuture = mock(KafkaFuture.class);
@@ -71,7 +72,7 @@ class TopicWritersTest {
                                 .partitions(1)
                                 .config(Map.of(TopicConfig.RETENTION_MS_CONFIG, "1000"))
                                 .build());
-        final var updated = topicWriter.write(updates);
+        final var updated = topicWriter.mutate(updates);
         final var next = updated.iterator().next();
 
         // verify
@@ -82,7 +83,7 @@ class TopicWritersTest {
 
     @Test
     void shouldWriteUpdatesToPartitionsWhenLarger() throws Exception {
-        final var topicWriter = new UpdateWriter(client);
+        final var topicWriter = new UpdateMutator(client);
 
         // Mock hell - crappy admin api
         final var topicDescriptionFuture = mock(KafkaFuture.class);
@@ -111,7 +112,7 @@ class TopicWritersTest {
                                 .state(Status.STATE.UPDATE)
                                 .partitions(999)
                                 .build());
-        final var updated = topicWriter.write(updates);
+        final var updated = topicWriter.mutate(updates);
         final var next = updated.iterator().next();
 
         // verify


### PR DESCRIPTION
#58 Topics: remove resources that aren't in the spec. provides a means of preventing resource drift and using the spec as the source of truth

note on 'Provision' command updated flags:
- use -dry or --dry-run to check action (inc cleaning)
- use -clean or --clean-unspecified to clean resources



Labels marked with `**` are excluded from release notes

### Reviewer checklist
- [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
- [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended