### PR TITLE
part 3 - ACLs for unspec cleanup #58

### DIFF
--- a/kafka/src/main/java/io/specmesh/kafka/provision/AclChangeSetCalculators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/AclChangeSetCalculators.java
@@ -28,11 +28,29 @@ import java.util.stream.Collectors;
  */
 public class AclChangeSetCalculators {
 
+    /** Calc unspecified acls */
+    public static final class CleanUnspecifiedCalculator implements ChangeSetCalculator {
+
+        /**
+         * returns unspec'd acls
+         *
+         * @param existingAcls - existing
+         * @param requiredAcls - needed
+         * @return set of acls to remove
+         */
+        @Override
+        public Collection<Acl> calculate(
+                final Collection<Acl> existingAcls, final Collection<Acl> requiredAcls) {
+            existingAcls.removeAll(requiredAcls);
+            return existingAcls;
+        }
+    }
+
     /** Returns those acls to create and ignores existing */
     public static final class CreateOrUpdateCalculator implements ChangeSetCalculator {
 
         /**
-         * Calculate set of Acls that dont already exist
+         * Calculate set of Acls that don't already exist
          *
          * @param existingAcls - existing
          * @param requiredAcls - needed
@@ -85,7 +103,7 @@ public class AclChangeSetCalculators {
          *
          * @param existingAcls - existing
          * @param requiredAcls - needed
-         * @return - set of those that dont exist
+         * @return - set of those that don't exist
          */
         Collection<Acl> calculate(Collection<Acl> existingAcls, Collection<Acl> requiredAcls);
     }
@@ -108,10 +126,15 @@ public class AclChangeSetCalculators {
         /**
          * build it
          *
+         * @param cleanUnspecified - clean up
          * @return required calculator
          */
-        public ChangeSetCalculator build() {
-            return new CreateOrUpdateCalculator();
+        public ChangeSetCalculator build(final boolean cleanUnspecified) {
+            if (cleanUnspecified) {
+                return new CleanUnspecifiedCalculator();
+            } else {
+                return new CreateOrUpdateCalculator();
+            }
         }
     }
 }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
@@ -64,7 +64,7 @@ public final class Provisioner {
                                         apiSpec,
                                         schemaResources,
                                         registryClient)));
-        status.acls(AclProvisioner.provision(dryRun, apiSpec, adminClient));
+        status.acls(AclProvisioner.provision(dryRun, cleanUnspecified, apiSpec, adminClient));
         return status.build();
     }
 

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
@@ -129,7 +129,7 @@ class KafkaAPISpecFunctionalTest {
     static void setUp() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
             TopicProvisioner.provision(false, false, API_SPEC, adminClient);
-            AclProvisioner.provision(false, API_SPEC, adminClient);
+            AclProvisioner.provision(false, false, API_SPEC, adminClient);
         }
     }
 

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
@@ -159,7 +159,7 @@ class ProvisionerFreshStartFunctionalTest {
     void shouldDryRunACLsFromEmptyCluster() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            final var changeset = AclProvisioner.provision(true, API_SPEC, adminClient);
+            final var changeset = AclProvisioner.provision(true, false, API_SPEC, adminClient);
 
             // Verify - 11 created
             assertThat(
@@ -302,7 +302,7 @@ class ProvisionerFreshStartFunctionalTest {
     void shouldDoRealACLsFromEmptyCluster() throws ExecutionException, InterruptedException {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            final var changeset = AclProvisioner.provision(false, API_SPEC, adminClient);
+            final var changeset = AclProvisioner.provision(false, false, API_SPEC, adminClient);
 
             // Verify - 11 created
             assertThat(

--- a/kafka/src/test/java/io/specmesh/kafka/TopicProvisionerUpdateFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/TopicProvisionerUpdateFunctionalTest.java
@@ -30,7 +30,6 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.specmesh.kafka.provision.AclProvisioner;
 import io.specmesh.kafka.provision.Status.STATE;
 import io.specmesh.kafka.provision.TopicProvisioner;
 import io.specmesh.kafka.provision.TopicProvisioner.Topic;
@@ -62,7 +61,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
         value = "IC_INIT_CIRCULARITY",
         justification = "shouldHaveInitializedEnumsCorrectly() proves this is false positive")
 @TestMethodOrder(MethodOrderer.OrderAnnotation.class)
-class ProvisionerUpdatingFunctionalTest {
+class TopicProvisionerUpdateFunctionalTest {
 
     private static final KafkaApiSpec API_SPEC =
             TestSpecLoader.loadFromClassPath("provisioner-functional-test-api.yaml");
@@ -106,7 +105,6 @@ class ProvisionerUpdatingFunctionalTest {
     void shouldProvisionExistingSpec() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
             TopicProvisioner.provision(false, false, API_SPEC, adminClient);
-            AclProvisioner.provision(false, API_SPEC, adminClient);
         }
     }
 
@@ -140,25 +138,6 @@ class ProvisionerUpdatingFunctionalTest {
             assertThat(
                     change.messages(),
                     is(Matchers.containsString(TopicConfig.RETENTION_MS_CONFIG)));
-        }
-    }
-
-    @Test
-    @Order(4)
-    void shouldPublishUpdatedAcls() {
-        try (Admin adminClient = KAFKA_ENV.adminClient()) {
-            final var dryRunAcls = AclProvisioner.provision(true, API_UPDATE_SPEC, adminClient);
-            assertThat(dryRunAcls, is(hasSize(2)));
-            assertThat(
-                    dryRunAcls.stream().filter(acl -> acl.state().equals(STATE.CREATE)).count(),
-                    is(2L));
-
-            final var createdAcls = AclProvisioner.provision(false, API_UPDATE_SPEC, adminClient);
-
-            assertThat(createdAcls, is(hasSize(2)));
-            assertThat(
-                    createdAcls.stream().filter(acl -> acl.state().equals(STATE.CREATED)).count(),
-                    is(2L));
         }
     }
 


### PR DESCRIPTION
Cleanup ACLs that aren't part of this spec. The adminClient ACL interface is terrible - you need to pull back all ACLs - there will be 3 for all private topics (prefixed), 3 for all public topic, and 3 for each/every protected topic. Where ACLs are excessive (i.e. too many topics - then avoid using 'protected' topic.

use Provisioner with -clean true -dry true flags.
-dry-run + -clean will display set of all resources to be cleaned

use Provisioner with -clean true -dry false flags to remove the reported set above

cherry picking not currently supported. could be a nice feature request

