### PR TITLE
Reduce size of cli docker image by removing tar

### DIFF
--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -13,6 +13,7 @@ COPY log4j /log
 
 RUN chmod +x /bin/*.sh
 
+COPY ${APP_NAME}-${APP_VERSION} /opt/specmesh/${APP_NAME}-${APP_VERSION}
 WORKDIR /opt/specmesh
 
 RUN ln -s ${APP_NAME}-${APP_VERSION} service

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -6,9 +6,6 @@ ENV VERSION=$APP_VERSION
 
 LABEL org.opencontainers.image.source=https://github.com/specmesh/specmesh-build/tree/main/cli
 
-RUN yum update -y
-RUN yum install -y tar lsof
-
 RUN mkdir -p /opt/specmesh
 
 COPY bin /bin
@@ -16,13 +13,9 @@ COPY log4j /log
 
 RUN chmod +x /bin/*.sh
 
-COPY ${APP_NAME}-${APP_VERSION}.tar /opt/specmesh
 WORKDIR /opt/specmesh
 
-RUN tar xf ${APP_NAME}-${APP_VERSION}.tar
 RUN ln -s ${APP_NAME}-${APP_VERSION} service
-
-
 
 ENTRYPOINT ["/bin/wrapper.sh"]
 #No CMD instruction is provided, allowing you to pass any number of arguments at runtime.

--- a/cli/Dockerfile
+++ b/cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM amazoncorretto:20@sha256:ac32b3e93f843470c7f55b7d694df016def3d02d55de83e2f43d432a8884b3a4
+FROM eclipse-temurin:11-jre-focal@sha256:4c1ab549795f20b661bfaaa22716e5e10a8eae66a534e668a1e028683c810efa
 
 ARG APP_NAME
 ARG APP_VERSION

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -67,7 +67,7 @@ tasks.register<Copy>("prepareDocker") {
 
     from(
         layout.projectDirectory.file("Dockerfile"),
-        layout.buildDirectory.file("distributions/${project.name}-${project.version}.tar"),
+        tarTree(layout.buildDirectory.file("distributions/${project.name}-${project.version}.tar")),
         layout.projectDirectory.dir("include"),
     )
 


### PR DESCRIPTION
fixes: https://github.com/specmesh/specmesh-build/issues/213

* First change:

Have the Gradle build unpack the distribution tar archive. This means there is no need to install tar or to have the tar file in the Docker image.

Reduces image down to ~600MB

* Second change:

Change base image to smaller one:

Reduces image down to ~360MB

### Reviewer checklist
- [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
- [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended