### PR TITLE
flattening structures for use by other AsyncApi spec tools

### DIFF
--- a/cli/README.md
+++ b/cli/README.md
@@ -531,10 +531,10 @@ A consumer group `some.other.app` with id `console-consumer...` is actively cons
   <summary>Long form</summary>
 
 ```
-Usage: export [-aggid=<aggid>] [-bs=<brokerUrl>] [-s=<secret>] [-u=<username>]
+Usage: export [-domainid=<domain>] [-bs=<brokerUrl>] [-s=<secret>] [-u=<username>]
 Build an incomplete spec from a running Cluster
-      -aggid, --agg-id=<aggid>
-                          specmesh - agg-id/prefix - aggregate identified
+      -domainid, --domain-id=<domain>
+                          specmesh - domain-id/prefix - domain/context identified
                             (app-id) to export against
       -bs, --bootstrap-server=<brokerUrl>
                           Kafka bootstrap server url

--- a/cli/README.md
+++ b/cli/README.md
@@ -1,6 +1,11 @@
 # SpecMesh CLI
 
-Commands to provision, export and capture production & consumption chargeback metrics for a SpecMesh app (aka data product - AsyncApi.yml)
+Commands:
+- `provision` from a spec.yml file
+- `export` existing Kafka resources to a spec when providing a domain-id to filter against
+-  capture `production`, `consumption` (chargeback metrics)  for a given spec and build chargeback reporting/billing
+- `flatten` to prefix the 'id' to each channel allowing existing tools to be used - for example: https://microcks.io/ and Spring boot code generators etc. many more [here](https://www.asyncapi.com/tools)
+
 
 This page also contains a simple docker guide for local testing.
 

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -36,6 +36,10 @@ dependencies {
     implementation("org.apache.logging.log4j:log4j-core:$log4jVersion")
     runtimeOnly("org.apache.logging.log4j:log4j-slf4j2-impl:$log4jVersion")
 
+    implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
+
+
+
     implementation(project(":parser"))
     implementation(project(":kafka"))
     testImplementation(project(":kafka-test"))

--- a/cli/include/bin/wrapper.sh
+++ b/cli/include/bin/wrapper.sh
@@ -37,10 +37,20 @@ function export() {
 
 }
 
+function flatten() {
+  echo "Flatten..."
+  exec java \
+   -Xms64m -Xmx64m \
+   -Dlog4j.configurationFile=/log/log4j2.xml \
+   -cp "/opt/specmesh/service/lib/*" \
+   io.specmesh.cli.Flatten "$@"
+
+}
+
 
 function usage() {
   echo "Usage "
-  echo " Commands         [provision, consumption, storage, export]"
+  echo " Commands         [provision, consumption, storage, export, flatten]"
   echo " Common args      --bootstrap-server|-bs, --username,-u, --secret,-p"
   echo " Schema Reg args  --schema-registry, -sr, --sr-api-key,-srKey, --sr-api-secret,-srSecret, --schema-path,-schemaPath "
   echo " Other args       --spec,-spec, --appId,-appId "
@@ -50,7 +60,7 @@ function usage() {
 }
 
 
-if [ $# -le 4 ]; then
+if [ $# -le 3 ]; then
   usage
 fi
 
@@ -71,6 +81,11 @@ case $1 in
       shift
       export "$@"
       ;;
+  flatten)
+      shift
+      flatten "$@"
+      ;;
+
   *)
     usage
     ;;

--- a/cli/resources/simple_schema_demo-api.yaml
+++ b/cli/resources/simple_schema_demo-api.yaml
@@ -30,6 +30,7 @@ channels:
 
     publish:
       summary: Inform about environmental lighting conditions for a particular streetlight.
+      description: Doing clever things
       operationId: onLightMeasured
       message:
         bindings:

--- a/cli/src/main/java/io/specmesh/cli/Export.java
+++ b/cli/src/main/java/io/specmesh/cli/Export.java
@@ -52,9 +52,8 @@ public class Export implements Callable<Integer> {
     private String brokerUrl = "";
 
     @Option(
-            names = {"-aggid", "--agg-id"},
-            description =
-                    "specmesh - agg-id/prefix - aggregate identified (app-id) to export against")
+            names = {"-id", "--domain-id"},
+            description = "specmesh - domain/prefix - domain identified (app-id) to export against")
     private String aggid;
 
     @Option(

--- a/cli/src/main/java/io/specmesh/cli/Flatten.java
+++ b/cli/src/main/java/io/specmesh/cli/Flatten.java
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.cli;
+
+import static picocli.CommandLine.Command;
+
+import com.fasterxml.jackson.annotation.JsonAutoDetect;
+import com.fasterxml.jackson.annotation.PropertyAccessor;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import io.specmesh.kafka.KafkaApiSpec;
+import java.io.FileOutputStream;
+import java.nio.charset.StandardCharsets;
+import java.util.concurrent.Callable;
+import picocli.CommandLine;
+import picocli.CommandLine.Option;
+
+/** Rewrite the spec with the id prefixed to the channel.id */
+@Command(
+        name = "flatten",
+        description =
+                "Flattens the 'id' into the channel name to support fully qualified channel names")
+public class Flatten implements Callable<Integer> {
+
+    /**
+     * Main method
+     *
+     * @param args args
+     */
+    public static void main(final String[] args) {
+        System.exit(new CommandLine(new Flatten()).execute(args));
+    }
+
+    @Option(
+            names = {"-in", "--in-spec"},
+            description = "Source spec to flatten")
+    private String inSpec = "";
+
+    @Option(
+            names = {"-out", "--out-spec"},
+            description = "output spec")
+    private String outSpec;
+
+    @Override
+    public Integer call() throws Exception {
+
+        final var apiSpec1 = KafkaApiSpec.loadFromClassPath(inSpec, Flatten.class.getClassLoader());
+
+        final var apiSpec = apiSpec1.apiSpec();
+
+        final var mapper =
+                new ObjectMapper(new YAMLFactory())
+                        .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
+                        .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
+        final var channels = apiSpec.channels();
+        apiSpec.channels(channels);
+        System.out.println(mapper.writeValueAsString(apiSpec));
+        try (FileOutputStream fileOutputStream = new FileOutputStream(outSpec)) {
+            fileOutputStream.write(
+                    mapper.writeValueAsString(apiSpec).getBytes(StandardCharsets.UTF_8));
+        }
+        return 0;
+    }
+}

--- a/cli/src/test/java/io/specmesh/cli/FlattenTest.java
+++ b/cli/src/test/java/io/specmesh/cli/FlattenTest.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.cli;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import picocli.CommandLine;
+
+class FlattenTest {
+
+    /**
+     * Generate flattened/prefixed version
+     *
+     * @throws Exception - when broken
+     */
+    @Test
+    void shouldFlattenIt() throws Exception {
+
+        final var flatten = new Flatten();
+
+        final var outSpexc = "build/finished-spec.yml";
+
+        // Given:
+        final CommandLine.ParseResult parseResult =
+                new CommandLine(flatten)
+                        .parseArgs(
+                                ("--in-spec simple_schema_demo-api.yaml"
+                                                + " --out-spec "
+                                                + outSpexc)
+                                        .split(" "));
+
+        assertThat(parseResult.matchedArgs().size(), is(2));
+
+        assertThat(flatten.call(), is(0));
+
+        assertThat(new File(outSpexc).exists(), is(true));
+
+        try (FileInputStream fis = new FileInputStream(outSpexc)) {
+            final var testOutput = new String(fis.readAllBytes(), StandardCharsets.UTF_8);
+            assertThat(testOutput, containsString("simple.schema_demo._public.user_signed_up:"));
+        }
+    }
+}

--- a/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
@@ -101,7 +101,7 @@ class StorageConsumptionFunctionalTest {
                         .parseArgs(
                                 ("--bootstrap-server "
                                                 + KAFKA_ENV.kafkaBootstrapServers()
-                                                + " --agg-id simple:schema_demo"
+                                                + " --domain-id simple:schema_demo"
                                                 + " --username admin"
                                                 + " --secret admin-secret")
                                         .split(" "));


### PR DESCRIPTION
See #221 - example command to flatten:

` % docker run --rm  -v "$(pwd)/resources:/app" ghcr.io/specmesh/specmesh-build-cli flatten --in-spec /app/simple_schema_demo-api.yaml --out-spec /app/testing.yaml`

Changes:
```yaml
channels:
  # PRODUCER/OWNER build pipe will publish schema to SR
  _public.user_signed_up:
```

into
```yaml
channels:
  simple.schema_demo._public.user_signed_up:
```
