### PR TITLE
Allow nested tests

### DIFF
--- a/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
@@ -172,7 +172,8 @@ public final class DockerKafkaEnvironment
     }
 
     /**
-     * @return the Docker network Kafka and SR are running on, allowing additional containers to use the same network, if needed.
+     * @return the Docker network Kafka and SR are running on, allowing additional containers to use
+     *     the same network, if needed.
      */
     public Network network() {
         if (network == null) {
@@ -219,7 +220,7 @@ public final class DockerKafkaEnvironment
         if (setUpCount.decrementAndGet() != 0) {
             return;
         }
-        
+
         if (schemaRegistry != null) {
             schemaRegistry.close();
             schemaRegistry = null;

--- a/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
@@ -36,6 +36,7 @@ import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -89,6 +90,7 @@ public final class DockerKafkaEnvironment
     private KafkaContainer kafkaBroker;
     private SchemaRegistryContainer schemaRegistry;
     private boolean invokedStatically = false;
+    private AtomicInteger setUpCount = new AtomicInteger(1);
 
     /**
      * @return returns a {@link Builder} instance to allow customisation of the environment.
@@ -180,7 +182,7 @@ public final class DockerKafkaEnvironment
     }
 
     private void setUp() {
-        if (network != null) {
+        if (setUpCount.incrementAndGet() != 1) {
             return;
         }
 
@@ -214,6 +216,10 @@ public final class DockerKafkaEnvironment
     }
 
     private void tearDown() {
+        if (setUpCount.decrementAndGet() != 0) {
+            return;
+        }
+        
         if (schemaRegistry != null) {
             schemaRegistry.close();
             schemaRegistry = null;

--- a/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
@@ -169,7 +169,21 @@ public final class DockerKafkaEnvironment
         return AdminClient.create(properties);
     }
 
+    /**
+     * @return the Docker network Kafka and SR are running on, allowing additional containers to use the same network, if needed.
+     */
+    public Network network() {
+        if (network == null) {
+            throw new IllegalStateException("Environment not running");
+        }
+        return network;
+    }
+
     private void setUp() {
+        if (network != null) {
+            return;
+        }
+
         network = Network.newNetwork();
 
         kafkaBroker =

--- a/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
@@ -75,6 +75,7 @@ import org.apache.kafka.streams.KafkaStreams;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import simple.schema_demo._public.user_signed_up_value.UserSignedUp;
@@ -215,24 +216,30 @@ class ClientsFunctionalDemoTest {
         }
     }
 
-    @Test
-    void shouldConsumeWithDifferentUser() throws Exception {
-        // Given:
-        final var userSignedUpTopic = topicName("_public.user_signed_up");
-        final var sentRecord = new UserSignedUp("joe blogs", "blogy@twasmail.com", 100);
+    @Nested
+    class NestedTest {
 
-        try (Consumer<Long, UserSignedUp> consumer =
-                        avroConsumer(userSignedUpTopic, DIFFERENT_USER);
-                Producer<Long, UserSignedUp> producer = avroProducer(OWNER_USER)) {
+        // Run one test in a nested class to test env works with such nesting...
 
-            // When:
-            producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L, sentRecord))
-                    .get(60, TimeUnit.SECONDS);
+        @Test
+        void shouldConsumeWithDifferentUser() throws Exception {
+            // Given:
+            final var userSignedUpTopic = topicName("_public.user_signed_up");
+            final var sentRecord = new UserSignedUp("joe blogs", "blogy@twasmail.com", 100);
 
-            // Then:
-            final var values = values(consumer);
-            assertThat("Should have received a record but got nothing", values, hasSize(1));
-            assertThat(values, contains(sentRecord));
+            try (Consumer<Long, UserSignedUp> consumer =
+                         avroConsumer(userSignedUpTopic, DIFFERENT_USER);
+                 Producer<Long, UserSignedUp> producer = avroProducer(OWNER_USER)) {
+
+                // When:
+                producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L, sentRecord))
+                        .get(60, TimeUnit.SECONDS);
+
+                // Then:
+                final var values = values(consumer);
+                assertThat("Should have received a record but got nothing", values, hasSize(1));
+                assertThat(values, contains(sentRecord));
+            }
         }
     }
 

--- a/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
@@ -228,8 +228,8 @@ class ClientsFunctionalDemoTest {
             final var sentRecord = new UserSignedUp("joe blogs", "blogy@twasmail.com", 100);
 
             try (Consumer<Long, UserSignedUp> consumer =
-                         avroConsumer(userSignedUpTopic, DIFFERENT_USER);
-                 Producer<Long, UserSignedUp> producer = avroProducer(OWNER_USER)) {
+                            avroConsumer(userSignedUpTopic, DIFFERENT_USER);
+                    Producer<Long, UserSignedUp> producer = avroProducer(OWNER_USER)) {
 
                 // When:
                 producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L, sentRecord))


### PR DESCRIPTION
Currently, running a JUnit5 test such as:

```java
class MyTest {
  @RegisterExtension
  private static final KafkaEnvironment KAFKA_ENV =
              DockerKafkaEnvironment.builder()
                      .build();

  @nested
  class InnerTest {
      // Blah...
  }
}
```

Won't work, as `DKE.setUp` gets called twice by JUnit. Once for the outer and once for the inner. Go figure.