### PR TITLE
Add support for key schemas

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,19 @@ channels:
     publish:
       message:
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
 
   _private.user_checkout:
     publish:
       message:
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
+          key:
+            type: long
+          value:
+             $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
 
 
   _protected.purchased:
@@ -142,7 +148,10 @@ Schema References are supported only by the Confluent Avro Serde. Common/Shared 
             key:
               type: string
         payload:
-          $ref: "/schema/com.example.shared.Currency.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/com.example.shared.Currency.avsc"
 ```
 
 More detail is provided below.
@@ -209,7 +218,10 @@ Source: com.example.trading-api.yml  (spec)
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/com.example.trading.Trade.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/com.example.trading.Trade.avsc"
 ```
 
 Trade.avsc references the _Currency_ .avsc schema (the shared schema type)
@@ -281,7 +293,10 @@ channels:
             key:
               type: string
         payload:
-          $ref: "/schema/com.example.shared.Currency.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/com.example.shared.Currency.avsc"
 ```
 
 

--- a/cli/resources/simple_schema_demo-api.yaml
+++ b/cli/resources/simple_schema_demo-api.yaml
@@ -37,13 +37,12 @@ channels:
           kafka:
             schemaIdLocation: "payload"
         payload:
-          properties:
-            key:
-              type: long
-            value:
-              schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
-              contentType: "application/octet-stream"
-              $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
+          key:
+            type: long
+          value:
+            schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
+            contentType: "application/octet-stream"
+            $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
 
   # PRODUCER/OWNER build pipe will publish schema to SR
   _public.user_checkout:
@@ -68,11 +67,10 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          properties:
-            key:
-              type: long
-            value:
-              $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
 
   # PRODUCER/OWNER build pipe will publish schema to SR
   _public.user_info:
@@ -98,11 +96,10 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          properties:
-            key:
-              type: long
-            value:
-              $ref: "/schema/simple.schema_demo._public.user_info.proto"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_info.proto"
   # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   london.hammersmith.transport._public.tube:
     subscribe:
@@ -119,7 +116,6 @@ channels:
             key:
               type: string
         payload:
-          properties:
           key:
             type: long
           value:

--- a/cli/resources/simple_schema_demo-api.yaml
+++ b/cli/resources/simple_schema_demo-api.yaml
@@ -36,10 +36,14 @@ channels:
         bindings:
           kafka:
             schemaIdLocation: "payload"
-        schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
-        contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
+          properties:
+            key:
+              type: long
+            value:
+              schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
+              contentType: "application/octet-stream"
+              $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
 
   # PRODUCER/OWNER build pipe will publish schema to SR
   _public.user_checkout:
@@ -64,8 +68,11 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
-
+          properties:
+            key:
+              type: long
+            value:
+              $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
 
   # PRODUCER/OWNER build pipe will publish schema to SR
   _public.user_info:
@@ -91,7 +98,11 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_info.proto"
+          properties:
+            key:
+              type: long
+            value:
+              $ref: "/schema/simple.schema_demo._public.user_info.proto"
   # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   london.hammersmith.transport._public.tube:
     subscribe:
@@ -108,6 +119,10 @@ channels:
             key:
               type: string
         payload:
-          # client should lookup this schema remotely from the schema registry - it is owned by the publisher
-          $ref: "london.hammersmith.transport._public.tube.passenger.avsc"
+          properties:
+          key:
+            type: long
+          value:
+            # client should lookup this schema remotely from the schema registry - it is owned by the publisher
+            $ref: "london.hammersmith.transport._public.tube.passenger.avsc"
 

--- a/cli/resources/simple_spec_demo-api.yaml
+++ b/cli/resources/simple_spec_demo-api.yaml
@@ -80,20 +80,23 @@ channels:
           name: "purchase"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: string
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the food
+              cost:
+                type: number
+                minimum: 0
+                description: GBP cost of the food item
+              human_id:
+                type: integer
+                minimum: 0
+                description: Id of the human purchasing the food
 
   # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   london.hammersmith.transport._public.tube:

--- a/cli/src/test/resources/simple_schema_demo-api.yaml
+++ b/cli/src/test/resources/simple_schema_demo-api.yaml
@@ -37,7 +37,10 @@ channels:
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
 
   # PRODUCER/OWNER build pipe will publish schema to SR
   _public.user_checkout:
@@ -62,7 +65,10 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
 
   # PRODUCER/OWNER build pipe will publish schema to SR
   _public.user_info:
@@ -88,7 +94,10 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_info.proto"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_info.proto"
   # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   .london.hammersmith.transport._public.tube:
     subscribe:
@@ -106,6 +115,9 @@ channels:
             key:
               type: string
         payload:
-          # client should lookup this schema remotely from the schema registry - it is owned by the publisher
-          $ref: "london.hammersmith.transport._public.tube.passenger.avsc"
+          key:
+            type: long
+          value:
+            # client should lookup this schema remotely from the schema registry - it is owned by the publisher
+            $ref: "london.hammersmith.transport._public.tube.passenger.avsc"
 

--- a/cli/src/test/resources/simple_spec_demo-api.yaml
+++ b/cli/src/test/resources/simple_spec_demo-api.yaml
@@ -80,20 +80,23 @@ channels:
           name: "purchase"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the food
+              cost:
+                type: number
+                minimum: 0
+                description: GBP cost of the food item
+              human_id:
+                type: integer
+                minimum: 0
+                description: Id of the human purchasing the food
 
   # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   /london/hammersmith/transport/_public/tube:

--- a/kafka-test/src/test/resources/kafka_test-simple_schema_demo-api.yaml
+++ b/kafka-test/src/test/resources/kafka_test-simple_schema_demo-api.yaml
@@ -38,7 +38,10 @@ channels:
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
 
   _public.user_signed_up_2:
     # publish bindings to instruct topic configuration per environment
@@ -63,7 +66,10 @@ channels:
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_signed_up_2.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_signed_up_2.avsc"
 
   # PRODUCER/OWNER build pipe will publish schema to SR
   _public.user_info:
@@ -88,7 +94,10 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/simple.schema_demo._public.user_info.proto"
+          key:
+            type: long
+          value:
+            $ref: "/simple.schema_demo._public.user_info.proto"
   # PRODUCER/OWNER build pipe will publish schema to SR
   _public.user_info_enriched:
     # publish bindings to instruct topic configuration per environment
@@ -114,7 +123,10 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/simple.schema_demo._public.user_info_enriched.proto"
+          key:
+            type: long
+          value:
+            $ref: "/simple.schema_demo._public.user_info_enriched.proto"
 # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   london.hammersmith.transport._public.tube:
     subscribe:
@@ -132,6 +144,9 @@ channels:
             key:
               type: string
         payload:
-          # client should lookup this schema remotely from the schema registry - it is owned by the publisher
-          $ref: "london.hammersmith.transport._public.tube.passenger.avsc"
+          key:
+            type: long
+          value:
+            # client should lookup this schema remotely from the schema registry - it is owned by the publisher
+            $ref: "london.hammersmith.transport._public.tube.passenger.avsc"
 

--- a/kafka/src/main/java/io/specmesh/kafka/Exporter.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Exporter.java
@@ -78,7 +78,7 @@ public final class Exporter {
     }
 
     /**
-     * Extract the Channel - todo Produce/Consume info
+     * Extract the Channel
      *
      * @param topic - kafka topic config map
      * @return decorated channel

--- a/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
+++ b/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
@@ -34,7 +34,9 @@ import static org.apache.kafka.common.resource.ResourceType.TRANSACTIONAL_ID;
 
 import io.specmesh.apiparser.AsyncApiParser;
 import io.specmesh.apiparser.model.ApiSpec;
-import io.specmesh.apiparser.model.SchemaInfo;
+import io.specmesh.apiparser.model.Channel;
+import io.specmesh.apiparser.model.Operation;
+import io.specmesh.apiparser.model.TopicSchema;
 import java.io.FileInputStream;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -42,8 +44,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -145,19 +149,20 @@ public final class KafkaApiSpec {
     }
 
     /**
-     * Get schema info for the supplied {@code topicName}
+     * Get schemas used for the supplied {@code topicName}.
      *
-     * @param topicName the name of the topic
-     * @return the schema info.
+     * @param topicName the name of the topic.
+     * @return the schemas the topic uses.
      */
-    public SchemaInfo schemaInfoForTopic(final String topicName) {
-        final List<NewTopic> myTopics = listDomainOwnedTopics();
-        myTopics.stream()
-                .filter(topic -> topic.name().equals(topicName))
-                .findFirst()
-                .orElseThrow(() -> new APIException("Not a domain topic:" + topicName));
+    public Stream<TopicSchema> schemasForTopic(final String topicName) {
+        final Channel channel = apiSpec.channels().get(topicName);
+        if (channel == null) {
+            throw new APIException("Unknown topic:" + topicName);
+        }
 
-        return apiSpec.channels().get(topicName).publish().schemaInfo();
+        return Stream.of(channel.publish(), channel.subscribe())
+                .filter(Objects::nonNull)
+                .flatMap(Operation::schemas);
     }
 
     /**

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaReaders.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaReaders.java
@@ -31,11 +31,9 @@ import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.Schema;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.SchemaProvisioningException;
-import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -59,38 +57,30 @@ public final class SchemaReaders {
 
     public static final class FileSystemSchemaReader {
 
-        public Collection<ParsedSchema> readLocal(final String filePath) {
+        public Collection<ParsedSchema> readLocal(final Path filePath) {
             try {
-                final var schemaContent = Files.readString(Paths.get(filePath));
+                final var schemaContent = Files.readString(filePath);
                 final var results = new ArrayList<ParsedSchema>();
 
-                if (filePath.endsWith(".avsc")) {
+                final String filename =
+                        filePath.getFileName() == null ? "" : filePath.getFileName().toString();
+                if (filename.endsWith(".avsc")) {
                     final var refs = resolveReferencesFor(filePath, schemaContent);
                     results.add(
                             new AvroSchema(
                                     schemaContent, refs.references, refs.resolvedReferences, -1));
-                }
-                if (filePath.endsWith(".yml")) {
+                } else if (filename.endsWith(".yml")) {
                     results.add(new JsonSchema(schemaContent));
-                }
-                if (filePath.endsWith(".proto")) {
+                } else if (filename.endsWith(".proto")) {
                     results.add(new ProtobufSchema(schemaContent));
+                } else {
+                    throw new UnsupportedOperationException("Unsupported schema file: " + filePath);
                 }
 
                 return results;
-            } catch (Throwable ex) {
-                try {
-                    throw new SchemaProvisioningException(
-                            "Failed to load: "
-                                    + filePath
-                                    + " from: "
-                                    + new File(".").getCanonicalFile().getAbsolutePath(),
-                            ex);
-                } catch (IOException e) {
-                    throw new RuntimeException(
-                            "Failed to read canonical path for file system:"
-                                    + new File(".").getAbsolutePath());
-                }
+            } catch (Exception ex) {
+                throw new SchemaProvisioningException(
+                        "Failed to load: " + filePath + " from: " + filePath.toAbsolutePath(), ex);
             }
         }
 
@@ -102,11 +92,11 @@ public final class SchemaReaders {
          * @return
          */
         private SchemaReferences resolveReferencesFor(
-                final String filePath, final String schemaContent) {
+                final Path filePath, final String schemaContent) {
             try {
                 final SchemaReferences results = new SchemaReferences();
                 final var refs = findJsonNodes(objectMapper.readTree(schemaContent), "subject");
-                final var parent = new File(filePath).getParent();
+                final var parent = filePath.toFile().getParent();
                 refs.forEach(ref -> results.add(parent, ref));
                 return results;
             } catch (JsonProcessingException e) {

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaReaders.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaReaders.java
@@ -40,6 +40,8 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -63,7 +65,9 @@ public final class SchemaReaders {
                 final var results = new ArrayList<ParsedSchema>();
 
                 final String filename =
-                        filePath.getFileName() == null ? "" : filePath.getFileName().toString();
+                        Optional.ofNullable(filePath.getFileName())
+                                .map(Objects::toString)
+                                .orElse("");
                 if (filename.endsWith(".avsc")) {
                     final var refs = resolveReferencesFor(filePath, schemaContent);
                     results.add(

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import io.specmesh.apiparser.model.SchemaInfo;
+import io.specmesh.apiparser.model.TopicSchema;
 import io.specmesh.test.TestSpecLoader;
 import java.util.Arrays;
 import java.util.List;
@@ -190,8 +190,13 @@ public class KafkaAPISpecTest {
 
     @Test
     public void shouldGetSchemaInfoForOwnedTopics() {
-        final List<NewTopic> newTopics = API_SPEC.listDomainOwnedTopics();
-        final SchemaInfo schemaInfo = API_SPEC.schemaInfoForTopic(newTopics.get(0).name());
-        assertThat(schemaInfo.schemaIdLocation(), is("header"));
+        final List<TopicSchema> topicSchemas =
+                API_SPEC.schemasForTopic(
+                                "london.hammersmith.olympia.bigdatalondon._public.attendee")
+                        .collect(Collectors.toList());
+        assertThat(topicSchemas, hasSize(1));
+        assertThat(topicSchemas.get(0).part(), is(TopicSchema.Part.value));
+        assertThat(topicSchemas.get(0).schemaRef(), is("/some/path"));
+        assertThat(topicSchemas.get(0).schemaLookupStrategy(), is("TopicNameStrategy"));
     }
 }

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecWithGrantAccessAclsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecWithGrantAccessAclsTest.java
@@ -22,7 +22,7 @@ import static org.hamcrest.Matchers.hasItems;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
-import io.specmesh.apiparser.model.SchemaInfo;
+import io.specmesh.apiparser.model.TopicSchema;
 import io.specmesh.test.TestSpecLoader;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -199,8 +199,12 @@ public class KafkaAPISpecWithGrantAccessAclsTest {
 
     @Test
     public void shouldGetSchemaInfoForOwnedTopics() {
-        final List<NewTopic> newTopics = API_SPEC.listDomainOwnedTopics();
-        final SchemaInfo schemaInfo = API_SPEC.schemaInfoForTopic(newTopics.get(0).name());
-        assertThat(schemaInfo.schemaIdLocation(), is("header"));
+        final List<TopicSchema> topicSchemas =
+                API_SPEC.schemasForTopic("london.hammersmith.olympia.bigdatalondon.attendee")
+                        .collect(Collectors.toList());
+        assertThat(topicSchemas, hasSize(1));
+        assertThat(topicSchemas.get(0).part(), is(TopicSchema.Part.key));
+        assertThat(topicSchemas.get(0).schemaRef(), is("/some/path"));
+        assertThat(topicSchemas.get(0).schemaLookupStrategy(), is("TopicNameStrategy"));
     }
 }

--- a/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
@@ -28,6 +28,7 @@ import io.specmesh.kafka.KafkaEnvironment;
 import io.specmesh.kafka.provision.Provisioner;
 import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.Schema;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -82,8 +83,8 @@ class SchemaChangeSetCalculatorsTest {
         assertThat(schemas.iterator().next().messages(), is(containsString("borked")));
     }
 
-    private static String filename(final String extra) {
-        return "./build/resources/test/schema/" + SCHEMA_FILENAME + extra;
+    private static Path filename(final String extra) {
+        return Path.of("./build/resources/test/schema/" + SCHEMA_FILENAME + extra);
     }
 
     static ParsedSchema getSchema(final String schemaRefType, final String content) {

--- a/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
@@ -19,13 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
-import io.confluent.kafka.schemaregistry.json.JsonSchema;
-import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.specmesh.kafka.DockerKafkaEnvironment;
 import io.specmesh.kafka.KafkaEnvironment;
-import io.specmesh.kafka.provision.Provisioner;
 import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.Schema;
 import java.nio.file.Path;
@@ -85,19 +80,5 @@ class SchemaChangeSetCalculatorsTest {
 
     private static Path filename(final String extra) {
         return Path.of("./build/resources/test/schema/" + SCHEMA_FILENAME + extra);
-    }
-
-    static ParsedSchema getSchema(final String schemaRefType, final String content) {
-
-        if (schemaRefType.endsWith(".avsc")) {
-            return new AvroSchema(content);
-        }
-        if (schemaRefType.endsWith(".yml")) {
-            return new JsonSchema(content);
-        }
-        if (schemaRefType.endsWith(".proto")) {
-            return new ProtobufSchema(content);
-        }
-        throw new Provisioner.ProvisioningException("Unsupported schema type");
     }
 }

--- a/kafka/src/test/resources/apispec-functional-test-app.yaml
+++ b/kafka/src/test/resources/apispec-functional-test-app.yaml
@@ -46,16 +46,19 @@ channels:
             schemaIdLocation: 'header'
             bindingVersion: '0.3.0'
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the human
+              age:
+                type: integer
+                minimum: 0
+                description: Age of the human
   _protected.retail.subway.food.purchase:
     bindings:
       kafka:
@@ -75,20 +78,23 @@ channels:
           name: "purchase"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the food
+              cost:
+                type: number
+                minimum: 0
+                description: GBP cost of the food item
+              human_id:
+                type: integer
+                minimum: 0
+                description: Id of the human purchasing the food
 
   _private.retail.subway.customers:
     bindings:
@@ -106,20 +112,23 @@ channels:
           name: "customer"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the food
+              cost:
+                type: number
+                minimum: 0
+                description: GBP cost of the food item
+              human_id:
+                type: integer
+                minimum: 0
+                description: Id of the human purchasing the food
 
 
   london.hammersmith.transport._public.tube:
@@ -129,13 +138,16 @@ channels:
       message:
         name: Human
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the human
+              age:
+                type: integer
+                minimum: 0
+                description: Age of the human

--- a/kafka/src/test/resources/bigdatalondon-api-with-grant-access-acls.yaml
+++ b/kafka/src/test/resources/bigdatalondon-api-with-grant-access-acls.yaml
@@ -50,16 +50,19 @@ channels:
             schemaIdLocation: 'header'
             bindingVersion: '0.3.0'
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            $ref: "/some/path"
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the human
+              age:
+                type: integer
+                minimum: 0
+                description: Age of the human
   #  protected
   retail.subway.food.purchase:
     bindings:
@@ -78,20 +81,23 @@ channels:
           name: "purchase"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the food
+              cost:
+                type: number
+                minimum: 0
+                description: GBP cost of the food item
+              human_id:
+                type: integer
+                minimum: 0
+                description: Id of the human purchasing the food
 
   # private
   retail.subway.customers:
@@ -108,20 +114,23 @@ channels:
           name: "customer"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the food
+              cost:
+                type: number
+                minimum: 0
+                description: GBP cost of the food item
+              human_id:
+                type: integer
+                minimum: 0
+                description: Id of the human purchasing the food
 
 
   # subscribing to another domains channel
@@ -131,13 +140,16 @@ channels:
       message:
         name: Human
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the human
+              age:
+                type: integer
+                minimum: 0
+                description: Age of the human

--- a/kafka/src/test/resources/bigdatalondon-api.yaml
+++ b/kafka/src/test/resources/bigdatalondon-api.yaml
@@ -46,16 +46,10 @@ channels:
             schemaIdLocation: 'header'
             bindingVersion: '0.3.0'
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            type: string
+          value:
+            $ref: "/some/path"
   _protected.retail.subway.food.purchase:
     bindings:
       kafka:
@@ -73,20 +67,26 @@ channels:
           name: "purchase"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: string
+          value:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                id:
+                  type: integer
+                  minimum: 0
+                  description: Id of the food
+                cost:
+                  type: number
+                  minimum: 0
+                  description: GBP cost of the food item
+                human_id:
+                  type: integer
+                  minimum: 0
+                  description: Id of the human purchasing the food
 
   _private.retail.subway.customers:
     bindings:
@@ -102,20 +102,26 @@ channels:
           name: "customer"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: string
+          value:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                id:
+                  type: integer
+                  minimum: 0
+                  description: Id of the food
+                cost:
+                  type: number
+                  minimum: 0
+                  description: GBP cost of the food item
+                human_id:
+                  type: integer
+                  minimum: 0
+                  description: Id of the human purchasing the food
 
 
   london.hammersmith.transport._public.tube:
@@ -124,13 +130,19 @@ channels:
       message:
         name: Human
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            type: string
+          value:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                id:
+                  type: integer
+                  minimum: 0
+                  description: Id of the human
+                age:
+                  type: integer
+                  minimum: 0
+                  description: Age of the human

--- a/kafka/src/test/resources/clientapi-functional-test-api.yaml
+++ b/kafka/src/test/resources/clientapi-functional-test-api.yaml
@@ -39,7 +39,10 @@ channels:
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
 
   _protected.user_info:
     bindings:
@@ -66,4 +69,7 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/schema/simple.schema_demo._public.user_info.proto"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.schema_demo._public.user_info.proto"

--- a/kafka/src/test/resources/customacl-bigdatalondon-api.yaml
+++ b/kafka/src/test/resources/customacl-bigdatalondon-api.yaml
@@ -46,16 +46,19 @@ channels:
             schemaIdLocation: 'header'
             bindingVersion: '0.3.0'
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the human
+              age:
+                type: integer
+                minimum: 0
+                description: Age of the human
   zzprotected.retail.subway.food.purchase:
     bindings:
       kafka:
@@ -73,20 +76,23 @@ channels:
           name: "purchase"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the food
+              cost:
+                type: number
+                minimum: 0
+                description: GBP cost of the food item
+              human_id:
+                type: integer
+                minimum: 0
+                description: Id of the human purchasing the food
 
   zzprivate.retail.subway.customers:
     bindings:
@@ -102,20 +108,23 @@ channels:
           name: "customer"
         ]
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the food
-            cost:
-              type: number
-              minimum: 0
-              description: GBP cost of the food item
-            human_id:
-              type: integer
-              minimum: 0
-              description: Id of the human purchasing the food
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the food
+                cost:
+                  type: number
+                  minimum: 0
+                  description: GBP cost of the food item
+                human_id:
+                  type: integer
+                  minimum: 0
+                  description: Id of the human purchasing the food
 
 
   london.hammersmith.transport._public.tube:
@@ -124,13 +133,16 @@ channels:
       message:
         name: Human
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the human
+              age:
+                type: integer
+                minimum: 0
+                description: Age of the human

--- a/kafka/src/test/resources/provisioner-functional-test-api.yaml
+++ b/kafka/src/test/resources/provisioner-functional-test-api.yaml
@@ -39,7 +39,10 @@ channels:
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/simple.provision_demo._public.user_signed_up.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.provision_demo._public.user_signed_up.avsc"
 
   _protected.user_info:
     bindings:
@@ -66,4 +69,7 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/schema/simple.provision_demo._public.user_info.proto"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.provision_demo._public.user_info.proto"

--- a/kafka/src/test/resources/provisioner-update-functional-test-api.yaml
+++ b/kafka/src/test/resources/provisioner-update-functional-test-api.yaml
@@ -38,7 +38,10 @@ channels:
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/simple.provision_demo._public.user_signed_up-v2.avsc"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.provision_demo._public.user_signed_up-v2.avsc"
   _protected.user_info:
     bindings:
       kafka:
@@ -65,4 +68,7 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/schema/simple.provision_demo._public.user_info.proto"
+          key:
+            type: long
+          value:
+            $ref: "/schema/simple.provision_demo._public.user_info.proto"

--- a/kafka/src/test/resources/schema-ref/com.example.shared-api.yml
+++ b/kafka/src/test/resources/schema-ref/com.example.shared-api.yml
@@ -31,5 +31,8 @@ channels:
             key:
               type: string
         payload:
-          $ref: "/schema/com.example.shared.Currency.avsc"
+          key:
+            type: uuid
+          value:
+            $ref: "/schema/com.example.shared.Currency.avsc"
 

--- a/kafka/src/test/resources/schema-ref/com.example.trading-api.yml
+++ b/kafka/src/test/resources/schema-ref/com.example.trading-api.yml
@@ -33,13 +33,14 @@ channels:
         bindings:
           kafka:
             schemaIdLocation: "header"
-            key:
-              type: string
 
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/com.example.trading.Trade.avsc"
+          key:
+            type: uuid
+          value:
+            $ref: "/schema/com.example.trading.Trade.avsc"
 
 
   # schema reference to - referenced here for topology reasons - schema also referenced from Trade.avsc
@@ -56,8 +57,9 @@ channels:
         bindings:
           kafka:
             schemaIdLocation: "header"
-            key:
-              type: string
         payload:
-          $ref: "/schema/com.example.shared.Currency.avsc"
+          key:
+            type: string
+          value:
+            $ref: "/schema/com.example.shared.Currency.avsc"
 

--- a/parser/src/main/java/io/specmesh/apiparser/model/Message.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Message.java
@@ -21,6 +21,7 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
@@ -40,7 +41,7 @@ public final class Message {
 
     @JsonProperty private Map headers;
 
-    @JsonProperty private Map payload;
+    @JsonProperty private Payload payload;
 
     @JsonProperty private Map correlationId;
 
@@ -70,7 +71,7 @@ public final class Message {
         this.tags = List.of();
         this.traits = Map.of();
         this.messageId = null;
-        this.payload = Map.of();
+        this.payload = null;
         this.name = null;
         this.title = null;
         this.summary = null;
@@ -79,9 +80,13 @@ public final class Message {
     }
 
     /**
-     * @return the location of the schema
+     * @return The schemas in use
      */
-    public String schemaRef() {
-        return (String) payload.get("$ref");
+    public Stream<TopicSchema> schemas() {
+        if (payload == null) {
+            return Stream.empty();
+        }
+
+        return payload.schemas(bindings.kafka().schemaLookupStrategy());
     }
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
@@ -22,6 +22,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.specmesh.apiparser.AsyncApiParser.APIParserException;
 import java.util.List;
 import java.util.Map;
+import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -54,10 +55,7 @@ public class Operation {
 
     @JsonProperty private String description;
 
-    @SuppressWarnings("rawtypes")
-    @JsonProperty
-    @Builder.Default
-    private List<Tag> tags = List.of();
+    @JsonProperty @Builder.Default private List<Tag> tags = List.of();
 
     @JsonProperty private Bindings bindings;
 
@@ -67,30 +65,19 @@ public class Operation {
     @JsonProperty private Message message;
 
     /**
-     * @return schema info
+     * @return The schemas in use
      */
-    public SchemaInfo schemaInfo() {
-        if (message.bindings() == null) {
-            throw new APIParserException(
-                    "Bindings not found for (publish|subscribe) operation: " + operationId);
+    public Stream<TopicSchema> schemas() {
+        if (message == null) {
+            return Stream.empty();
         }
-        return new SchemaInfo(
-                message().schemaRef(),
-                message().schemaFormat(),
-                message.bindings().kafka().schemaIdLocation(),
-                message().contentType(),
-                message.bindings().kafka().schemaLookupStrategy());
+
+        return message.schemas();
     }
 
     public void validate() {
         if (operationId == null) {
             throw new APIParserException("(publish|subscribe) operationId  is null");
         }
-    }
-
-    public boolean isSchemaRequired() {
-        return this.message() != null
-                && this.message().schemaRef() != null
-                && this.message().schemaRef().length() > 0;
     }
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/Payload.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Payload.java
@@ -1,0 +1,238 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.specmesh.apiparser.AsyncApiParser;
+import io.specmesh.apiparser.util.JsonLocation;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import lombok.Value;
+import lombok.experimental.Accessors;
+
+@Value
+@Accessors(fluent = true)
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class Payload {
+
+    private final PayloadPart key;
+    private final PayloadPart value;
+
+    public Payload(
+            @JsonProperty(value = "key", required = true) final PayloadPart key,
+            @JsonProperty(value = "value", required = true) final PayloadPart value) {
+        this.key = requireNonNull(key, "key");
+        this.value = requireNonNull(value, "value");
+    }
+
+    public PayloadPart key() {
+        return key;
+    }
+
+    public PayloadPart value() {
+        return value;
+    }
+
+    /**
+     * @return The schemas in use
+     */
+    public Stream<TopicSchema> schemas(final String defaultSchemaLookupStrategy) {
+        final Optional<TopicSchema> keySchema =
+                key.schemaRef()
+                        .map(
+                                ref ->
+                                        new TopicSchema(
+                                                TopicSchema.Part.key,
+                                                ref,
+                                                defaultSchemaLookupStrategy));
+
+        final Optional<TopicSchema> valSchema =
+                value.schemaRef()
+                        .map(
+                                ref ->
+                                        new TopicSchema(
+                                                TopicSchema.Part.value,
+                                                ref,
+                                                defaultSchemaLookupStrategy));
+
+        return Stream.of(keySchema, valSchema).flatMap(Optional::stream);
+    }
+
+    @JsonDeserialize(using = PayloadPartDeserializer.class)
+    public interface PayloadPart {
+        /**
+         * @return reference to an external schema file.
+         */
+        default Optional<String> schemaRef() {
+            return Optional.empty();
+        }
+    }
+
+    @Value
+    public static final class KafkaPart implements PayloadPart {
+        // Types supported by for standard Kafka serializers:
+        public enum KafkaType {
+            UUID("uuid"),
+            Long("long"),
+            Int("int"),
+            Short("short"),
+            Float("float"),
+            Double("double"),
+            String("string"),
+            Bytes("bytes"),
+            Void("void");
+
+            private static final String VALID_VALUES =
+                    Arrays.stream(values())
+                            .map(KafkaType::toString)
+                            .collect(Collectors.joining(", ", "[", "]"));
+
+            private final String text;
+
+            KafkaType(final String text) {
+                this.text = requireNonNull(text, "text");
+            }
+
+            @JsonValue
+            @Override
+            public String toString() {
+                return text;
+            }
+
+            public static KafkaType fromText(final String text) {
+                return Arrays.stream(values())
+                        .filter(t -> t.text.equals(text))
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Unknown KafkaType: "
+                                                        + text
+                                                        + ". Valid values are: "
+                                                        + VALID_VALUES));
+            }
+        }
+
+        private final KafkaType kafkaType;
+
+        public KafkaPart(final KafkaType kafkaType) {
+            this.kafkaType = requireNonNull(kafkaType, "kafkaType");
+        }
+    }
+
+    @Value
+    public static final class SchemaRefPart implements PayloadPart {
+        private final String schemaRef;
+
+        SchemaRefPart(final String schemaRef) {
+            this.schemaRef = requireNonNull(schemaRef, "schemaRef");
+        }
+
+        public Optional<String> schemaRef() {
+            return Optional.of(schemaRef);
+        }
+    }
+
+    @Value
+    public static final class OtherPart implements PayloadPart {
+        private final JsonNode node;
+
+        OtherPart(final JsonNode node) {
+            this.node = requireNonNull(node, "node");
+        }
+    }
+
+    private static class PayloadPartDeserializer extends JsonDeserializer<PayloadPart> {
+
+        private static final String REF_FIELD = "$ref";
+        private static final String TYPE_FIELD = "type";
+
+        @Override
+        public PayloadPart deserialize(final JsonParser parser, final DeserializationContext ctx)
+                throws IOException {
+            final URI location = JsonLocation.location(parser);
+
+            if (parser.currentToken() != JsonToken.START_OBJECT) {
+                throw new AsyncApiParser.APIParserException(
+                        "Payload part should be an object with either "
+                                + REF_FIELD
+                                + " or "
+                                + TYPE_FIELD
+                                + ", but not both. location: "
+                                + location);
+            }
+
+            parser.nextToken();
+
+            Optional<String> ref = Optional.empty();
+            Optional<String> type = Optional.empty();
+            JsonNode props = ctx.getNodeFactory().objectNode();
+
+            while (parser.currentToken() != JsonToken.END_OBJECT) {
+                final String fieldName = parser.currentName();
+                parser.nextToken();
+
+                switch (fieldName) {
+                    case REF_FIELD:
+                        ref = Optional.of(ctx.readValue(parser, String.class));
+                        break;
+                    case TYPE_FIELD:
+                        type = Optional.of(ctx.readValue(parser, String.class));
+                        break;
+                    case "properties":
+                        props = ctx.readTree(parser);
+                        break;
+                    default:
+                        ctx.readTree(parser);
+                        break;
+                }
+
+                parser.nextToken();
+            }
+
+            if (ref.isPresent() && type.isPresent()) {
+                throw new AsyncApiParser.APIParserException(
+                        "Payload part requires either "
+                                + REF_FIELD
+                                + " or "
+                                + TYPE_FIELD
+                                + ", but not both. location: "
+                                + location);
+            }
+
+            return ref.isPresent()
+                    ? new SchemaRefPart(ref.get())
+                    : type.filter(t -> !t.equals("object")).isPresent()
+                            ? new KafkaPart(KafkaPart.KafkaType.fromText(type.get()))
+                            : new OtherPart(props);
+        }
+    }
+}

--- a/parser/src/main/java/io/specmesh/apiparser/model/Payload.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Payload.java
@@ -62,26 +62,23 @@ public class Payload {
     }
 
     /**
+     * @param schemaLookupStrategy the schema lookup strategy
      * @return The schemas in use
      */
-    public Stream<TopicSchema> schemas(final String defaultSchemaLookupStrategy) {
+    public Stream<TopicSchema> schemas(final String schemaLookupStrategy) {
         final Optional<TopicSchema> keySchema =
                 key.schemaRef()
                         .map(
                                 ref ->
                                         new TopicSchema(
-                                                TopicSchema.Part.key,
-                                                ref,
-                                                defaultSchemaLookupStrategy));
+                                                TopicSchema.Part.key, ref, schemaLookupStrategy));
 
         final Optional<TopicSchema> valSchema =
                 value.schemaRef()
                         .map(
                                 ref ->
                                         new TopicSchema(
-                                                TopicSchema.Part.value,
-                                                ref,
-                                                defaultSchemaLookupStrategy));
+                                                TopicSchema.Part.value, ref, schemaLookupStrategy));
 
         return Stream.of(keySchema, valSchema).flatMap(Optional::stream);
     }

--- a/parser/src/main/java/io/specmesh/apiparser/model/TopicSchema.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/TopicSchema.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.model;
+
+import static java.util.Objects.requireNonNull;
+
+public final class TopicSchema {
+
+    public enum Part {
+        key,
+        value
+    };
+
+    private final Part part;
+    private final String schemaRef;
+    private final String lookupStrategy;
+
+    public TopicSchema(final Part part, final String schemaRef, final String lookupStrategy) {
+        this.part = requireNonNull(part, "part");
+        this.schemaRef = requireNonNull(schemaRef, "schemaRef");
+        this.lookupStrategy = requireNonNull(lookupStrategy, "lookupStrategy");
+    }
+
+    public Part part() {
+        return part;
+    }
+
+    public String schemaRef() {
+        return schemaRef;
+    }
+
+    public String schemaLookupStrategy() {
+        return lookupStrategy;
+    }
+}

--- a/parser/src/main/java/io/specmesh/apiparser/model/TopicSchema.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/TopicSchema.java
@@ -23,7 +23,7 @@ public final class TopicSchema {
     public enum Part {
         key,
         value
-    };
+    }
 
     private final Part part;
     private final String schemaRef;

--- a/parser/src/main/java/io/specmesh/apiparser/util/JsonLocation.java
+++ b/parser/src/main/java/io/specmesh/apiparser/util/JsonLocation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import java.io.File;
+import java.net.URI;
+
+/**
+ * Util class for determining the current location within a JSON/YAML file being parsed.
+ *
+ * <p>Locations are in the URI form: {@code file:///path/to/file.yml:<line number>}.
+ */
+public final class JsonLocation {
+
+    private static final URI UNKNOWN = URI.create("unknown");
+
+    private JsonLocation() {}
+
+    /**
+     * Get the current location from the parser.
+     *
+     * @param parser the parser.
+     * @return the current location.
+     */
+    public static URI location(final JsonParser parser) {
+        return location(parser.currentLocation());
+    }
+
+    /**
+     * Get the location from the Jackson location
+     *
+     * @param location the Jackson location
+     * @return the location.
+     */
+    public static URI location(final com.fasterxml.jackson.core.JsonLocation location) {
+        final Object content = location.contentReference().getRawContent();
+        if (!(content instanceof File)) {
+            return UNKNOWN;
+        }
+
+        final String filePath =
+                ((File) content).toURI().toString().replaceFirst("file:/", "file:///");
+
+        return URI.create(filePath + ":" + location.getLineNr());
+    }
+}

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
@@ -25,6 +25,7 @@ import io.specmesh.apiparser.model.ApiSpec;
 import io.specmesh.apiparser.model.Channel;
 import io.specmesh.apiparser.model.Operation;
 import java.util.Map;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
 public class AsyncApiSchemaParserTest {
@@ -42,14 +43,15 @@ public class AsyncApiSchemaParserTest {
 
         final Operation publish =
                 channelsMap.get(".simple.schema-demo._public.user.signed").publish();
-        assertThat(publish.message().schemaRef(), is("simple_schema_demo_user-signedup.avsc"));
+        assertThat(
+                publish.message().payload().value().schemaRef(),
+                is(Optional.of("simple_schema_demo_user-signedup.avsc")));
 
         assertThat(
                 publish.message().schemaFormat(),
                 is("application/vnd.apache.avro+json;version=1.9.0"));
         assertThat(publish.message().contentType(), is("application/octet-stream"));
         assertThat(publish.message().bindings().kafka().schemaIdLocation(), is("payload"));
-        assertThat(publish.schemaInfo().schemaIdLocation(), is("payload"));
     }
 
     @Test
@@ -64,8 +66,8 @@ public class AsyncApiSchemaParserTest {
         final Operation subscribe =
                 channelsMap.get("london.hammersmith.transport._public.tube").subscribe();
         assertThat(
-                subscribe.message().schemaRef(),
-                is("london_hammersmith_transport_public_passenger.avsc"));
+                subscribe.message().payload().value().schemaRef(),
+                is(Optional.of("london_hammersmith_transport_public_passenger.avsc")));
         assertThat(
                 subscribe.message().schemaFormat(),
                 is("application/vnd.apache.avro+json;version=1.9.0"));

--- a/parser/src/test/java/io/specmesh/apiparser/model/PayloadTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/model/PayloadTest.java
@@ -1,0 +1,266 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.specmesh.apiparser.model.Payload.KafkaPart.KafkaType;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class PayloadTest {
+
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    @Test
+    void shouldThrowIfNoKey() {
+        // Given:
+        final String json =
+                "{\n" + "  \"value\": {\n" + "    \"type\": \"string\"\n" + "  }\n" + "}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        JsonMappingException.class, () -> MAPPER.readValue(json, Payload.class));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Missing required creator property 'key'"));
+    }
+
+    @Test
+    void shouldThrowIfNoValue() {
+        // Given:
+        final String json = "{\n" + "  \"key\": {\n" + "    \"type\": \"string\"\n" + "  }" + "}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        JsonMappingException.class, () -> MAPPER.readValue(json, Payload.class));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("Missing required creator property 'value'"));
+    }
+
+    @Test
+    void shouldThrowIfBothRefAndTypeDefined() {
+        // Given:
+        final String json =
+                "{\n"
+                        + "  \"key\": {\n"
+                        + "    \"type\": \"string\",\n"
+                        + "    \"$ref\": \"/some/path\"\n"
+                        + "  },\n"
+                        + "  \"value\": {\n"
+                        + "    \"type\": \"string\"\n"
+                        + "  }\n"
+                        + "}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        JsonMappingException.class, () -> MAPPER.readValue(json, Payload.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                startsWith(
+                        "Payload part requires either $ref or type, but not both. location:"
+                                + " unknown"));
+    }
+
+    @Test
+    void shouldThrowOnUnknownKafkaType() {
+        // Given:
+        final String json =
+                "{\n"
+                        + "  \"key\": {\n"
+                        + "    \"type\": \"not-valid\"\n"
+                        + "  },\n"
+                        + "  \"value\": {\n"
+                        + "    \"type\": \"string\"\n"
+                        + "  }\n"
+                        + "}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        JsonMappingException.class, () -> MAPPER.readValue(json, Payload.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                containsString(
+                        "Unknown KafkaType: not-valid. Valid values are: "
+                                + "[uuid, long, int, short, float, double, string, bytes, void]"));
+    }
+
+    @Test
+    void shouldThrowOnPrimitivePart() {
+        // Given:
+        final String json =
+                "{\n"
+                        + "  \"key\": {\n"
+                        + "    \"type\": \"int\"\n"
+                        + "  },\n"
+                        + "  \"value\": 10\n"
+                        + "  }\n"
+                        + "}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        JsonMappingException.class, () -> MAPPER.readValue(json, Payload.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                containsString(
+                        "Payload part should be an object with either $ref or type, but not both"));
+    }
+
+    @Test
+    void shouldThrowOnArrayPart() {
+        // Given:
+        final String json =
+                "{\n"
+                        + "  \"key\": {\n"
+                        + "    \"type\": \"int\"\n"
+                        + "  },\n"
+                        + "  \"value\": [ \"type\", \"int\" ]\n"
+                        + "}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        JsonMappingException.class, () -> MAPPER.readValue(json, Payload.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                containsString(
+                        "Payload part should be an object with either $ref or type, but not both"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(KafkaType.class)
+    void shouldDeserializeKafkaTypeKey(final KafkaType keyType) throws Exception {
+        // Given:
+        final String json =
+                "{\n"
+                        + "  \"key\": {\n"
+                        + "    \"type\": \""
+                        + keyType.toString()
+                        + "\"\n"
+                        + "  },\n"
+                        + "  \"value\": {\n"
+                        + "    \"type\": \"string\"\n"
+                        + "  }\n"
+                        + "}";
+
+        // When:
+        final Payload result = MAPPER.readValue(json, Payload.class);
+
+        // Then:
+        assertThat(result.key(), is(new Payload.KafkaPart(keyType)));
+    }
+
+    @ParameterizedTest
+    @EnumSource(KafkaType.class)
+    void shouldDeserializeKafkaTypeValue(final KafkaType valueType) throws Exception {
+        // Given:
+        final String json =
+                "{\n"
+                        + "  \"key\": {\n"
+                        + "    \"type\": \"string\"\n"
+                        + "  },\n"
+                        + "  \"value\": {\n"
+                        + "    \"type\": \""
+                        + valueType.toString()
+                        + "\"\n"
+                        + "  }\n"
+                        + "}";
+
+        // When:
+        final Payload result = MAPPER.readValue(json, Payload.class);
+
+        // Then:
+        assertThat(result.value(), is(new Payload.KafkaPart(valueType)));
+    }
+
+    @Test
+    void shouldDeserializeSchemaRef() throws Exception {
+        // Given:
+        final String json =
+                "{\n"
+                        + "  \"key\": {\n"
+                        + "    \"$ref\": \"/some/path/key.avsc\"\n"
+                        + "  },\n"
+                        + "  \"value\": {\n"
+                        + "    \"$ref\": \"/some/path/value.avsc\"\n"
+                        + "  }\n"
+                        + "}";
+
+        // When:
+        final Payload result = MAPPER.readValue(json, Payload.class);
+
+        // Then:
+        assertThat(result.key().schemaRef(), is(Optional.of("/some/path/key.avsc")));
+        assertThat(result.value().schemaRef(), is(Optional.of("/some/path/value.avsc")));
+    }
+
+    @Test
+    void shouldDeserializeInlineSchema() throws Exception {
+        // Given:
+        final String json =
+                "{\n"
+                        + "  \"key\": {\n"
+                        + "    \"type\": \"object\",\n"
+                        + "    \"properties\": {\n"
+                        + "      \"name\": {\n"
+                        + "        \"type\": \"string\"\n"
+                        + "      }\n"
+                        + "    }\n"
+                        + "  },\n"
+                        + "  \"value\": {\n"
+                        + "    \"properties\": {\n"
+                        + "      \"id\": {\n"
+                        + "        \"type\": \"integer\"\n"
+                        + "      }\n"
+                        + "    },\n"
+                        + "    \"type\": \"object\"\n"
+                        + "  }\n"
+                        + "}";
+
+        // When:
+        final Payload payload = MAPPER.readValue(json, Payload.class);
+
+        // Then:
+        assertThat(payload.key(), is(instanceOf(Payload.OtherPart.class)));
+        assertThat(payload.value(), is(instanceOf(Payload.OtherPart.class)));
+        assertThat(payload.key().schemaRef(), is(Optional.empty()));
+        assertThat(payload.value().schemaRef(), is(Optional.empty()));
+    }
+}

--- a/parser/src/test/java/io/specmesh/apiparser/util/JsonLocationTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/util/JsonLocationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JsonLocationTest {
+
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper().enable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
+
+    @TempDir private Path testDir;
+
+    @Test
+    void shouldGetLocationIfParsingFile() throws Exception {
+        // Given:
+        final String json = "{\"k\": \"v\"}";
+        final Path file = testDir.resolve("test.yml");
+        Files.writeString(file, json);
+
+        // When:
+        final TestThing result = MAPPER.readValue(file.toFile(), TestThing.class);
+
+        // Then:
+        final String location = result.location.toString();
+        assertThat(location, startsWith("file:///"));
+        assertThat(location, endsWith("/test.yml:1"));
+    }
+
+    @Test
+    void shouldNotGetLocationIfParsingText() throws Exception {
+        // Given:
+        final String json = "{\"k\": \"v\"}";
+
+        // When:
+        final TestThing result = MAPPER.readValue(json, TestThing.class);
+
+        // Then:
+        assertThat(result.location, is(URI.create("unknown")));
+    }
+
+    @JsonDeserialize(using = JsonLocationTest.ThingDeserializer.class)
+    public static final class TestThing {
+
+        private final URI location;
+
+        TestThing(final URI location) {
+            this.location = location;
+        }
+    }
+
+    public static final class ThingDeserializer extends JsonDeserializer<TestThing> {
+        @Override
+        public TestThing deserialize(final JsonParser p, final DeserializationContext ctx)
+                throws IOException {
+            p.nextFieldName();
+            final URI location = JsonLocation.location(p);
+            p.nextTextValue();
+            return new TestThing(location);
+        }
+    }
+}

--- a/parser/src/test/resources/parser_simple_schema_demo-api.yaml
+++ b/parser/src/test/resources/parser_simple_schema_demo-api.yaml
@@ -37,7 +37,10 @@ channels:
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "simple_schema_demo_user-signedup.avsc"
+          key:
+            type: string
+          value:
+            $ref: "simple_schema_demo_user-signedup.avsc"
 
 # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   london.hammersmith.transport._public.tube:
@@ -52,9 +55,10 @@ channels:
         bindings:
           kafka:
             schemaIdLocation: "header"
-            key:
-              type: string
         payload:
-          # client should lookup this schema remotely from the schema registry - it is owned by the publisher
-          $ref: "london_hammersmith_transport_public_passenger.avsc"
+          key:
+            type: string
+          value:
+            # client should lookup this schema remotely from the schema registry - it is owned by the publisher
+            $ref: "london_hammersmith_transport_public_passenger.avsc"
 

--- a/parser/src/test/resources/streetlights-simple-api.yaml
+++ b/parser/src/test/resources/streetlights-simple-api.yaml
@@ -21,33 +21,39 @@ channels:
       message:
         name: LightMeasured
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the streetlight.
-            lumens:
-              type: integer
-              minimum: 0
-              description: Light intensity measured in lumens.
-            sentAt:
-              type: string
-              format: date-time
-              description: Date and time when the message was sent.
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the streetlight.
+              lumens:
+                type: integer
+                minimum: 0
+                description: Light intensity measured in lumens.
+              sentAt:
+                type: string
+                format: date-time
+                description: Date and time when the message was sent.
   london.hammersmith.transport.public.tube:
     subscribe:
       summary: Humans arriving in the borough
       message:
         name: Human
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            type: long
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the human
+              age:
+                type: integer
+                minimum: 0
+                description: Age of the human

--- a/parser/src/test/resources/test-streetlights-simple-api.yaml
+++ b/parser/src/test/resources/test-streetlights-simple-api.yaml
@@ -114,21 +114,18 @@ channels:
           key:
             type: object
             properties:
-              key:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the streetlight.
+              lumens:
+                type: integer
+                minimum: 0
+                description: Light intensity measured in lumens.
+              sentAt:
                 type: string
-              value:
-                id:
-                  type: integer
-                  minimum: 0
-                  description: Id of the streetlight.
-                lumens:
-                  type: integer
-                  minimum: 0
-                  description: Light intensity measured in lumens.
-                sentAt:
-                  type: string
-                  format: date-time
-                  description: Date and time when the message was sent.
+                format: date-time
+                description: Date and time when the message was sent.
           value:
             $ref: "/schema/com.example.shared.Currency.avsc"
 

--- a/parser/src/test/resources/test-streetlights-simple-api.yaml
+++ b/parser/src/test/resources/test-streetlights-simple-api.yaml
@@ -37,20 +37,23 @@ channels:
           - name: "big data london"
             description: "data mesh thing"
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the streetlight.
-            lumens:
-              type: integer
-              minimum: 0
-              description: Light intensity measured in lumens.
-            sentAt:
-              type: string
-              format: date-time
-              description: Date and time when the message was sent.
+          key:
+            type: string
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the streetlight.
+              lumens:
+                type: integer
+                minimum: 0
+                description: Light intensity measured in lumens.
+              sentAt:
+                type: string
+                format: date-time
+                description: Date and time when the message was sent.
   london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
@@ -60,13 +63,72 @@ channels:
       message:
         name: Human
         payload:
-          type: object
-          properties:
-            id:
-              type: integer
-              minimum: 0
-              description: Id of the human
-            age:
-              type: integer
-              minimum: 0
-              description: Age of the human
+          key:
+            type: string
+          value:
+            type: object
+            properties:
+              id:
+                type: integer
+                minimum: 0
+                description: Id of the human
+              age:
+                type: integer
+                minimum: 0
+                description: Age of the human
+  _public.avro.key:
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 3
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+
+    publish:
+      operationId: avroKeyed
+      message:
+        payload:
+          key:
+            $ref: "/schema/com.example.shared.Currency.avsc"
+          value:
+            type: int
+
+  _public.avro.value:
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 3
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+
+    publish:
+      operationId: avroKeyed
+      message:
+        payload:
+          key:
+            type: object
+            properties:
+              key:
+                type: string
+              value:
+                id:
+                  type: integer
+                  minimum: 0
+                  description: Id of the streetlight.
+                lumens:
+                  type: integer
+                  minimum: 0
+                  description: Light intensity measured in lumens.
+                sentAt:
+                  type: string
+                  format: date-time
+                  description: Date and time when the message was sent.
+          value:
+            $ref: "/schema/com.example.shared.Currency.avsc"
+


### PR DESCRIPTION
fixes: #301

BREAKING CHANGE

With Kafka, different parts of the message payload, i.e. the Kafka record, can have type and schema information associated with them.  Most people think of the record value, but there is also the key to think about, and in the future the headers.

This change seeings support for providing type & schema information for the key of each Kafka record in a topic.  This is done by requiring the message payload to define both a `key` and `value` section. Hence this is a BREAKING CHANGE.

Previously, the value schema could be supplied via a reference:

```yaml
  message:
    payload:
      $ref: "/schema/value.avsc"
```

To support key schemas this is now achieved by changing the spec to:

```yaml
  message:
    payload:
      key:
        $ref: "/schema/key.avsc"
      value:
        $ref: "/schema/value.avsc"
```

The key, or indeed the value, can also be defined as holding one of the inbuilt Kafka types, i.e. types for which most Kafka clients provide serializers out of the box, e.g.

```yaml
  message:
    payload:
      key:
        type: string
      value:
        $ref: "/schema/value.avsc"
```

Support for inline schemas for both key and value remains, however, the provisioning of inline schemas is still unsupported.
