### PR TITLE
Support key schemas and types

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,12 +43,20 @@ channels:
 
     publish:
       message:
+        bindings:
+          kafka:
+            key:
+              type: long
         payload:
           $ref: "/schema/simple.schema_demo._public.user_signed_up.avsc"
 
   _private.user_checkout:
     publish:
       message:
+        bindings:
+          kafka:
+            key:
+              $ref: "/schema/simple.schema_demo._public.user_checkout_key.yml"
         payload:
           $ref: "/schema/simple.schema_demo._public.user_checkout.yml"
 
@@ -76,6 +84,8 @@ channels:
 
 2.2. Schema published:
 - /schema/simple.schema_demo._public.user_signed_up.avsc
+- /schema/simple.schema_demo._public.user_checkout_key.yml
+- /schema/simple.schema_demo._public.user_checkout.yml
 
 2.3. ACLs created:
 - "name" : "(pattern=ResourcePattern(resourceType=TOPIC, name=simple.spec_demo._public, patternType=PREFIXED), entry=(principal=User:*, host=*, operation=READ, permissionType=ALLOW))",

--- a/cli/resources/simple_schema_demo-api.yaml
+++ b/cli/resources/simple_schema_demo-api.yaml
@@ -35,6 +35,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
@@ -60,6 +62,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
@@ -87,6 +91,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"

--- a/cli/src/main/java/io/specmesh/cli/Export.java
+++ b/cli/src/main/java/io/specmesh/cli/Export.java
@@ -20,10 +20,10 @@ import static picocli.CommandLine.Command;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.specmesh.apiparser.model.ApiSpec;
+import io.specmesh.apiparser.parse.SpecMapper;
 import io.specmesh.kafka.Clients;
 import io.specmesh.kafka.Exporter;
 import java.util.Map;
@@ -92,7 +92,7 @@ public class Export implements Callable<Integer> {
         try (Admin adminClient = Clients.adminClient(brokerUrl, username, secret)) {
             final var apiSpec = Exporter.export(aggid, adminClient);
             final var mapper =
-                    new ObjectMapper()
+                    SpecMapper.mapper()
                             .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
                             .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
             System.out.println(mapper.writeValueAsString(apiSpec));

--- a/cli/src/main/java/io/specmesh/cli/Flatten.java
+++ b/cli/src/main/java/io/specmesh/cli/Flatten.java
@@ -20,10 +20,9 @@ import static picocli.CommandLine.Command;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
-import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import io.specmesh.apiparser.parse.SpecMapper;
 import io.specmesh.kafka.KafkaApiSpec;
 import java.io.FileOutputStream;
 import java.nio.charset.StandardCharsets;
@@ -73,7 +72,7 @@ public class Flatten implements Callable<Integer> {
         final var apiSpec = apiSpec1.apiSpec();
 
         final var mapper =
-                new ObjectMapper(new YAMLFactory())
+                SpecMapper.mapper()
                         .setVisibility(PropertyAccessor.FIELD, JsonAutoDetect.Visibility.ANY)
                         .disable(SerializationFeature.FAIL_ON_EMPTY_BEANS);
         final var channels = apiSpec.channels();

--- a/cli/src/test/resources/simple_schema_demo-api.yaml
+++ b/cli/src/test/resources/simple_schema_demo-api.yaml
@@ -33,6 +33,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
@@ -58,6 +60,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
@@ -84,6 +88,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"

--- a/kafka/src/main/java/io/specmesh/kafka/Exporter.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Exporter.java
@@ -78,7 +78,7 @@ public final class Exporter {
     }
 
     /**
-     * Extract the Channel - todo Produce/Consume info
+     * Extract the Channel
      *
      * @param topic - kafka topic config map
      * @return decorated channel

--- a/kafka/src/main/java/io/specmesh/kafka/ExporterYamlWriter.java
+++ b/kafka/src/main/java/io/specmesh/kafka/ExporterYamlWriter.java
@@ -17,9 +17,8 @@
 package io.specmesh.kafka;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.specmesh.apiparser.model.ApiSpec;
+import io.specmesh.apiparser.parse.SpecMapper;
 
 /** Export the Spec object to its yaml representation */
 public class ExporterYamlWriter implements ExporterWriter {
@@ -34,7 +33,7 @@ public class ExporterYamlWriter implements ExporterWriter {
     @Override
     public String export(final ApiSpec apiSpec) throws Exporter.ExporterException {
         try {
-            return new ObjectMapper(new YAMLFactory()).writeValueAsString(apiSpec);
+            return SpecMapper.mapper().writeValueAsString(apiSpec);
         } catch (JsonProcessingException e) {
             throw new Exporter.ExporterException("Failed to convert to YAML", e);
         }

--- a/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
+++ b/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
@@ -34,6 +34,8 @@ import static org.apache.kafka.common.resource.ResourceType.TRANSACTIONAL_ID;
 
 import io.specmesh.apiparser.AsyncApiParser;
 import io.specmesh.apiparser.model.ApiSpec;
+import io.specmesh.apiparser.model.Channel;
+import io.specmesh.apiparser.model.Operation;
 import io.specmesh.apiparser.model.SchemaInfo;
 import java.io.FileInputStream;
 import java.io.InputStream;
@@ -42,8 +44,10 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.kafka.clients.admin.NewTopic;
 import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
@@ -149,15 +153,54 @@ public final class KafkaApiSpec {
      *
      * @param topicName the name of the topic
      * @return the schema info.
+     * @deprecated use {@link #ownedTopicSchemas}
      */
+    @Deprecated
     public SchemaInfo schemaInfoForTopic(final String topicName) {
-        final List<NewTopic> myTopics = listDomainOwnedTopics();
-        myTopics.stream()
-                .filter(topic -> topic.name().equals(topicName))
-                .findFirst()
-                .orElseThrow(() -> new APIException("Not a domain topic:" + topicName));
+        final List<SchemaInfo> schemas = ownedTopicSchemas(topicName).collect(Collectors.toList());
+        if (schemas.size() != 1) {
+            throw new APIException(
+                    "Unexpected number of topic schemas. Expected 1, got " + schemas);
+        }
+        return schemas.get(0);
+    }
 
-        return apiSpec.channels().get(topicName).publish().schemaInfo();
+    /**
+     * Get info about schemas that are conceptually owned by the supplied {@code topicName}.
+     *
+     * <p>This differs from {@link #topicSchemas} in that it only returned schemas that should be
+     * registered when provisioning the topic.
+     *
+     * @param topicName the name of the topic
+     * @return stream of the schema info.
+     */
+    public Stream<SchemaInfo> ownedTopicSchemas(final String topicName) {
+        final Channel channel = apiSpec.channels().get(topicName);
+        if (channel == null) {
+            throw new APIException("Unknown topic:" + topicName);
+        }
+
+        return Stream.of(channel.publish()).filter(Objects::nonNull).map(Operation::schemaInfo);
+    }
+
+    /**
+     * Get schema info for the supplied {@code topicName}
+     *
+     * <p>This differs from {@link #ownedTopicSchemas} in that it returned all known schemas
+     * associated with the topic.
+     *
+     * @param topicName the name of the topic
+     * @return stream of the schema info.
+     */
+    public Stream<SchemaInfo> topicSchemas(final String topicName) {
+        final Channel channel = apiSpec.channels().get(topicName);
+        if (channel == null) {
+            throw new APIException("Unknown topic:" + topicName);
+        }
+
+        return Stream.of(channel.publish(), channel.subscribe())
+                .filter(Objects::nonNull)
+                .map(Operation::schemaInfo);
     }
 
     /**

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
@@ -204,14 +204,7 @@ public final class SchemaProvisioner {
             final Collection<ParsedSchema> schemas,
             final SchemaInfo schemaInfo,
             final String partName) {
-        final String lookup =
-                schemaInfo
-                        .schemaLookupStrategy()
-                        .orElseThrow(
-                                () ->
-                                        new IllegalArgumentException(
-                                                "no 'schemaLookupStrategy' defined for topic: "
-                                                        + topicName));
+        final String lookup = schemaInfo.schemaLookupStrategy().orElse("");
 
         if (lookup.equalsIgnoreCase("SimpleTopicIdStrategy")) {
             return topicName;

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
@@ -126,7 +126,7 @@ public final class SchemaProvisioner {
 
     private static Stream<Schema> topicSchemas(
             final KafkaApiSpec apiSpec, final String baseResourcePath, final String topicName) {
-        return apiSpec.ownedTopicSchemas(topicName)
+        return apiSpec.ownedTopicSchemas(topicName).stream()
                 .flatMap(
                         si ->
                                 Stream.of(

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
@@ -23,6 +23,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import io.confluent.kafka.schemaregistry.avro.AvroSchema;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.specmesh.apiparser.model.RecordPart;
 import io.specmesh.apiparser.model.SchemaInfo;
 import io.specmesh.kafka.KafkaApiSpec;
 import io.specmesh.kafka.provision.ExceptionWrapper;
@@ -30,10 +31,13 @@ import io.specmesh.kafka.provision.Provisioner;
 import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.WithState;
 import io.specmesh.kafka.provision.schema.SchemaReaders.SchemaReader;
+import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -116,37 +120,60 @@ public final class SchemaProvisioner {
     private static List<Schema> requiredSchemas(
             final KafkaApiSpec apiSpec, final String baseResourcePath) {
         return apiSpec.listDomainOwnedTopics().stream()
-                .filter(
-                        topic ->
-                                apiSpec.apiSpec()
-                                        .channels()
-                                        .get(topic.name())
-                                        .publish()
-                                        .isSchemaRequired())
-                .map(
-                        (topic -> {
-                            final var schema = Schema.builder();
-                            try {
-                                final var schemaInfo = apiSpec.schemaInfoForTopic(topic.name());
-                                final var schemaRef = schemaInfo.schemaRef();
-                                final var schemaPath = Paths.get(baseResourcePath, schemaRef);
-                                final var schemas =
-                                        new SchemaReaders.FileSystemSchemaReader()
-                                                .readLocal(schemaPath.toString());
-                                schema.schemas(schemas)
-                                        .type(schemaInfo.schemaRef())
-                                        .subject(
-                                                resolveSubjectName(
-                                                        topic.name(), schemas, schemaInfo));
-                                schema.state(CREATE);
-
-                            } catch (Provisioner.ProvisioningException ex) {
-                                schema.state(FAILED);
-                                schema.exception(ex);
-                            }
-                            return schema.build();
-                        }))
+                .flatMap(topic -> topicSchemas(apiSpec, baseResourcePath, topic.name()))
                 .collect(Collectors.toList());
+    }
+
+    private static Stream<Schema> topicSchemas(
+            final KafkaApiSpec apiSpec, final String baseResourcePath, final String topicName) {
+        return apiSpec.ownedTopicSchemas(topicName)
+                .flatMap(
+                        si ->
+                                Stream.of(
+                                        si.key()
+                                                .flatMap(RecordPart::schemaRef)
+                                                .map(
+                                                        schemaRef ->
+                                                                partSchema(
+                                                                        "key",
+                                                                        schemaRef,
+                                                                        si,
+                                                                        baseResourcePath,
+                                                                        topicName)),
+                                        si.value()
+                                                .schemaRef()
+                                                .map(
+                                                        schemaRef ->
+                                                                partSchema(
+                                                                        "value",
+                                                                        schemaRef,
+                                                                        si,
+                                                                        baseResourcePath,
+                                                                        topicName))))
+                .flatMap(Optional::stream);
+    }
+
+    private static Schema partSchema(
+            final String partName,
+            final String schemaRef,
+            final SchemaInfo si,
+            final String baseResourcePath,
+            final String topicName) {
+        final Schema.SchemaBuilder builder = Schema.builder();
+        try {
+            final Path schemaPath = Paths.get(baseResourcePath, schemaRef);
+            final Collection<ParsedSchema> schemas =
+                    new SchemaReaders.FileSystemSchemaReader().readLocal(schemaPath);
+
+            builder.schemas(schemas)
+                    .type(schemaRef)
+                    .subject(resolveSubjectName(topicName, schemas, si, partName));
+            builder.state(CREATE);
+        } catch (Provisioner.ProvisioningException ex) {
+            builder.state(FAILED);
+            builder.exception(ex);
+        }
+        return builder.build();
     }
 
     /**
@@ -175,8 +202,17 @@ public final class SchemaProvisioner {
     private static String resolveSubjectName(
             final String topicName,
             final Collection<ParsedSchema> schemas,
-            final SchemaInfo schemaInfo) {
-        final var lookup = schemaInfo.schemaLookupStrategy();
+            final SchemaInfo schemaInfo,
+            final String partName) {
+        final String lookup =
+                schemaInfo
+                        .schemaLookupStrategy()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "no 'schemaLookupStrategy' defined for topic: "
+                                                        + topicName));
+
         if (lookup.equalsIgnoreCase("SimpleTopicIdStrategy")) {
             return topicName;
         }
@@ -202,7 +238,7 @@ public final class SchemaProvisioner {
 
             return topicName + "-" + ((AvroSchema) next).rawSchema().getFullName();
         }
-        return topicName + "-value";
+        return topicName + "-" + partName;
     }
 
     private static boolean isAvro(final ParsedSchema schema) {

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
@@ -191,11 +191,9 @@ public class KafkaAPISpecTest {
 
     @Test
     public void shouldGetSchemaInfoForOwnedTopics() {
-        final List<SchemaInfo> schemas =
+        final Optional<SchemaInfo> schema =
                 API_SPEC.ownedTopicSchemas(
-                                "london.hammersmith.olympia.bigdatalondon._public.attendee")
-                        .collect(Collectors.toList());
-        assertThat(schemas, hasSize(1));
-        assertThat(schemas.get(0).schemaIdLocation(), is(Optional.of("header")));
+                        "london.hammersmith.olympia.bigdatalondon._public.attendee");
+        assertThat(schema.flatMap(SchemaInfo::schemaIdLocation), is(Optional.of("header")));
     }
 }

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
@@ -26,6 +26,7 @@ import io.specmesh.apiparser.model.SchemaInfo;
 import io.specmesh.test.TestSpecLoader;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -190,8 +191,11 @@ public class KafkaAPISpecTest {
 
     @Test
     public void shouldGetSchemaInfoForOwnedTopics() {
-        final List<NewTopic> newTopics = API_SPEC.listDomainOwnedTopics();
-        final SchemaInfo schemaInfo = API_SPEC.schemaInfoForTopic(newTopics.get(0).name());
-        assertThat(schemaInfo.schemaIdLocation(), is("header"));
+        final List<SchemaInfo> schemas =
+                API_SPEC.ownedTopicSchemas(
+                                "london.hammersmith.olympia.bigdatalondon._public.attendee")
+                        .collect(Collectors.toList());
+        assertThat(schemas, hasSize(1));
+        assertThat(schemas.get(0).schemaIdLocation(), is(Optional.of("header")));
     }
 }

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecWithGrantAccessAclsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecWithGrantAccessAclsTest.java
@@ -27,6 +27,7 @@ import io.specmesh.test.TestSpecLoader;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.NewTopic;
@@ -199,8 +200,10 @@ public class KafkaAPISpecWithGrantAccessAclsTest {
 
     @Test
     public void shouldGetSchemaInfoForOwnedTopics() {
-        final List<NewTopic> newTopics = API_SPEC.listDomainOwnedTopics();
-        final SchemaInfo schemaInfo = API_SPEC.schemaInfoForTopic(newTopics.get(0).name());
-        assertThat(schemaInfo.schemaIdLocation(), is("header"));
+        final List<SchemaInfo> schemas =
+                API_SPEC.ownedTopicSchemas("london.hammersmith.olympia.bigdatalondon.attendee")
+                        .collect(Collectors.toList());
+        assertThat(schemas, hasSize(1));
+        assertThat(schemas.get(0).schemaIdLocation(), is(Optional.of("header")));
     }
 }

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecWithGrantAccessAclsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecWithGrantAccessAclsTest.java
@@ -200,10 +200,8 @@ public class KafkaAPISpecWithGrantAccessAclsTest {
 
     @Test
     public void shouldGetSchemaInfoForOwnedTopics() {
-        final List<SchemaInfo> schemas =
-                API_SPEC.ownedTopicSchemas("london.hammersmith.olympia.bigdatalondon.attendee")
-                        .collect(Collectors.toList());
-        assertThat(schemas, hasSize(1));
-        assertThat(schemas.get(0).schemaIdLocation(), is(Optional.of("header")));
+        final Optional<SchemaInfo> schema =
+                API_SPEC.ownedTopicSchemas("london.hammersmith.olympia.bigdatalondon.attendee");
+        assertThat(schema.flatMap(SchemaInfo::schemaIdLocation), is(Optional.of("header")));
     }
 }

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
@@ -197,7 +197,7 @@ class ProvisionerFreshStartFunctionalTest {
         assertThat(
                 "dry run should leave changeset in 'create' state",
                 changeset.stream().filter(topic -> topic.state() == Status.STATE.CREATE).count(),
-                is(2L));
+                is(3L));
 
         // Verify - should have 2 SR entries
         final var allSubjects = srClient.getAllSubjects();
@@ -341,12 +341,12 @@ class ProvisionerFreshStartFunctionalTest {
         // Verify - 11 created
         assertThat(
                 changeset.stream().filter(topic -> topic.state() == Status.STATE.CREATED).count(),
-                is(2L));
+                is(3L));
 
-        // Verify - should have 2 SR entries
+        // Verify - should have 3 SR entries
         final var allSubjects = srClient.getAllSubjects();
 
-        assertThat(allSubjects, is(hasSize(2)));
+        assertThat(allSubjects, is(hasSize(3)));
 
         final var schemas = srClient.getSchemas("simple", false, false);
 
@@ -358,6 +358,7 @@ class ProvisionerFreshStartFunctionalTest {
                 is(
                         containsInAnyOrder(
                                 "io.specmesh.kafka.schema.UserInfo",
+                                "simple.provision_demo._public.user_signed_up_value.key.UserSignedUpKey",
                                 "simple.provision_demo._public.user_signed_up_value.UserSignedUp")));
     }
 

--- a/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
@@ -28,6 +28,7 @@ import io.specmesh.kafka.KafkaEnvironment;
 import io.specmesh.kafka.provision.Provisioner;
 import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.Schema;
+import java.nio.file.Path;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -82,8 +83,8 @@ class SchemaChangeSetCalculatorsTest {
         assertThat(schemas.iterator().next().messages(), is(containsString("borked")));
     }
 
-    private static String filename(final String extra) {
-        return "./build/resources/test/schema/" + SCHEMA_FILENAME + extra;
+    private static Path filename(final String extra) {
+        return Path.of("./build/resources/test/schema/" + SCHEMA_FILENAME + extra);
     }
 
     static ParsedSchema getSchema(final String schemaRefType, final String content) {

--- a/kafka/src/test/resources/bigdatalondon-api-with-grant-access-acls.yaml
+++ b/kafka/src/test/resources/bigdatalondon-api-with-grant-access-acls.yaml
@@ -71,6 +71,10 @@ channels:
       tags: [
         name: "grant-access:some.other.domain.root"
       ]
+      bindings:
+        kafka:
+          key:
+            type: long
       message:
         name: Food Item
         tags: [
@@ -107,6 +111,10 @@ channels:
           name: "human",
           name: "customer"
         ]
+        bindings:
+          kafka:
+            key:
+              type: long
         payload:
           type: object
           properties:

--- a/kafka/src/test/resources/bigdatalondon-api.yaml
+++ b/kafka/src/test/resources/bigdatalondon-api.yaml
@@ -68,6 +68,10 @@ channels:
       ]
       message:
         name: Food Item
+        bindings:
+          kafka:
+            key:
+              type: long
         tags: [
           name: "human",
           name: "purchase"
@@ -97,6 +101,10 @@ channels:
       summary: Humans customers
       message:
         name: Food Item
+        bindings:
+          kafka:
+            key:
+              type: long
         tags: [
           name: "human",
           name: "customer"
@@ -123,6 +131,10 @@ channels:
       summary: Humans arriving in the borough
       message:
         name: Human
+        bindings:
+          kafka:
+            key:
+              type: long
         payload:
           type: object
           properties:

--- a/kafka/src/test/resources/clientapi-functional-test-api.yaml
+++ b/kafka/src/test/resources/clientapi-functional-test-api.yaml
@@ -35,6 +35,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
@@ -62,6 +64,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"

--- a/kafka/src/test/resources/exporter-expected-spec.yaml
+++ b/kafka/src/test/resources/exporter-expected-spec.yaml
@@ -1,19 +1,14 @@
 ---
 id: "urn:asyncapi-id"
 version: "version-123"
-asyncapi: null
 channels:
   one-topic-channel:
     description: "one-topic-channel-description"
     bindings:
       kafka:
-        envs: []
         partitions: 1
         replicas: 3
-        configs: {}
         groupId: "kafka-binding-group-id"
         schemaIdLocation: "payload"
         schemaLookupStrategy: "TopicNameStrategy"
-        bindingVersion: null
-    publish: null
-    subscribe: null
+        bindingVersion: "latest"

--- a/kafka/src/test/resources/provisioner-functional-test-api.yaml
+++ b/kafka/src/test/resources/provisioner-functional-test-api.yaml
@@ -28,19 +28,19 @@ channels:
           cleanup.policy: delete
           retention.ms: 3600000
 
-
     publish:
       summary: Inform about signup
       operationId: onUserSignedUp
       message:
         bindings:
           kafka:
+            key:
+              $ref: schema/simple.provision_demo._public.user_signed_up.key.avsc
             schemaIdLocation: "payload"
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
           $ref: "/schema/simple.provision_demo._public.user_signed_up.avsc"
-
   _protected.user_info:
     bindings:
       kafka:
@@ -62,6 +62,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"

--- a/kafka/src/test/resources/provisioner-update-functional-test-api.yaml
+++ b/kafka/src/test/resources/provisioner-update-functional-test-api.yaml
@@ -34,6 +34,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              $ref: schema/simple.provision_demo._public.user_signed_up.key.avsc
             schemaIdLocation: "payload"
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
@@ -61,6 +63,8 @@ channels:
       message:
         bindings:
           kafka:
+            key:
+              type: long
             schemaIdLocation: "payload"
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"

--- a/kafka/src/test/resources/schema/simple.provision_demo._public.user_signed_up.key.avsc
+++ b/kafka/src/test/resources/schema/simple.provision_demo._public.user_signed_up.key.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "namespace": "simple.provision_demo._public.user_signed_up_value.key",
+  "name": "UserSignedUpKey",
+  "fields": [
+    {"name": "id", "type": "int"}
+  ]
+}

--- a/parser/build.gradle.kts
+++ b/parser/build.gradle.kts
@@ -27,6 +27,7 @@ dependencies {
     api("com.fasterxml.jackson.core:jackson-annotations:$jacksonVersion")
 
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
+    implementation("com.fasterxml.jackson.datatype:jackson-datatype-jdk8:$jacksonVersion")
 
     compileOnly("org.projectlombok:lombok:$lombokVersion")
     annotationProcessor("org.projectlombok:lombok:$lombokVersion")

--- a/parser/src/main/java/io/specmesh/apiparser/AsyncApiParser.java
+++ b/parser/src/main/java/io/specmesh/apiparser/AsyncApiParser.java
@@ -16,9 +16,8 @@
 
 package io.specmesh.apiparser;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import io.specmesh.apiparser.model.ApiSpec;
+import io.specmesh.apiparser.parse.SpecMapper;
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -36,7 +35,7 @@ public class AsyncApiParser {
         if (inputStream == null || inputStream.available() == 0) {
             throw new RuntimeException("Not found");
         }
-        return new ObjectMapper(new YAMLFactory()).readValue(inputStream, ApiSpec.class);
+        return SpecMapper.mapper().readValue(inputStream, ApiSpec.class);
     }
 
     public static class APIParserException extends RuntimeException {

--- a/parser/src/main/java/io/specmesh/apiparser/model/Bindings.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Bindings.java
@@ -34,7 +34,7 @@ import lombok.experimental.Accessors;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class Bindings {
 
-    @JsonProperty KafkaBinding kafka;
+    @JsonProperty private KafkaBinding kafka;
 
     public void validate() {
         kafka.validate();

--- a/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
@@ -19,10 +19,9 @@ package io.specmesh.apiparser.model;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import java.util.Collections;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -38,16 +37,15 @@ import lombok.experimental.Accessors;
  */
 
 /** Pojo representing a Kafka binding */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Builder
 @Data
 @AllArgsConstructor(access = AccessLevel.PRIVATE)
 @NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
-@SuppressWarnings({"unchecked"})
 @SuppressFBWarnings
 public class KafkaBinding {
-    private static final int DAYS_TO_MS = 24 * 60 * 60 * 1000;
 
     @Builder.Default @JsonProperty private List<String> envs = List.of();
 
@@ -57,19 +55,23 @@ public class KafkaBinding {
 
     @Builder.Default @JsonProperty private Map<String, String> configs = Map.of();
 
-    @JsonProperty private String groupId;
+    @Builder.Default @JsonProperty private String groupId = "";
 
     @Builder.Default @JsonProperty private String schemaIdLocation = "payload";
 
+    @Builder.Default @JsonProperty private String schemaIdPayloadEncoding = "";
+
     @Builder.Default @JsonProperty private String schemaLookupStrategy = "TopicNameStrategy";
 
-    @JsonProperty private String bindingVersion;
+    @Builder.Default @JsonProperty private String bindingVersion = "latest";
+
+    @Builder.Default @JsonProperty private Optional<RecordPart> key = Optional.empty();
 
     /**
      * @return configs
      */
     public Map<String, String> configs() {
-        return new LinkedHashMap<>(configs == null ? Collections.emptyMap() : configs);
+        return Map.copyOf(configs);
     }
 
     /**

--- a/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
@@ -54,10 +54,7 @@ public class Operation {
 
     @JsonProperty private String description;
 
-    @SuppressWarnings("rawtypes")
-    @JsonProperty
-    @Builder.Default
-    private List<Tag> tags = List.of();
+    @JsonProperty @Builder.Default private List<Tag> tags = List.of();
 
     @JsonProperty private Bindings bindings;
 
@@ -70,27 +67,18 @@ public class Operation {
      * @return schema info
      */
     public SchemaInfo schemaInfo() {
-        if (message.bindings() == null) {
+        try {
+            return message.schemas();
+        } catch (Exception e) {
             throw new APIParserException(
-                    "Bindings not found for (publish|subscribe) operation: " + operationId);
+                    "Error extracting schemas from (publish|subscribe) operation: " + operationId,
+                    e);
         }
-        return new SchemaInfo(
-                message().schemaRef(),
-                message().schemaFormat(),
-                message.bindings().kafka().schemaIdLocation(),
-                message().contentType(),
-                message.bindings().kafka().schemaLookupStrategy());
     }
 
     public void validate() {
         if (operationId == null) {
             throw new APIParserException("(publish|subscribe) operationId  is null");
         }
-    }
-
-    public boolean isSchemaRequired() {
-        return this.message() != null
-                && this.message().schemaRef() != null
-                && this.message().schemaRef().length() > 0;
     }
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/RecordPart.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/RecordPart.java
@@ -1,0 +1,199 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.model;
+
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonToken;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import io.specmesh.apiparser.AsyncApiParser;
+import io.specmesh.apiparser.util.JsonLocation;
+import java.io.IOException;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import lombok.Value;
+
+/**
+ * Metadata describing a part of a Kafka record.
+ *
+ * <p>e.g. the key or value of a record.
+ */
+@JsonDeserialize(using = RecordPart.Deserializer.class)
+public interface RecordPart {
+    /**
+     * @return reference to an external schema file.
+     */
+    default Optional<String> schemaRef() {
+        return Optional.empty();
+    }
+
+    @Value
+    final class KafkaPart implements RecordPart {
+        // Types supported by for standard Kafka serializers:
+        public enum KafkaType {
+            UUID("uuid"),
+            Long("long"),
+            Int("int"),
+            Short("short"),
+            Float("float"),
+            Double("double"),
+            String("string"),
+            Bytes("bytes"),
+            Void("void");
+
+            private static final String VALID_VALUES =
+                    Arrays.stream(values())
+                            .map(KafkaPart.KafkaType::toString)
+                            .collect(Collectors.joining(", ", "[", "]"));
+
+            private final String text;
+
+            KafkaType(final String text) {
+                this.text = requireNonNull(text, "text");
+            }
+
+            @JsonValue
+            @Override
+            public String toString() {
+                return text;
+            }
+
+            public static KafkaPart.KafkaType fromText(final String text) {
+                return Arrays.stream(values())
+                        .filter(t -> t.text.equals(text))
+                        .findFirst()
+                        .orElseThrow(
+                                () ->
+                                        new IllegalArgumentException(
+                                                "Unknown KafkaType: "
+                                                        + text
+                                                        + ". Valid values are: "
+                                                        + VALID_VALUES));
+            }
+        }
+
+        private final KafkaPart.KafkaType kafkaType;
+
+        public KafkaPart(final KafkaPart.KafkaType kafkaType) {
+            this.kafkaType = requireNonNull(kafkaType, "kafkaType");
+        }
+    }
+
+    @Value
+    final class SchemaRefPart implements RecordPart {
+        private final String schemaRef;
+
+        public SchemaRefPart(final String schemaRef) {
+            this.schemaRef = requireNonNull(schemaRef, "schemaRef");
+        }
+
+        public Optional<String> schemaRef() {
+            return Optional.of(schemaRef);
+        }
+    }
+
+    @Value
+    final class OtherPart implements RecordPart {
+        private final JsonNode node;
+
+        public OtherPart(final JsonNode node) {
+            this.node = requireNonNull(node, "node");
+        }
+    }
+
+    final class Deserializer extends JsonDeserializer<RecordPart> {
+
+        private static final String REF_FIELD = "$ref";
+        private static final String TYPE_FIELD = "type";
+
+        @Override
+        public RecordPart deserialize(final JsonParser parser, final DeserializationContext ctx)
+                throws IOException {
+            final URI location = JsonLocation.location(parser);
+
+            if (parser.currentToken() != JsonToken.START_OBJECT) {
+                throw new AsyncApiParser.APIParserException(
+                        "Record part should be an object with either "
+                                + REF_FIELD
+                                + " or "
+                                + TYPE_FIELD
+                                + ". location: "
+                                + location);
+            }
+
+            parser.nextToken();
+
+            Optional<String> ref = Optional.empty();
+            Optional<String> type = Optional.empty();
+            Optional<JsonNode> props = Optional.empty();
+
+            while (parser.currentToken() != JsonToken.END_OBJECT) {
+                final String fieldName = parser.currentName();
+                parser.nextToken();
+
+                switch (fieldName) {
+                    case REF_FIELD:
+                        ref = Optional.of(ctx.readValue(parser, String.class));
+                        break;
+                    case TYPE_FIELD:
+                        type = Optional.of(ctx.readValue(parser, String.class));
+                        break;
+                    case "properties":
+                        props = Optional.of(ctx.readTree(parser));
+                        break;
+                    default:
+                        ctx.readTree(parser);
+                        break;
+                }
+
+                parser.nextToken();
+            }
+
+            if (ref.isPresent() == type.isPresent()) {
+                throw new AsyncApiParser.APIParserException(
+                        "Record part requires either "
+                                + REF_FIELD
+                                + " or "
+                                + TYPE_FIELD
+                                + ", but not both. location: "
+                                + location);
+            }
+
+            if (ref.isPresent()) {
+                return new SchemaRefPart(ref.get());
+            }
+
+            if (!"object".equals(type.get())) {
+                return new KafkaPart(KafkaPart.KafkaType.fromText(type.get()));
+            }
+
+            return new OtherPart(
+                    props.orElseThrow(
+                            () ->
+                                    new AsyncApiParser.APIParserException(
+                                            "'object' types requires inline 'properties. location: "
+                                                    + location)));
+        }
+    }
+}

--- a/parser/src/main/java/io/specmesh/apiparser/model/SchemaInfo.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/SchemaInfo.java
@@ -18,33 +18,39 @@ package io.specmesh.apiparser.model;
 
 import static java.util.Objects.requireNonNull;
 
+import java.util.Optional;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
 /** Pojo representing a schmea */
+@SuppressWarnings("OptionalUsedAsFieldOrParameterType")
 @Value
 @Accessors(fluent = true)
 public class SchemaInfo {
-    private final String schemaRef;
-    private final String schemaFormat;
-    private final String schemaIdLocation;
-    private final String contentType;
-    private String schemaLookupStrategy;
+    private final Optional<RecordPart> key;
+    private final RecordPart value;
+    private final Optional<String> schemaFormat;
+    private final Optional<String> schemaIdLocation;
+    private final Optional<String> contentType;
+    private final Optional<String> schemaLookupStrategy;
 
     /**
-     * @param schemaRef location of schema
+     * @param key schema info for the key of the Kafka Record
+     * @param value schema info for the value of the Kafka Record
      * @param schemaFormat format of schema
      * @param schemaIdLocation header || payload
      * @param contentType content type of schema
      * @param schemaLookupStrategy schema lookup strategy
      */
     public SchemaInfo(
-            final String schemaRef,
-            final String schemaFormat,
-            final String schemaIdLocation,
-            final String contentType,
-            final String schemaLookupStrategy) {
-        this.schemaRef = schemaRef;
+            final Optional<RecordPart> key,
+            final RecordPart value,
+            final Optional<String> schemaFormat,
+            final Optional<String> schemaIdLocation,
+            final Optional<String> contentType,
+            final Optional<String> schemaLookupStrategy) {
+        this.key = requireNonNull(key, "key");
+        this.value = requireNonNull(value, "value");
         this.schemaFormat = requireNonNull(schemaFormat, "schemaFormat");
         this.schemaIdLocation = requireNonNull(schemaIdLocation, "schemaIdLocation");
         this.contentType = requireNonNull(contentType, "contentType");

--- a/parser/src/main/java/io/specmesh/apiparser/parse/SpecMapper.java
+++ b/parser/src/main/java/io/specmesh/apiparser/parse/SpecMapper.java
@@ -1,0 +1,35 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.parse;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+
+/** ObjectMapper for use (de)serializing openapi / specmesh specs. */
+public final class SpecMapper {
+
+    private SpecMapper() {}
+
+    public static JsonMapper mapper() {
+        return JsonMapper.builder(new YAMLFactory())
+                .addModule(new Jdk8Module())
+                .serializationInclusion(JsonInclude.Include.NON_EMPTY)
+                .build();
+    }
+}

--- a/parser/src/main/java/io/specmesh/apiparser/util/JsonLocation.java
+++ b/parser/src/main/java/io/specmesh/apiparser/util/JsonLocation.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.util;
+
+import com.fasterxml.jackson.core.JsonParser;
+import java.io.File;
+import java.net.URI;
+
+/**
+ * Util class for determining the current location within a JSON/YAML file being parsed.
+ *
+ * <p>Locations are in the URI form: {@code file:///path/to/file.yml:<line number>}.
+ */
+public final class JsonLocation {
+
+    private static final URI UNKNOWN = URI.create("unknown");
+
+    private JsonLocation() {}
+
+    /**
+     * Get the current location from the parser.
+     *
+     * @param parser the parser.
+     * @return the current location.
+     */
+    public static URI location(final JsonParser parser) {
+        return location(parser.currentLocation());
+    }
+
+    /**
+     * Get the location from the Jackson location
+     *
+     * @param location the Jackson location
+     * @return the location.
+     */
+    public static URI location(final com.fasterxml.jackson.core.JsonLocation location) {
+        final Object content = location.contentReference().getRawContent();
+        if (!(content instanceof File)) {
+            return UNKNOWN;
+        }
+
+        final String filePath =
+                ((File) content).toURI().toString().replaceFirst("file:/", "file:///");
+
+        return URI.create(filePath + ":" + location.getLineNr());
+    }
+}

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiSchemaParserTest.java
@@ -24,8 +24,8 @@ import static org.hamcrest.Matchers.is;
 import io.specmesh.apiparser.model.ApiSpec;
 import io.specmesh.apiparser.model.Channel;
 import io.specmesh.apiparser.model.Operation;
+import io.specmesh.apiparser.model.RecordPart;
 import io.specmesh.apiparser.model.RecordPart.KafkaPart;
-import io.specmesh.apiparser.model.RecordPart.KafkaPart.KafkaType;
 import io.specmesh.apiparser.model.RecordPart.SchemaRefPart;
 import java.util.Map;
 import java.util.Optional;
@@ -82,7 +82,7 @@ public class AsyncApiSchemaParserTest {
         assertThat(op.message().bindings().kafka().schemaIdLocation(), is("header"));
         assertThat(
                 op.message().bindings().kafka().key(),
-                is(Optional.of(new KafkaPart(KafkaType.String))));
+                is(Optional.of(new KafkaPart(RecordPart.KafkaType.String))));
         assertThat(
                 op.message().payload().schemaRef(),
                 is(Optional.of("london_hammersmith_transport_public_passenger.avsc")));

--- a/parser/src/test/java/io/specmesh/apiparser/model/MessageTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/model/MessageTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertThrows;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.specmesh.apiparser.AsyncApiParser.APIParserException;
 import io.specmesh.apiparser.model.RecordPart.KafkaPart;
-import io.specmesh.apiparser.model.RecordPart.KafkaPart.KafkaType;
 import io.specmesh.apiparser.model.RecordPart.OtherPart;
 import io.specmesh.apiparser.model.RecordPart.SchemaRefPart;
 import io.specmesh.apiparser.parse.SpecMapper;
@@ -109,8 +108,8 @@ class MessageTest {
         final SchemaInfo schemas = message.schemas();
 
         // Then:
-        assertThat(schemas.key(), is(Optional.of(new KafkaPart(KafkaType.Long))));
-        assertThat(schemas.value(), is(new KafkaPart(KafkaType.String)));
+        assertThat(schemas.key(), is(Optional.of(new KafkaPart(RecordPart.KafkaType.Long))));
+        assertThat(schemas.value(), is(new KafkaPart(RecordPart.KafkaType.String)));
     }
 
     @Test

--- a/parser/src/test/java/io/specmesh/apiparser/model/MessageTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/model/MessageTest.java
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.specmesh.apiparser.AsyncApiParser.APIParserException;
+import io.specmesh.apiparser.model.RecordPart.KafkaPart;
+import io.specmesh.apiparser.model.RecordPart.KafkaPart.KafkaType;
+import io.specmesh.apiparser.model.RecordPart.OtherPart;
+import io.specmesh.apiparser.model.RecordPart.SchemaRefPart;
+import io.specmesh.apiparser.parse.SpecMapper;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class MessageTest {
+
+    private static final JsonMapper MAPPER = SpecMapper.mapper();
+
+    @Test
+    void shouldHandleMissingKey() throws Exception {
+        // Given:
+        final String json = "message.bindings:\n" + "  kafka:\n" + "payload:\n" + "  type: string";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.key(), is(Optional.empty()));
+    }
+
+    @Test
+    void shouldHandleMissingKafkaBindings() throws Exception {
+        // Given:
+        final String json = "bindings:\n" + "payload:\n" + "  type: string";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.key(), is(Optional.empty()));
+    }
+
+    @Test
+    void shouldHandleMissingBindings() throws Exception {
+        // Given:
+        final String json = "payload:\n" + "  type: string";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.key(), is(Optional.empty()));
+    }
+
+    @Test
+    void shouldThrowOnMissingPayload() throws Exception {
+        // Given:
+        final String json = "bindings:\n" + "  kafka:\n" + "    key:\n" + "      type: long";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final Exception e = assertThrows(APIParserException.class, message::schemas);
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("missing 'message.payload' definition"));
+    }
+
+    @Test
+    void shouldExtractInbuiltKafkaSchemaInfo() throws Exception {
+        // Given:
+        final String json =
+                "bindings:\n"
+                        + "  kafka:\n"
+                        + "    key:\n"
+                        + "      type: long\n"
+                        + "payload:\n"
+                        + "  type: string";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.key(), is(Optional.of(new KafkaPart(KafkaType.Long))));
+        assertThat(schemas.value(), is(new KafkaPart(KafkaType.String)));
+    }
+
+    @Test
+    void shouldExtractSchemaRefInfo() throws Exception {
+        // Given:
+        final String json =
+                "bindings:\n"
+                        + "  kafka:\n"
+                        + "    key:\n"
+                        + "      $ref: key.schema\n"
+                        + "payload:\n"
+                        + "  $ref: value.schema";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.key(), is(Optional.of(new SchemaRefPart("key.schema"))));
+        assertThat(schemas.value(), is(new SchemaRefPart("value.schema")));
+    }
+
+    @Test
+    void shouldNotBaulkAtInlineSchema() throws Exception {
+        // Given:
+        final String json =
+                "bindings:\n"
+                        + "  kafka:\n"
+                        + "    key:\n"
+                        + "      type: object\n"
+                        + "      properties:\n"
+                        + "        id:\n"
+                        + "payload:\n"
+                        + "  type: object\n"
+                        + "  properties:\n"
+                        + "    name:\n";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.key().map(Object::getClass), is(Optional.of(OtherPart.class)));
+        assertThat(schemas.value(), is(instanceOf(OtherPart.class)));
+    }
+
+    @Test
+    void shouldExtractSchemaFormat() throws Exception {
+        // Given:
+        final String json =
+                "bindings:\n"
+                        + "  kafka:\n"
+                        + "    key:\n"
+                        + "      type: long\n"
+                        + "payload:\n"
+                        + "  $ref: value.schema\n"
+                        + "schemaFormat: expected\n";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.schemaFormat(), is(Optional.of("expected")));
+    }
+
+    @Test
+    void shouldExtractSchemaIdLocation() throws Exception {
+        // Given:
+        final String json =
+                "bindings:\n"
+                        + "  kafka:\n"
+                        + "    key:\n"
+                        + "      type: long\n"
+                        + "    schemaIdLocation: expected\n"
+                        + "payload:\n"
+                        + "  $ref: value.schema";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.schemaIdLocation(), is(Optional.of("expected")));
+    }
+
+    @Test
+    void shouldExtractContentType() throws Exception {
+        // Given:
+        final String json =
+                "bindings:\n"
+                        + "  kafka:\n"
+                        + "    key:\n"
+                        + "      type: long\n"
+                        + "payload:\n"
+                        + "  $ref: value.schema\n"
+                        + "contentType: expected\n";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.contentType(), is(Optional.of("expected")));
+    }
+
+    @Test
+    void shouldExtractSchemaLookupStrategy() throws Exception {
+        // Given:
+        final String json =
+                "bindings:\n"
+                        + "  kafka:\n"
+                        + "    key:\n"
+                        + "      type: long\n"
+                        + "    schemaLookupStrategy: expected\n"
+                        + "payload:\n"
+                        + "  $ref: value.schema";
+
+        final Message message = MAPPER.readValue(json, Message.class);
+
+        // When:
+        final SchemaInfo schemas = message.schemas();
+
+        // Then:
+        assertThat(schemas.schemaLookupStrategy(), is(Optional.of("expected")));
+    }
+}

--- a/parser/src/test/java/io/specmesh/apiparser/model/RecordPartTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/model/RecordPartTest.java
@@ -1,0 +1,182 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.specmesh.apiparser.AsyncApiParser.APIParserException;
+import io.specmesh.apiparser.model.RecordPart.KafkaPart.KafkaType;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+class RecordPartTest {
+    private static final JsonMapper MAPPER = JsonMapper.builder().build();
+
+    @Test
+    void shouldThrowIfNotObject() {
+        // Given:
+        final String json = "1";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        APIParserException.class, () -> MAPPER.readValue(json, RecordPart.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                startsWith("Record part should be an object with either $ref or type."));
+    }
+
+    @Test
+    void shouldThrowIfArray() {
+        // Given:
+        final String json = "[]";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        APIParserException.class, () -> MAPPER.readValue(json, RecordPart.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                startsWith("Record part should be an object with either $ref or type."));
+    }
+
+    @Test
+    void shouldThrowIfEmptyObject() {
+        // Given:
+        final String json = "{}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        APIParserException.class, () -> MAPPER.readValue(json, RecordPart.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                startsWith("Record part requires either $ref or type, but not both"));
+    }
+
+    @Test
+    void shouldThrowOnObjectWithoutProps() {
+        // Given:
+        final String json = "{\"type\": \"object\"}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        APIParserException.class, () -> MAPPER.readValue(json, RecordPart.class));
+
+        // Then:
+        assertThat(e.getMessage(), startsWith("'object' types requires inline 'properties."));
+    }
+
+    @Test
+    void shouldThrowIfBothRefAndTypeDefined() {
+        // Given:
+        final String json = "{" + "\"type\": \"string\"," + "\"$ref\": \"/some/path\"" + "}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        APIParserException.class, () -> MAPPER.readValue(json, RecordPart.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                startsWith(
+                        "Record part requires either $ref or type, but not both. location:"
+                                + " unknown"));
+    }
+
+    @Test
+    void shouldThrowOnUnknownKafkaType() {
+        // Given:
+        final String json = "{\"type\": \"not-valid\"}";
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> MAPPER.readValue(json, RecordPart.class));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                containsString(
+                        "Unknown KafkaType: not-valid. Valid values are: "
+                                + "[uuid, long, int, short, float, double, string, bytes, void]"));
+    }
+
+    @ParameterizedTest
+    @EnumSource(KafkaType.class)
+    void shouldDeserializeKafkaType(final KafkaType keyType) throws Exception {
+        // Given:
+        final String json = "{\"type\": \"" + keyType.toString() + "\"}";
+
+        // When:
+        final RecordPart result = MAPPER.readValue(json, RecordPart.class);
+
+        // Then:
+        assertThat(result, is(new RecordPart.KafkaPart(keyType)));
+        assertThat(result.schemaRef(), is(Optional.empty()));
+    }
+
+    @Test
+    void shouldDeserializeSchemaRef() throws Exception {
+        // Given:
+        final String json = "{\"$ref\": \"/some/path/to/schema.avsc\"}";
+
+        // When:
+        final RecordPart result = MAPPER.readValue(json, RecordPart.class);
+
+        // Then:
+        assertThat(result.schemaRef(), is(Optional.of("/some/path/to/schema.avsc")));
+    }
+
+    @Test
+    void shouldDeserializeInlineSchema() throws Exception {
+        // Given:
+        final String json =
+                "{"
+                        + "\"type\": \"object\","
+                        + "\"properties\": {"
+                        + "  \"name\": {"
+                        + "    \"type\": \"string\""
+                        + "  }"
+                        + " }"
+                        + "}";
+
+        // When:
+        final RecordPart result = MAPPER.readValue(json, RecordPart.class);
+
+        // Then:
+        assertThat(result, is(instanceOf(RecordPart.OtherPart.class)));
+        assertThat(result.schemaRef(), is(Optional.empty()));
+    }
+}

--- a/parser/src/test/java/io/specmesh/apiparser/model/RecordPartTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/model/RecordPartTest.java
@@ -25,7 +25,7 @@ import static org.junit.Assert.assertThrows;
 
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import io.specmesh.apiparser.AsyncApiParser.APIParserException;
-import io.specmesh.apiparser.model.RecordPart.KafkaPart.KafkaType;
+import io.specmesh.apiparser.model.RecordPart.KafkaType;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;

--- a/parser/src/test/java/io/specmesh/apiparser/util/JsonLocationTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/util/JsonLocationTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.JsonDeserializer;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import java.io.IOException;
+import java.net.URI;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class JsonLocationTest {
+
+    private static final ObjectMapper MAPPER =
+            new ObjectMapper().enable(JsonParser.Feature.INCLUDE_SOURCE_IN_LOCATION);
+
+    @TempDir private Path testDir;
+
+    @Test
+    void shouldGetLocationIfParsingFile() throws Exception {
+        // Given:
+        final String json = "{\"k\": \"v\"}";
+        final Path file = testDir.resolve("test.yml");
+        Files.writeString(file, json);
+
+        // When:
+        final TestThing result = MAPPER.readValue(file.toFile(), TestThing.class);
+
+        // Then:
+        final String location = result.location.toString();
+        assertThat(location, startsWith("file:///"));
+        assertThat(location, endsWith("/test.yml:1"));
+    }
+
+    @Test
+    void shouldNotGetLocationIfParsingText() throws Exception {
+        // Given:
+        final String json = "{\"k\": \"v\"}";
+
+        // When:
+        final TestThing result = MAPPER.readValue(json, TestThing.class);
+
+        // Then:
+        assertThat(result.location, is(URI.create("unknown")));
+    }
+
+    @JsonDeserialize(using = JsonLocationTest.ThingDeserializer.class)
+    public static final class TestThing {
+
+        private final URI location;
+
+        TestThing(final URI location) {
+            this.location = location;
+        }
+    }
+
+    public static final class ThingDeserializer extends JsonDeserializer<TestThing> {
+        @Override
+        public TestThing deserialize(final JsonParser p, final DeserializationContext ctx)
+                throws IOException {
+            p.nextFieldName();
+            final URI location = JsonLocation.location(p);
+            p.nextTextValue();
+            return new TestThing(location);
+        }
+    }
+}

--- a/parser/src/test/resources/parser_simple_schema_demo-api.yaml
+++ b/parser/src/test/resources/parser_simple_schema_demo-api.yaml
@@ -34,6 +34,8 @@ channels:
         bindings:
           kafka:
             schemaIdLocation: "payload"
+            key:
+              $ref: "key.avsc"
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:


### PR DESCRIPTION
fixes: #301 
replaces: https://github.com/specmesh/specmesh-build/pull/318 & https://github.com/specmesh/specmesh-build/pull/304

BREAKING CHANGE: The API of the `SchemaInfo` type has changed, which can cause compilation issues.

With Kafka, different parts of the message payload, i.e. the Kafka record, can have type and schema information associated with them.  Most people think of the record value, but there is also the key to think about, and in the future the headers.

This change seeings support for providing type & schema information for the key of each Kafka record in a topic.  This is done by extracting the key information from the channel's `message.bindings.kafka.key` field.

For example, the following defines a Kafka topic with a key that contains a complex type:

```yaml
  message:
    bindings:
      kafka:
        key:
          $ref: "/schema/key.avsc"
    payload:
      $ref: "/schema/value.avsc"
```

The key, or indeed the value, can also be defined as holding one of the inbuilt Kafka types, i.e. types for which most Kafka clients provide serializers out of the box, e.g.

```yaml
  message:
    bindings:
      kafka:
        key:
          type: string
    payload:
      $ref: "/schema/value.avsc"
```

Support for inline schemas for both key and value remains, however, the provisioning of inline schemas is still unsupported.

The `Provisioner` api remains backwards compatible.  

The `SchemaInfo` class has changed, with optional fields now encoded as `Optional` types. 

`KafkaApiSpec.schemaInfoForTopic`  is now marked as deprecated, as a topic can now define multiple schema.  Use `ownedTopicSchemas` as a direct replacement, or `topicSchemas` to get _all_ schemas associated with a topic, rather than just those required for provisioning.
