### PR TITLE
Don't blow up if no message is defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ channels:
       message:
         name: Food Item
         tags: 
-          - name: "human",
+          - name: "human"
           - name: "purchase"
 ```
 
@@ -223,7 +223,7 @@ Source: com.example.trading-api.yml  (spec)
 ```
 
 Trade.avsc references the _Currency_ .avsc schema (the shared schema type)
-```avro schema
+```json
 {
   "metadata": {
     "author": "John Doe",
@@ -298,4 +298,4 @@ channels:
 # Developer Notes
 
 1. Install the intellij checkstyle plugin and load the config from config/checkstyle.xml
-1. build using: ./gradlew spotlessApply build
+1. build using: `./gradlew`

--- a/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
+++ b/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
@@ -175,7 +175,7 @@ public final class KafkaApiSpec {
             throw new APIException("Unknown topic:" + topicName);
         }
 
-        return Optional.ofNullable(channel.publish()).map(Operation::schemaInfo);
+        return Optional.ofNullable(channel.publish()).flatMap(Operation::schemaInfo);
     }
 
     /**
@@ -195,7 +195,8 @@ public final class KafkaApiSpec {
 
         return Stream.of(channel.publish(), channel.subscribe())
                 .filter(Objects::nonNull)
-                .map(Operation::schemaInfo);
+                .map(Operation::schemaInfo)
+                .flatMap(Optional::stream);
     }
 
     /**

--- a/kafka/src/test/java/io/specmesh/kafka/provision/TopicMutatorsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/TopicMutatorsTest.java
@@ -46,20 +46,21 @@ import org.mockito.junit.jupiter.MockitoExtension;
 class TopicMutatorsTest {
 
     @Mock Admin client;
+    @Mock KafkaFuture<TopicDescription> descriptionFuture;
+    @Mock KafkaFuture<Void> createPartitionsFuture;
 
     @Test
     void shouldWriteUpdatesForRetentionChange() throws Exception {
         final var topicWriter = new UpdateMutator(client);
 
         // Mock hell - crappy admin api
-        final var topicDescriptionFuture = mock(KafkaFuture.class);
-        when(topicDescriptionFuture.get(Provisioner.REQUEST_TIMEOUT, TimeUnit.SECONDS))
+        when(descriptionFuture.get(Provisioner.REQUEST_TIMEOUT, TimeUnit.SECONDS))
                 .thenReturn(getTopicDescription());
 
         final var describeResult = mock(DescribeTopicsResult.class);
 
         // test value of existing topic
-        when(describeResult.topicNameValues()).thenReturn(Map.of("test", topicDescriptionFuture));
+        when(describeResult.topicNameValues()).thenReturn(Map.of("test", descriptionFuture));
 
         when(client.describeTopics(List.of("test"))).thenReturn(describeResult);
 
@@ -86,22 +87,20 @@ class TopicMutatorsTest {
         final var topicWriter = new UpdateMutator(client);
 
         // Mock hell - crappy admin api
-        final var topicDescriptionFuture = mock(KafkaFuture.class);
-        when(topicDescriptionFuture.get(Provisioner.REQUEST_TIMEOUT, TimeUnit.SECONDS))
+        when(descriptionFuture.get(Provisioner.REQUEST_TIMEOUT, TimeUnit.SECONDS))
                 .thenReturn(getTopicDescription());
 
         final var describeResult = mock(DescribeTopicsResult.class);
 
         // test value of existing topic
-        when(describeResult.topicNameValues()).thenReturn(Map.of("test", topicDescriptionFuture));
+        when(describeResult.topicNameValues()).thenReturn(Map.of("test", descriptionFuture));
 
         when(client.describeTopics(List.of("test"))).thenReturn(describeResult);
 
         final var createPartitionsResult = mock(CreatePartitionsResult.class);
-        final var createPartitionFuture = mock(KafkaFuture.class);
-        when(createPartitionsResult.all()).thenReturn(createPartitionFuture);
-        when(createPartitionFuture.get(Provisioner.REQUEST_TIMEOUT, TimeUnit.SECONDS))
-                .thenReturn(Void.class);
+        when(createPartitionsResult.all()).thenReturn(createPartitionsFuture);
+        when(createPartitionsFuture.get(Provisioner.REQUEST_TIMEOUT, TimeUnit.SECONDS))
+                .thenReturn(null);
         when(client.createPartitions(any(), any())).thenReturn(createPartitionsResult);
 
         // test

--- a/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
@@ -22,6 +22,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.specmesh.apiparser.AsyncApiParser.APIParserException;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -66,9 +67,12 @@ public class Operation {
     /**
      * @return schema info
      */
-    public SchemaInfo schemaInfo() {
+    public Optional<SchemaInfo> schemaInfo() {
+        if (message == null) {
+            return Optional.empty();
+        }
         try {
-            return message.schemas();
+            return Optional.of(message.schemas());
         } catch (Exception e) {
             throw new APIParserException(
                     "Error extracting schemas from (publish|subscribe) operation: " + operationId,

--- a/parser/src/test/resources/parser_simple_schema_demo-api.yaml
+++ b/parser/src/test/resources/parser_simple_schema_demo-api.yaml
@@ -41,6 +41,11 @@ channels:
         payload:
           $ref: "simple_schema_demo_user-signedup.avsc"
 
+  _public.user.message-less:
+    # channel with no message defined:
+    publish:
+      operationId: opId
+
 # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   london.hammersmith.transport._public.tube:
     subscribe:


### PR DESCRIPTION
Currently, if a channel is defined with no `message` then the `operation.schemaInfo()` call throws an NPE.  `message` is not required, so a `null` `message should not cause an NPE.
