### PR TITLE
Allow users to load spec from the file system

### DIFF
--- a/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
+++ b/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
@@ -375,7 +375,7 @@ public final class KafkaApiSpec {
      * @param spec to load
      * @return loaded spec
      */
-    private static KafkaApiSpec loadFromFileSystem(final String spec) {
+    public static KafkaApiSpec loadFromFileSystem(final String spec) {
         try (InputStream fis = new FileInputStream(spec)) {
             return new KafkaApiSpec(new AsyncApiParser().loadResource(fis));
         } catch (Exception ex) {


### PR DESCRIPTION
There's no reason why the spec needs to be on the classpath - in fact I'd say it's more normal for it to be on the filesystem - so allow this as a first class citizen of the api
