### PR TITLE
Add units to `storage`

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ channels:
 >
 
 ```json
- {"acme.lifestyle.onboarding._public.user_signed_up":{"storage":1590,"offset-total":6},"acme.lifestyle._protected.purchased":{"storage":0,"offset-total":0},"acme.lifestyle._private.user_checkout":{"storage":9185,"offset-total":57}}
+ {"acme.lifestyle.onboarding._public.user_signed_up":{"storage-bytes":1590,"offset-total":6},"acme.lifestyle._protected.purchased":{"storage-bytes":0,"offset-total":0},"acme.lifestyle._private.user_checkout":{"storage-bytes":9185,"offset-total":57}}
 ```
 .
 

--- a/cli/README.md
+++ b/cli/README.md
@@ -491,7 +491,7 @@ each of its topic in bytes
 Topic data that matches the app-id (prefixed with `simple.spec_demo` within the api.yaml)
 
 ```json
- {"simple.spec_demo._private.user_checkout":{"storage":1590,"offset-total":6},"simple.spec_demo._protected.purchased":{"storage":0,"offset-total":0},"simple.spec_demo._public.user_signed_up":{"storage":9185,"offset-total":57}}
+ {"simple.spec_demo._private.user_checkout":{"storage-bytes":1590,"offset-total":6},"simple.spec_demo._protected.purchased":{"storage-bytes":0,"offset-total":0},"simple.spec_demo._public.user_signed_up":{"storage-bytes":9185,"offset-total":57}}
 ```
 
 ## Command: Consumption (chargeback metrics)

--- a/cli/src/main/java/io/specmesh/cli/Storage.java
+++ b/cli/src/main/java/io/specmesh/cli/Storage.java
@@ -110,7 +110,7 @@ public class Storage implements Callable<Integer> {
                         results.put(
                                 topic,
                                 Map.of(
-                                        "storage",
+                                        "storage-bytes",
                                         client.topicVolumeUsingLogDirs(topic),
                                         "offset-total",
                                         client.topicVolumeOffsets(topic))));

--- a/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
@@ -152,8 +152,8 @@ class StorageConsumptionFunctionalTest {
         final var volume =
                 (Map<String, Long>) storage.get("simple.schema_demo._public.user_signed_up");
 
-        assertThat(volume.get("storage"), is(1120000L));
         assertThat(volume.get("offset-total"), is(10000L));
+        assertThat(volume.get("storage-bytes"), is(1120000L));
     }
 
     private static void checkConsumptionStats() throws Exception {


### PR DESCRIPTION
Changed `storage` metric to `storage-bytes`, cos units matter!
