### PR TITLE
Evolvable `Provisioner` api

### DIFF
--- a/cli/src/test/java/io/specmesh/cli/ProvisionFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/ProvisionFunctionalTest.java
@@ -18,13 +18,11 @@ package io.specmesh.cli;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import io.specmesh.kafka.DockerKafkaEnvironment;
 import io.specmesh.kafka.KafkaEnvironment;
-import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.TopicProvisioner.Topic;
 import java.util.List;
 import java.util.Set;
@@ -64,29 +62,6 @@ class ProvisionFunctionalTest {
         admin.close();
     }
 
-    @Test
-    void shouldProvisionCmdWithLombock() {
-        final var provision = Provision.builder().brokerUrl("borker").aclDisabled(false).build();
-        assertThat(provision.aclDisabled(), is(false));
-        assertThat(provision.brokerUrl(), is("borker"));
-    }
-
-    @Test
-    void shouldNotSwallowExceptions() {
-        final var topic = Topic.builder().build();
-        final var swallowed =
-                Status.builder()
-                        .topics(
-                                List.of(
-                                        topic.exception(
-                                                new RuntimeException(
-                                                        new RuntimeException("swallowed")))))
-                        .build();
-        assertThat(
-                swallowed.topics().iterator().next().exception().toString(),
-                containsString(".java:"));
-    }
-
     /**
      * Provision all resources apart from schemas. note: Dont specify SR credentials to avoid schema
      * publishing
@@ -96,7 +71,7 @@ class ProvisionFunctionalTest {
     @Test
     void shouldProvisionTopicsAndAclResourcesWithSchemas() throws Exception {
 
-        final Provision provision = Provision.builder().build();
+        final Provision provision = new Provision();
 
         // Given:
         final CommandLine.ParseResult parseResult =

--- a/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
@@ -44,7 +44,6 @@ import io.specmesh.test.TestSpecLoader;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -89,14 +88,15 @@ class StorageConsumptionFunctionalTest {
     @Test
     void shouldGetStorageAndConsumptionMetrics() throws Exception {
 
-        Provisioner.provision(
-                        true,
-                        false,
-                        false,
-                        API_SPEC,
-                        "./build/resources/test",
-                        KAFKA_ENV.adminClient(),
-                        Optional.of(KAFKA_ENV.srClient()))
+        Provisioner.builder()
+                .apiSpec(API_SPEC)
+                .schemaPath("./build/resources/test")
+                .adminClient(KAFKA_ENV.adminClient())
+                .closeAdminClient(true)
+                .schemaRegistryClient(KAFKA_ENV.srClient())
+                .closeSchemaClient(true)
+                .build()
+                .provision()
                 .check();
 
         try (Admin adminClient = KAFKA_ENV.adminClient()) {

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -160,7 +160,7 @@ public final class Clients {
                 + "\";";
     }
 
-    @Deprecated(forRemoval = true)
+    @Deprecated(forRemoval = true, since = "0.10.1")
     public static Optional<SchemaRegistryClient> schemaRegistryClient(
             final boolean srEnabled,
             final String schemaRegistryUrl,

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -16,6 +16,8 @@
 
 package io.specmesh.kafka;
 
+import static java.util.Objects.requireNonNull;
+
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
@@ -158,23 +160,32 @@ public final class Clients {
                 + "\";";
     }
 
+    /**
+     * @deprecated use {@link #schemaRegistryClient(String, String, String)}
+     */
+    @Deprecated(forRemoval = true)
     public static Optional<SchemaRegistryClient> schemaRegistryClient(
             final boolean srEnabled,
             final String schemaRegistryUrl,
             final String srApiKey,
             final String srApiSecret) {
         if (srEnabled && schemaRegistryUrl != null) {
-            final Map<String, Object> properties = new HashMap<>();
-            if (srApiKey != null) {
-                properties.put(
-                        SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
-                properties.put(
-                        SchemaRegistryClientConfig.USER_INFO_CONFIG, srApiKey + ":" + srApiSecret);
-            }
-            return Optional.of(new CachedSchemaRegistryClient(schemaRegistryUrl, 5, properties));
+            return Optional.of(schemaRegistryClient(schemaRegistryUrl, srApiKey, srApiSecret));
         } else {
             return Optional.empty();
         }
+    }
+
+    public static SchemaRegistryClient schemaRegistryClient(
+            final String schemaRegistryUrl, final String srApiKey, final String srApiSecret) {
+        final Map<String, Object> properties = new HashMap<>();
+        if (srApiKey != null && !srApiKey.isBlank()) {
+            properties.put(SchemaRegistryClientConfig.BASIC_AUTH_CREDENTIALS_SOURCE, "USER_INFO");
+            properties.put(
+                    SchemaRegistryClientConfig.USER_INFO_CONFIG, srApiKey + ":" + srApiSecret);
+        }
+        return new CachedSchemaRegistryClient(
+                requireNonNull(schemaRegistryUrl, "schemaRegistryUrl"), 5, properties);
     }
 
     /**

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -160,9 +160,6 @@ public final class Clients {
                 + "\";";
     }
 
-    /**
-     * @deprecated use {@link #schemaRegistryClient(String, String, String)}
-     */
     @Deprecated(forRemoval = true)
     public static Optional<SchemaRegistryClient> schemaRegistryClient(
             final boolean srEnabled,

--- a/kafka/src/main/java/io/specmesh/kafka/provision/AclMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/AclMutators.java
@@ -18,7 +18,6 @@ package io.specmesh.kafka.provision;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.specmesh.kafka.provision.AclProvisioner.Acl;
-import io.specmesh.kafka.provision.Provisioner.ProvisioningException;
 import io.specmesh.kafka.provision.Status.STATE;
 import java.util.Collection;
 import java.util.concurrent.TimeUnit;

--- a/kafka/src/main/java/io/specmesh/kafka/provision/AclProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/AclProvisioner.java
@@ -43,7 +43,7 @@ public final class AclProvisioner {
      * @param apiSpec respect the spec
      * @param adminClient cluster connection
      * @return status of provisioning
-     * @throws Provisioner.ProvisioningException on interrupt
+     * @throws ProvisioningException on interrupt
      */
     public static Collection<Acl> provision(
             final boolean dryRun,

--- a/kafka/src/main/java/io/specmesh/kafka/provision/AclReaders.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/AclReaders.java
@@ -18,7 +18,6 @@ package io.specmesh.kafka.provision;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.specmesh.kafka.provision.AclProvisioner.Acl;
-import io.specmesh.kafka.provision.Provisioner.ProvisioningException;
 import java.util.Collection;
 import java.util.List;
 import java.util.concurrent.TimeUnit;

--- a/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
@@ -33,7 +33,7 @@ import org.apache.kafka.clients.admin.Admin;
 @Accessors(fluent = true)
 @Builder
 @SuppressFBWarnings
-public class Provisioner {
+public final class Provisioner {
 
     static final int REQUEST_TIMEOUT = 60;
 

--- a/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
@@ -16,33 +16,141 @@
 
 package io.specmesh.kafka.provision;
 
+import com.google.common.annotations.VisibleForTesting;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.specmesh.kafka.Clients;
 import io.specmesh.kafka.KafkaApiSpec;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner;
 import java.util.Optional;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.experimental.Accessors;
 import org.apache.kafka.clients.admin.Admin;
 
-/** Provisions Kafka and SR resources */
-public final class Provisioner {
+/** SpecMesh Kafka Provisioner */
+@Getter
+@Accessors(fluent = true)
+@Builder
+@SuppressFBWarnings
+public class Provisioner {
 
-    public static final int REQUEST_TIMEOUT = 60;
+    static final int REQUEST_TIMEOUT = 60;
 
-    private Provisioner() {}
+    private Status state;
 
-    /**
-     * Provision Topics, ACLS and schemas
-     *
-     * @param aclEnabled enable or disable ACLs
-     * @param dryRun test or execute
-     * @param cleanUnspecified cleanup
-     * @param apiSpec given spec
-     * @param schemaResources schema path
-     * @param adminClient kafka admin client
-     * @param schemaRegistryClient sr client
-     * @return status of provisioning
-     * @throws ProvisioningException when cant provision resources
-     */
-    public static Status provision(
+    @Builder.Default private String brokerUrl = "";
+    private boolean srDisabled;
+    private boolean aclDisabled;
+    @Builder.Default private String schemaRegistryUrl = "";
+    private String srApiKey;
+    private String srApiSecret;
+    private SchemaRegistryClient schemaRegistryClient;
+    @Builder.Default private boolean closeSchemaClient = false;
+    private String schemaPath;
+    @Builder.Default private String specPath = "";
+    private KafkaApiSpec apiSpec;
+    private String username;
+    private String secret;
+    private Admin adminClient;
+    @Builder.Default private boolean closeAdminClient = false;
+    private boolean dryRun;
+    private boolean cleanUnspecified;
+
+    public Status provision() {
+        return provision(
+                Provisioner::provision,
+                Clients::adminClient,
+                Clients::schemaRegistryClient,
+                KafkaApiSpec::loadFromClassPath);
+    }
+
+    @VisibleForTesting
+    Status provision(
+            final ProvisionerMethod method,
+            final AdminFactory adminFactory,
+            final SrClientFactory srClientFactory,
+            final SpecLoader specLoader) {
+        try {
+            ensureApiSpec(specLoader);
+            ensureAdminClient(adminFactory);
+            ensureSrClient(srClientFactory);
+
+            final var status =
+                    method.provision(
+                            !aclDisabled,
+                            dryRun,
+                            cleanUnspecified,
+                            apiSpec,
+                            schemaPath,
+                            adminClient,
+                            srDisabled ? Optional.empty() : Optional.of(schemaRegistryClient));
+
+            System.out.println(status.toString());
+            this.state = status;
+            return status;
+        } finally {
+            if (closeAdminClient) {
+                try {
+                    adminClient.close();
+                } catch (Exception e) {
+                    e.printStackTrace(System.err);
+                }
+                adminClient = null;
+            }
+
+            if (closeSchemaClient) {
+                try {
+                    schemaRegistryClient.close();
+                } catch (Exception e) {
+                    e.printStackTrace(System.err);
+                }
+                schemaRegistryClient = null;
+            }
+        }
+    }
+
+    private void ensureSrClient(final SrClientFactory srClientFactory) {
+        if (srDisabled || schemaRegistryClient != null) {
+            return;
+        }
+
+        if (schemaRegistryUrl.isBlank()) {
+            throw new IllegalStateException("Please set a schema registry url");
+        }
+
+        schemaRegistryClient =
+                srClientFactory.schemaRegistryClient(schemaRegistryUrl, srApiKey, srApiSecret);
+        closeSchemaClient = true;
+    }
+
+    private void ensureAdminClient(final AdminFactory adminFactory) {
+        if (adminClient != null) {
+            return;
+        }
+
+        if (brokerUrl.isBlank()) {
+            throw new IllegalStateException("Please set a broker url");
+        }
+
+        adminClient = adminFactory.adminClient(brokerUrl, username, secret);
+        closeAdminClient = true;
+    }
+
+    private void ensureApiSpec(final SpecLoader specLoader) {
+        if (apiSpec != null) {
+            return;
+        }
+
+        if (specPath.isBlank()) {
+            throw new IllegalStateException("Please set the path to the specification file");
+        }
+
+        apiSpec = specLoader.loadFromClassPath(specPath, Provisioner.class.getClassLoader());
+    }
+
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    private static Status provision(
             final boolean aclEnabled,
             final boolean dryRun,
             final boolean cleanUnspecified,
@@ -73,14 +181,32 @@ public final class Provisioner {
         return status.build();
     }
 
-    public static class ProvisioningException extends RuntimeException {
+    @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+    @VisibleForTesting
+    interface ProvisionerMethod {
+        Status provision(
+                boolean aclEnabled,
+                boolean dryRun,
+                boolean cleanUnspecified,
+                KafkaApiSpec apiSpec,
+                String schemaResources,
+                Admin adminClient,
+                Optional<SchemaRegistryClient> schemaRegistryClient);
+    }
 
-        public ProvisioningException(final String msg) {
-            super(msg);
-        }
+    @VisibleForTesting
+    interface AdminFactory {
+        Admin adminClient(String brokerUrl, String username, String secret);
+    }
 
-        public ProvisioningException(final String msg, final Throwable cause) {
-            super(msg, cause);
-        }
+    @VisibleForTesting
+    interface SrClientFactory {
+        SchemaRegistryClient schemaRegistryClient(
+                String schemaRegistryUrl, String srApiKey, String srApiSecret);
+    }
+
+    @VisibleForTesting
+    interface SpecLoader {
+        KafkaApiSpec loadFromClassPath(String spec, ClassLoader classLoader);
     }
 }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/ProvisioningException.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/ProvisioningException.java
@@ -1,0 +1,24 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.kafka.provision;
+
+public final class ProvisioningException extends RuntimeException {
+
+    public ProvisioningException(final String msg, final Throwable cause) {
+        super(msg, cause);
+    }
+}

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicMutators.java
@@ -19,7 +19,6 @@ package io.specmesh.kafka.provision;
 import static org.apache.kafka.common.config.TopicConfig.RETENTION_MS_CONFIG;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.specmesh.kafka.provision.Provisioner.ProvisioningException;
 import io.specmesh.kafka.provision.Status.STATE;
 import io.specmesh.kafka.provision.TopicProvisioner.Topic;
 import java.util.Arrays;

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
@@ -43,7 +43,7 @@ public final class TopicProvisioner {
      * @param apiSpec the api spec.
      * @param adminClient admin client for the Kafka cluster.
      * @return number of topics created
-     * @throws Provisioner.ProvisioningException on provision failure
+     * @throws ProvisioningException on provision failure
      */
     public static Collection<Topic> provision(
             final boolean dryRun,

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicReaders.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicReaders.java
@@ -16,7 +16,6 @@
 
 package io.specmesh.kafka.provision;
 
-import io.specmesh.kafka.provision.Provisioner.ProvisioningException;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaMutators.java
@@ -25,7 +25,7 @@ import static io.specmesh.kafka.provision.Status.STATE.UPDATED;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
-import io.specmesh.kafka.provision.Provisioner.ProvisioningException;
+import io.specmesh.kafka.provision.ProvisioningException;
 import io.specmesh.kafka.provision.Status.STATE;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.Schema;
 import java.io.IOException;

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
@@ -27,7 +27,7 @@ import io.specmesh.apiparser.model.RecordPart;
 import io.specmesh.apiparser.model.SchemaInfo;
 import io.specmesh.kafka.KafkaApiSpec;
 import io.specmesh.kafka.provision.ExceptionWrapper;
-import io.specmesh.kafka.provision.Provisioner;
+import io.specmesh.kafka.provision.ProvisioningException;
 import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.WithState;
 import io.specmesh.kafka.provision.schema.SchemaReaders.SchemaReader;
@@ -169,7 +169,7 @@ public final class SchemaProvisioner {
                     .type(schemaRef)
                     .subject(resolveSubjectName(topicName, schemas, si, partName));
             builder.state(CREATE);
-        } catch (Provisioner.ProvisioningException ex) {
+        } catch (ProvisioningException ex) {
             builder.state(FAILED);
             builder.exception(ex);
         }

--- a/kafka/src/test/java/io/specmesh/kafka/ExporterFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ExporterFunctionalTest.java
@@ -39,7 +39,6 @@ import io.specmesh.test.TestSpecLoader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.acl.AccessControlEntry;
@@ -95,17 +94,15 @@ class ExporterFunctionalTest {
 
     @BeforeAll
     static void setUp() {
-        try (Admin adminClient = KAFKA_ENV.adminClient()) {
-            Provisioner.provision(
-                            true,
-                            false,
-                            false,
-                            API_SPEC,
-                            "./build/resources/test",
-                            adminClient,
-                            Optional.empty())
-                    .check();
-        }
+        Provisioner.builder()
+                .apiSpec(API_SPEC)
+                .schemaPath("./build/resources/test")
+                .adminClient(KAFKA_ENV.adminClient())
+                .closeAdminClient(true)
+                .srDisabled(true)
+                .build()
+                .provision()
+                .check();
     }
 
     @Test

--- a/kafka/src/test/java/io/specmesh/kafka/admin/SimpleAdminClientTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/admin/SimpleAdminClientTest.java
@@ -31,7 +31,6 @@ import io.specmesh.test.TestSpecLoader;
 import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
@@ -71,14 +70,15 @@ class SimpleAdminClientTest {
 
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
             final var client = SmAdminClient.create(adminClient);
-            Provisioner.provision(
-                            true,
-                            false,
-                            false,
-                            API_SPEC,
-                            "./build/resources/test",
-                            adminClient,
-                            Optional.of(KAFKA_ENV.srClient()))
+
+            Provisioner.builder()
+                    .apiSpec(API_SPEC)
+                    .schemaPath("./build/resources/test")
+                    .adminClient(adminClient)
+                    .schemaRegistryClient(KAFKA_ENV.srClient())
+                    .closeSchemaClient(true)
+                    .build()
+                    .provision()
                     .check();
 
             // write seed info

--- a/kafka/src/test/java/io/specmesh/kafka/provision/AclProvisionerUpdateFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/AclProvisionerUpdateFunctionalTest.java
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package io.specmesh.kafka;
+package io.specmesh.kafka.provision;
 
 import static org.apache.kafka.common.acl.AclOperation.ALL;
 import static org.apache.kafka.common.acl.AclOperation.IDEMPOTENT_WRITE;
@@ -30,8 +30,9 @@ import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
-import io.specmesh.kafka.provision.AclProvisioner;
-import io.specmesh.kafka.provision.Provisioner;
+import io.specmesh.kafka.DockerKafkaEnvironment;
+import io.specmesh.kafka.KafkaApiSpec;
+import io.specmesh.kafka.KafkaEnvironment;
 import io.specmesh.kafka.provision.Status.STATE;
 import io.specmesh.test.TestSpecLoader;
 import java.util.List;

--- a/kafka/src/test/java/io/specmesh/kafka/provision/ProvisionerTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/ProvisionerTest.java
@@ -1,0 +1,321 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.kafka.provision;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyBoolean;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.specmesh.kafka.KafkaApiSpec;
+import java.util.Optional;
+import org.apache.kafka.clients.admin.Admin;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
+
+@SuppressWarnings("resource")
+@ExtendWith(MockitoExtension.class)
+@MockitoSettings(strictness = Strictness.LENIENT)
+class ProvisionerTest {
+
+    @Mock private Provisioner.ProvisionerMethod provisionMethod;
+    @Mock private Provisioner.AdminFactory adminFactory;
+    @Mock private Provisioner.SrClientFactory srClientFactory;
+    @Mock private Provisioner.SpecLoader specLoader;
+    @Mock private Status status;
+    @Mock private KafkaApiSpec spec;
+    @Mock private SchemaRegistryClient srClient;
+    @Mock private Admin adminClient;
+
+    @BeforeEach
+    void setUp() {
+        when(provisionMethod.provision(
+                        anyBoolean(), anyBoolean(), anyBoolean(), any(), any(), any(), any()))
+                .thenReturn(status);
+
+        when(adminFactory.adminClient(any(), any(), any())).thenReturn(adminClient);
+        when(srClientFactory.schemaRegistryClient(any(), any(), any())).thenReturn(srClient);
+        when(specLoader.loadFromClassPath(any(), any())).thenReturn(spec);
+    }
+
+    @Test
+    void shouldProvideGetters() {
+        // When:
+        final var provision = Provisioner.builder().brokerUrl("borker").aclDisabled(false).build();
+
+        // Then:
+        assertThat(provision.aclDisabled(), is(false));
+        assertThat(provision.brokerUrl(), is("borker"));
+    }
+
+    @Test
+    void shouldThrowIfBrokerUrlNotProvided() {
+        // Given:
+        final Provisioner provisioner =
+                Provisioner.builder()
+                        // Not set: .brokerUrl("something")
+                        .schemaRegistryUrl("something")
+                        .specPath("something")
+                        .build();
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                provisioner.provision(
+                                        provisionMethod,
+                                        adminFactory,
+                                        srClientFactory,
+                                        specLoader));
+
+        // Then:
+        assertThat(e.getMessage(), is("Please set a broker url"));
+    }
+
+    @Test
+    void shouldThrowIfSchemaRegistryUrlNotProvided() {
+        // Given:
+        final Provisioner provisioner =
+                Provisioner.builder()
+                        .brokerUrl("something")
+                        // Not set: .schemaRegistryUrl("something")
+                        .specPath("something")
+                        .build();
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                provisioner.provision(
+                                        provisionMethod,
+                                        adminFactory,
+                                        srClientFactory,
+                                        specLoader));
+
+        // Then:
+        assertThat(e.getMessage(), is("Please set a schema registry url"));
+    }
+
+    @Test
+    void shouldNotThrowIfSchemaRegistryUrlNotProvidedWhenSchemasAreDisabled() {
+        // Given:
+        final Provisioner provisioner =
+                Provisioner.builder()
+                        .brokerUrl("something")
+                        // Not set: .schemaRegistryUrl("something")
+                        .specPath("something")
+                        .srDisabled(true)
+                        .build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then: did not throw
+    }
+
+    @Test
+    void shouldThrowIfSpecPathNotProvided() {
+        // Given:
+        final Provisioner provisioner =
+                Provisioner.builder()
+                        .brokerUrl("something")
+                        .schemaRegistryUrl("something")
+                        // Not set: .spec("something")
+                        .build();
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalStateException.class,
+                        () ->
+                                provisioner.provision(
+                                        provisionMethod,
+                                        adminFactory,
+                                        srClientFactory,
+                                        specLoader));
+
+        // Then:
+        assertThat(e.getMessage(), is("Please set the path to the specification file"));
+    }
+
+    @Test
+    void shouldNotThrowIfSpecPathNotProvidedButApiSpecIs() {
+        // Given:
+        final KafkaApiSpec explicitSpec = mock(KafkaApiSpec.class);
+        final Provisioner provisioner =
+                Provisioner.builder()
+                        .brokerUrl("something")
+                        .schemaRegistryUrl("something")
+                        // Not set: .specPath("something")
+                        .apiSpec(explicitSpec)
+                        .build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then: did not throw, and
+        verify(provisionMethod)
+                .provision(
+                        anyBoolean(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        eq(explicitSpec),
+                        any(),
+                        any(),
+                        any());
+    }
+
+    @Test
+    void shouldWorkWithMinimalConfig() {
+        // Given:
+        final Provisioner provisioner = minimalBuilder().build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then:
+        verify(adminFactory).adminClient("kafka-url", null, null);
+        verify(specLoader).loadFromClassPath("spec-path", Provisioner.class.getClassLoader());
+        verify(srClientFactory).schemaRegistryClient("sr-url", null, null);
+        verify(provisionMethod)
+                .provision(true, false, false, spec, null, adminClient, Optional.of(srClient));
+    }
+
+    @Test
+    void shouldUseAuthToCreateAdmin() {
+        // Given:
+        final Provisioner provisioner = minimalBuilder().username("bob").secret("shhhh!").build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then:
+        verify(adminFactory).adminClient("kafka-url", "bob", "shhhh!");
+    }
+
+    @Test
+    void shouldUseAuthToCreateSrClient() {
+        // Given:
+        final Provisioner provisioner =
+                minimalBuilder().srApiKey("bob").srApiSecret("shhhh!").build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then:
+        verify(srClientFactory).schemaRegistryClient("sr-url", "bob", "shhhh!");
+    }
+
+    @Test
+    void shouldSupportDisablingAcls() {
+        // Given:
+        final Provisioner provisioner = minimalBuilder().aclDisabled(true).build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then:
+        verify(provisionMethod)
+                .provision(eq(false), anyBoolean(), anyBoolean(), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldSupportDisablingSchemas() {
+        // Given:
+        final Provisioner provisioner = minimalBuilder().srDisabled(true).build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then:
+        verify(provisionMethod)
+                .provision(
+                        anyBoolean(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        any(),
+                        any(),
+                        any(),
+                        eq(Optional.empty()));
+    }
+
+    @Test
+    void shouldSupportDryRun() {
+        // Given:
+        final Provisioner provisioner = minimalBuilder().dryRun(true).build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then:
+        verify(provisionMethod)
+                .provision(anyBoolean(), eq(true), anyBoolean(), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldSupportCleaningUnspecific() {
+        // Given:
+        final Provisioner provisioner = minimalBuilder().cleanUnspecified(true).build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then:
+        verify(provisionMethod)
+                .provision(anyBoolean(), anyBoolean(), eq(true), any(), any(), any(), any());
+    }
+
+    @Test
+    void shouldSupportCustomSchemaRoot() {
+        // Given:
+        final Provisioner provisioner = minimalBuilder().schemaPath("schema-path").build();
+
+        // When:
+        provisioner.provision(provisionMethod, adminFactory, srClientFactory, specLoader);
+
+        // Then:
+        verify(provisionMethod)
+                .provision(
+                        anyBoolean(),
+                        anyBoolean(),
+                        anyBoolean(),
+                        any(),
+                        eq("schema-path"),
+                        any(),
+                        any());
+    }
+
+    private static Provisioner.ProvisionerBuilder minimalBuilder() {
+        return Provisioner.builder()
+                .brokerUrl("kafka-url")
+                .schemaRegistryUrl("sr-url")
+                .specPath("spec-path");
+    }
+}

--- a/kafka/src/test/java/io/specmesh/kafka/provision/TopicProvisionerTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/TopicProvisionerTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.specmesh.kafka.provision;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class TopicProvisionerTest {
+
+    @Test
+    void shouldNotSwallowExceptions() {
+        final var topic = TopicProvisioner.Topic.builder().build();
+        final var swallowed =
+                Status.builder()
+                        .topics(
+                                List.of(
+                                        topic.exception(
+                                                new RuntimeException(
+                                                        new RuntimeException("swallowed")))))
+                        .build();
+        assertThat(
+                swallowed.topics().iterator().next().exception().toString(),
+                containsString(".java:"));
+    }
+}

--- a/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
@@ -19,13 +19,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.is;
 
-import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.avro.AvroSchema;
-import io.confluent.kafka.schemaregistry.json.JsonSchema;
-import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchema;
 import io.specmesh.kafka.DockerKafkaEnvironment;
 import io.specmesh.kafka.KafkaEnvironment;
-import io.specmesh.kafka.provision.Provisioner;
 import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.Schema;
 import java.nio.file.Path;
@@ -85,19 +80,5 @@ class SchemaChangeSetCalculatorsTest {
 
     private static Path filename(final String extra) {
         return Path.of("./build/resources/test/schema/" + SCHEMA_FILENAME + extra);
-    }
-
-    static ParsedSchema getSchema(final String schemaRefType, final String content) {
-
-        if (schemaRefType.endsWith(".avsc")) {
-            return new AvroSchema(content);
-        }
-        if (schemaRefType.endsWith(".yml")) {
-            return new JsonSchema(content);
-        }
-        if (schemaRefType.endsWith(".proto")) {
-            return new ProtobufSchema(content);
-        }
-        throw new Provisioner.ProvisioningException("Unsupported schema type");
     }
 }


### PR DESCRIPTION
BREAKING CHANGE: `Provision` and `Provisioner` types changes are not backwards compatible, depending on usage. Command line should not have changed.

Previous design didn't allow for new versions to accept new parameters to be provided. Using a builder factory makes the api more evolvable.
