### PR TITLE
Support generated usernames

### DIFF
--- a/cli/src/main/java/io/specmesh/cli/Provision.java
+++ b/cli/src/main/java/io/specmesh/cli/Provision.java
@@ -64,14 +64,8 @@ public final class Provision implements Callable<Integer> {
                             + "` from:"
                             + new File(propertyFilename).getAbsolutePath());
             properties.load(fis);
-            properties
-                    .entrySet()
-                    .forEach(
-                            entry -> {
-                                properties.put(
-                                        entry.getKey().toString().replace(".", "-"),
-                                        entry.getValue());
-                            });
+            properties.forEach(
+                    (key, value) -> properties.put(key.toString().replace(".", "-"), value));
             System.out.println(
                     "Loaded `properties` from cwd:" + new File(propertyFilename).getAbsolutePath());
         } catch (IOException e) {
@@ -82,7 +76,7 @@ public final class Provision implements Callable<Integer> {
                             + new File(propertyFilename).getAbsolutePath()
                             + "\nERROR:"
                             + e);
-            e.printStackTrace();
+            throw new RuntimeException(e);
         }
 
         final var provider = new CommandLine.PropertiesDefaultProvider(properties);

--- a/cli/src/main/java/io/specmesh/cli/Provision.java
+++ b/cli/src/main/java/io/specmesh/cli/Provision.java
@@ -147,6 +147,22 @@ public final class Provision implements Callable<Integer> {
     }
 
     @Option(
+            names = {"-du", "--domain-user"},
+            description =
+                    "optional custom domain user, to be used when creating ACLs. By default,"
+                        + " specmesh expects the principle used to authenticate with Kafka to have"
+                        + " the same name as the domain id. For example, given a domain id of"
+                        + " 'urn:acme.products', specmesh expects the user to be called"
+                        + " 'acme.products', and creates ACLs accordingly. In some situations, e.g."
+                        + " Confluent Cloud Service Accounts, the username is system generated or"
+                        + " outside control of administrators.  In these situations, use this"
+                        + " option to provide the generated username and specmesh will provision"
+                        + " ACLs accordingly.")
+    public void domainUserAlias(final String alias) {
+        builder.domainUserAlias(alias);
+    }
+
+    @Option(
             names = {"-u", "--username"},
             description = "username or api key for the Kafka cluster connection")
     public void username(final String username) {

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -147,7 +147,7 @@ public final class Clients {
      * @return true if principal was set
      */
     private static boolean isPrincipalSpecified(final String principal) {
-        return principal != null && principal.length() > 0;
+        return principal != null && !principal.isEmpty();
     }
 
     private static String buildJaasConfig(final String userName, final String password) {

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -226,7 +226,7 @@ public final class Clients {
             final Class<?> valueSerializerClass,
             final boolean acksAll,
             final Map<String, Object>... additionalProperties) {
-        final Map<String, Object> props = clientProperties(domainId, bootstrapServers);
+        final Map<String, Object> props = clientProperties(bootstrapServers);
         props.putAll(
                 Map.of(
                         AdminClientConfig.CLIENT_ID_CONFIG,
@@ -279,7 +279,7 @@ public final class Clients {
             final boolean acksAll,
             final Map<String, Object>... additionalProperties) {
 
-        final Map<String, Object> props = clientProperties(domainId, bootstrapServers);
+        final Map<String, Object> props = clientProperties(bootstrapServers);
         props.putAll(
                 Map.of(
                         StreamsConfig.APPLICATION_ID_CONFIG,
@@ -354,7 +354,7 @@ public final class Clients {
             final Class<?> valueDeserializerClass,
             final boolean autoOffsetResetEarliest,
             final Map<String, Object>... additionalProperties) {
-        final Map<String, Object> props = clientProperties(domainId, bootstrapServers);
+        final Map<String, Object> props = clientProperties(bootstrapServers);
         props.putAll(
                 Map.of(
                         ConsumerConfig.CLIENT_ID_CONFIG,
@@ -375,10 +375,8 @@ public final class Clients {
         return props;
     }
 
-    private static Map<String, Object> clientProperties(
-            final String domainId, final String bootstrapServers) {
+    private static Map<String, Object> clientProperties(final String bootstrapServers) {
         final Map<String, Object> basicProps = new HashMap<>();
-        basicProps.put(AdminClientConfig.CLIENT_ID_CONFIG, domainId);
         basicProps.put(AdminClientConfig.BOOTSTRAP_SERVERS_CONFIG, bootstrapServers);
         return basicProps;
     }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/AclProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/AclProvisioner.java
@@ -35,6 +35,7 @@ public final class AclProvisioner {
 
     /** defensive */
     private AclProvisioner() {}
+
     /**
      * Provision acls in the Kafka cluster
      *
@@ -44,14 +45,38 @@ public final class AclProvisioner {
      * @param adminClient cluster connection
      * @return status of provisioning
      * @throws ProvisioningException on interrupt
+     * @deprecated use {@link AclProvisioner#provision(boolean, boolean, KafkaApiSpec, String,
+     *     Admin)}
      */
+    @Deprecated(forRemoval = true, since = "0.10.1")
     public static Collection<Acl> provision(
             final boolean dryRun,
             final boolean cleanUnspecified,
             final KafkaApiSpec apiSpec,
             final Admin adminClient) {
 
-        final var requiredAcls = bindingsToAcls(apiSpec.requiredAcls());
+        return provision(dryRun, cleanUnspecified, apiSpec, apiSpec.id(), adminClient);
+    }
+
+    /**
+     * Provision acls in the Kafka cluster
+     *
+     * @param dryRun for mode of operation
+     * @param cleanUnspecified remove unwanted
+     * @param apiSpec respect the spec
+     * @param userName user name
+     * @param adminClient cluster connection
+     * @return status of provisioning
+     * @throws ProvisioningException on interrupt
+     */
+    public static Collection<Acl> provision(
+            final boolean dryRun,
+            final boolean cleanUnspecified,
+            final KafkaApiSpec apiSpec,
+            final String userName,
+            final Admin adminClient) {
+
+        final var requiredAcls = bindingsToAcls(apiSpec.requiredAcls(userName));
         final var existing = reader(adminClient).read(apiSpec.id(), requiredAcls);
 
         final var required = calculator(cleanUnspecified).calculate(existing, requiredAcls);

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
@@ -129,7 +129,7 @@ class KafkaAPISpecFunctionalTest {
     static void setUp() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
             TopicProvisioner.provision(false, false, API_SPEC, adminClient);
-            AclProvisioner.provision(false, false, API_SPEC, adminClient);
+            AclProvisioner.provision(false, false, API_SPEC, API_SPEC.id(), adminClient);
         }
     }
 

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
@@ -153,7 +153,8 @@ class ProvisionerFreshStartFunctionalTest {
     void shouldDryRunACLsFromEmptyCluster() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            final var changeset = AclProvisioner.provision(true, false, API_SPEC, adminClient);
+            final var changeset =
+                    AclProvisioner.provision(true, false, API_SPEC, API_SPEC.id(), adminClient);
 
             // Verify - 11 created
             assertThat(
@@ -286,7 +287,8 @@ class ProvisionerFreshStartFunctionalTest {
     void shouldDoRealACLsFromEmptyCluster() throws ExecutionException, InterruptedException {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            final var changeset = AclProvisioner.provision(false, false, API_SPEC, adminClient);
+            final var changeset =
+                    AclProvisioner.provision(false, false, API_SPEC, API_SPEC.id(), adminClient);
 
             // Verify - 11 created
             assertThat(

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
@@ -62,6 +62,7 @@ import org.junit.jupiter.api.extension.RegisterExtension;
  * Tests execution DryRuns and UPDATES where the provisioner-functional-test-api.yml is NOT
  * provisioned
  */
+@SuppressWarnings("OptionalGetWithoutIsPresent")
 @SuppressFBWarnings(
         value = "IC_INIT_CIRCULARITY",
         justification = "shouldHaveInitializedEnumsCorrectly() proves this is false positive")

--- a/kafka/src/test/java/io/specmesh/kafka/provision/AclProvisionerUpdateFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/AclProvisionerUpdateFunctionalTest.java
@@ -102,7 +102,7 @@ class AclProvisionerUpdateFunctionalTest {
     @Order(1)
     void shouldProvisionExistingSpec() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
-            AclProvisioner.provision(false, false, API_SPEC, adminClient);
+            AclProvisioner.provision(false, false, API_SPEC, API_SPEC.id(), adminClient);
         }
     }
 
@@ -111,14 +111,16 @@ class AclProvisionerUpdateFunctionalTest {
     void shouldPublishUpdatedAcls() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
             final var dryRunAcls =
-                    AclProvisioner.provision(true, false, API_UPDATE_SPEC, adminClient);
+                    AclProvisioner.provision(
+                            true, false, API_UPDATE_SPEC, API_UPDATE_SPEC.id(), adminClient);
             assertThat(dryRunAcls, is(hasSize(2)));
             assertThat(
                     dryRunAcls.stream().filter(acl -> acl.state().equals(STATE.CREATE)).count(),
                     is(2L));
 
             final var createdAcls =
-                    AclProvisioner.provision(false, false, API_UPDATE_SPEC, adminClient);
+                    AclProvisioner.provision(
+                            false, false, API_UPDATE_SPEC, API_UPDATE_SPEC.id(), adminClient);
 
             assertThat(createdAcls, is(hasSize(2)));
             assertThat(
@@ -149,11 +151,13 @@ class AclProvisionerUpdateFunctionalTest {
                     .all()
                     .get(Provisioner.REQUEST_TIMEOUT, TimeUnit.SECONDS);
 
-            final var dryRunAcls = AclProvisioner.provision(true, true, API_SPEC, adminClient);
+            final var dryRunAcls =
+                    AclProvisioner.provision(true, true, API_SPEC, API_SPEC.id(), adminClient);
             assertThat(dryRunAcls, is(hasSize(1)));
             assertThat(dryRunAcls.iterator().next().state(), is(STATE.DELETE));
 
-            final var createdAcls = AclProvisioner.provision(false, true, API_SPEC, adminClient);
+            final var createdAcls =
+                    AclProvisioner.provision(false, true, API_SPEC, API_SPEC.id(), adminClient);
 
             assertThat(createdAcls, is(hasSize(1)));
             assertThat(createdAcls.iterator().next().state(), is(STATE.DELETED));


### PR DESCRIPTION
Some platforms do not allow the administrator to control / choose the name of the principle. Instead, it is a generated name.

For example, Confluent Cloud when using Service Accounts, uses the system generated account id as the principle name, e.g. `sa-l35n4kd`

Specmesh now supports tweaking the ACLs created to use the system generated principle name via:

1. the `Provisioner.builder().domainUserAlias("bob")` method.
2. the `--domain-user` or `-du` command line parameters to `Provision` command.