### PR TITLE
Fix sr env in `DockerKafkaEnvironment`

### DIFF
--- a/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
@@ -370,7 +370,7 @@ public final class DockerKafkaEnvironment
          * @return self.
          */
         public Builder withSchemaRegistryEnv(final Map<String, String> env) {
-            this.kafkaEnv.putAll(env);
+            this.srEnv.putAll(env);
             return this;
         }
 


### PR DESCRIPTION
`DockerKafkaEnvironment.Builder.withSchemaRegistryEnv` calls were incorrectly being sent to the Kafka container, not the Schema registry container.