### PR TITLE
Partition and replica count in KafkaBinding should be optional

### DIFF
--- a/kafka/src/main/java/io/specmesh/kafka/Exporter.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Exporter.java
@@ -25,6 +25,7 @@ import io.specmesh.kafka.provision.TopicProvisioner.Topic;
 import io.specmesh.kafka.provision.TopicReaders;
 import io.specmesh.kafka.provision.TopicReaders.TopicsReaderBuilder;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.Admin;
 
@@ -93,8 +94,8 @@ public final class Exporter {
     private static KafkaBinding kafkaBindings(final Topic topic) {
         return KafkaBinding.builder()
                 .bindingVersion("unknown")
-                .replicas(topic.replication())
-                .partitions(topic.partitions())
+                .replicas(Optional.of(topic.replication()))
+                .partitions(Optional.of(topic.partitions()))
                 .configs(topic.config())
                 .build();
     }

--- a/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
+++ b/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
@@ -98,7 +98,7 @@ public final class KafkaApiSpec {
                                 new NewTopic(
                                                 e.getKey(),
                                                 e.getValue().bindings().kafka().partitions(),
-                                                (short) e.getValue().bindings().kafka().replicas())
+                                                e.getValue().bindings().kafka().replicas())
                                         .configs(e.getValue().bindings().kafka().configs()))
                 .collect(Collectors.toList());
     }

--- a/kafka/src/test/java/io/specmesh/kafka/ExporterFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ExporterFunctionalTest.java
@@ -39,6 +39,7 @@ import io.specmesh.test.TestSpecLoader;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.common.acl.AccessControlEntry;
@@ -137,6 +138,13 @@ class ExporterFunctionalTest {
                                                                         KafkaBinding.builder()
                                                                                 .groupId(
                                                                                         "kafka-binding-group-id")
+                                                                                .partitions(
+                                                                                        Optional.of(
+                                                                                                1))
+                                                                                .replicas(
+                                                                                        Optional.of(
+                                                                                                (short)
+                                                                                                        3))
                                                                                 .build())
                                                                 .build())
                                                 .build()))

--- a/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
@@ -49,9 +49,9 @@ public class KafkaBinding {
 
     @Builder.Default @JsonProperty private List<String> envs = List.of();
 
-    @Builder.Default @JsonProperty private int partitions = 1;
+    @Builder.Default @JsonProperty private Optional<Integer> partitions = Optional.empty();
 
-    @Builder.Default @JsonProperty private int replicas = 3;
+    @Builder.Default @JsonProperty private Optional<Short> replicas = Optional.empty();
 
     @Builder.Default @JsonProperty private Map<String, String> configs = Map.of();
 

--- a/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/AsyncApiParserTest.java
@@ -25,6 +25,7 @@ import io.specmesh.apiparser.model.ApiSpec;
 import io.specmesh.apiparser.model.Bindings;
 import io.specmesh.apiparser.model.Channel;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.kafka.common.config.TopicConfig;
 import org.hamcrest.Matchers;
@@ -64,8 +65,8 @@ public class AsyncApiParserTest {
 
         final Bindings producerBindings =
                 channelsMap.get(".simple.streetlights._public.light.measured").bindings();
-        assertThat(producerBindings.kafka().partitions(), is(3));
-        assertThat(producerBindings.kafka().replicas(), is(1));
+        assertThat(producerBindings.kafka().partitions(), is(Optional.of(3)));
+        assertThat(producerBindings.kafka().replicas(), is(Optional.of((short) 1)));
 
         assertThat(
                 "Should use absolute path",

--- a/parser/src/test/java/io/specmesh/apiparser/model/KafkaBindingTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/model/KafkaBindingTest.java
@@ -1,0 +1,66 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.specmesh.apiparser.parse.SpecMapper;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class KafkaBindingTest {
+
+    private static final JsonMapper MAPPER = SpecMapper.mapper();
+
+    @Test
+    void shouldParseMinimal() throws Exception {
+        // Given:
+        final String yaml = "configs: {}";
+
+        // When:
+        final KafkaBinding binding = MAPPER.readValue(yaml, KafkaBinding.class);
+
+        // Then:
+        assertThat(binding, is(KafkaBinding.builder().build()));
+    }
+
+    @Test
+    void shouldParsePartitions() throws Exception {
+        // Given:
+        final String yaml = "partitions: 4";
+
+        // When:
+        final KafkaBinding binding = MAPPER.readValue(yaml, KafkaBinding.class);
+
+        // Then:
+        assertThat(binding.partitions(), is(Optional.of(4)));
+    }
+
+    @Test
+    void shouldParseReplicationFactor() throws Exception {
+        // Given:
+        final String yaml = "replicas: 2";
+
+        // When:
+        final KafkaBinding binding = MAPPER.readValue(yaml, KafkaBinding.class);
+
+        // Then:
+        assertThat(binding.replicas(), is(Optional.of((short) 2)));
+    }
+}


### PR DESCRIPTION
The Kafka cluster has default partition and replica counts. Users should be able to leverage these defaults if they choose by not explicitly setting the counts in the spec.

This can be particularly useful for replica counts, where different environments can set different default counts to save money, e.g. dev: 1, prod: 3
