### PR TITLE
Stick at protobuf3 for now...

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,9 @@ updates:
     open-pull-requests-limit: 50
     schedule:
       interval: monthly
+    ignore:
+      - dependency-name: "com.google.protobuf:protobuf-java"
+        update-types: [ "version-update:semver-major" ]
   - package-ecosystem: gradle
     directory: /
     open-pull-requests-limit: 50


### PR DESCRIPTION
Stop dependabot raising PRs to upgrade to proto4 like https://github.com/specmesh/specmesh-build/pull/369