### PR TITLE
Spec's returned from parser should be valid.

### DIFF
--- a/cli/resources/simple_schema_demo-api.yaml
+++ b/cli/resources/simple_schema_demo-api.yaml
@@ -102,6 +102,7 @@ channels:
   london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
+      operationId: onTube
       bindings:
         kafka:
           groupId: 'aConsumerGroupId'

--- a/kafka/src/main/java/io/specmesh/kafka/Exporter.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Exporter.java
@@ -87,7 +87,7 @@ public final class Exporter {
     private static Channel channel(final Topic topic) {
         return Channel.builder()
                 .bindings(Bindings.builder().kafka(kafkaBindings(topic)).build())
-                .publish(Operation.builder().build())
+                .publish(Operation.builder().operationId("OnPublish").build())
                 .build();
     }
 

--- a/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
@@ -110,8 +110,6 @@ public final class Provisioner {
             final AclProvision aclProvision) {
         final String userName = domainUserAlias.isBlank() ? apiSpec.id() : domainUserAlias;
 
-        apiSpec.apiSpec().validate();
-
         final Status.StatusBuilder status =
                 Status.builder()
                         .topics(

--- a/kafka/src/test/java/io/specmesh/kafka/provision/ProvisionerTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/ProvisionerTest.java
@@ -211,7 +211,6 @@ class ProvisionerTest {
                 .provision(anyBoolean(), anyBoolean(), eq(explicitSpec), any(), any());
         verify(aclProvisioner)
                 .provision(anyBoolean(), anyBoolean(), eq(explicitSpec), any(), any());
-        verify(explicitSpec.apiSpec()).validate();
     }
 
     @Test
@@ -387,24 +386,6 @@ class ProvisionerTest {
 
         // Then:
         verify(aclProvisioner).provision(anyBoolean(), anyBoolean(), any(), eq("bob"), any());
-    }
-
-    @Test
-    void shouldValidateSpec() {
-        // Given:
-        final Provisioner provisioner = minimalBuilder().build();
-
-        // When:
-        provisioner.provision(
-                adminFactory,
-                srClientFactory,
-                specLoader,
-                topicProvisioner,
-                schemaProvisioner,
-                aclProvisioner);
-
-        // Then:
-        verify(spec.apiSpec()).validate();
     }
 
     @Test

--- a/kafka/src/test/resources/bigdatalondon-api-with-grant-access-acls.yaml
+++ b/kafka/src/test/resources/bigdatalondon-api-with-grant-access-acls.yaml
@@ -68,6 +68,7 @@ channels:
 
     publish:
       summary: Humans purchasing food
+      operationId: onPublishFood
       tags: [
         name: "grant-access:some.other.domain.root"
       ]
@@ -105,6 +106,7 @@ channels:
 
     publish:
       summary: Humans customers
+      operationId: onPublishCustomers
       message:
         name: Food Item
         tags: [
@@ -136,6 +138,7 @@ channels:
   paris.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
+      operationId: onSub
       message:
         name: Human
         payload:

--- a/kafka/src/test/resources/bigdatalondon-api.yaml
+++ b/kafka/src/test/resources/bigdatalondon-api.yaml
@@ -63,6 +63,7 @@ channels:
 
     publish:
       summary: Humans purchasing food
+      operationId: onPublishFood
       tags: [
         name: "grant-access:some.other.domain.root"
       ]
@@ -99,6 +100,7 @@ channels:
 
     publish:
       summary: Humans customers
+      operationId: onPublishCustomers
       message:
         name: Food Item
         bindings:
@@ -129,6 +131,7 @@ channels:
   london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
+      operationId: onSubscribeTube
       message:
         name: Human
         bindings:

--- a/kafka/src/test/resources/customacl-bigdatalondon-api.yaml
+++ b/kafka/src/test/resources/customacl-bigdatalondon-api.yaml
@@ -63,6 +63,7 @@ channels:
 
     publish:
       summary: Humans purchasing food
+      operationId: onPublishFood
       tags: [
         name: "grant-access:some.other.domain.root"
       ]
@@ -95,6 +96,7 @@ channels:
 
     publish:
       summary: Humans customers
+      operationId: onPublishCustomers
       message:
         name: Food Item
         tags: [
@@ -121,6 +123,7 @@ channels:
   london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
+      operationId: onSubscribeTube
       message:
         name: Human
         payload:

--- a/parser/src/main/java/io/specmesh/apiparser/model/Bindings.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Bindings.java
@@ -35,8 +35,4 @@ import lombok.experimental.Accessors;
 public class Bindings {
 
     @JsonProperty private KafkaBinding kafka;
-
-    public void validate() {
-        kafka.validate();
-    }
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/Channel.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Channel.java
@@ -41,16 +41,4 @@ public class Channel {
     @JsonProperty Operation publish;
 
     @JsonProperty Operation subscribe;
-
-    public void validate() {
-        if (this.bindings != null) {
-            this.bindings.validate();
-        }
-        if (publish != null) {
-            publish.validate();
-        }
-        if (subscribe != null) {
-            subscribe.validate();
-        }
-    }
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/KafkaBinding.java
@@ -80,6 +80,4 @@ public class KafkaBinding {
     public List<String> envs() {
         return List.copyOf(envs);
     }
-
-    public void validate() {}
 }

--- a/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Operation.java
@@ -16,6 +16,9 @@
 
 package io.specmesh.apiparser.model;
 
+import static java.util.Objects.requireNonNull;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -23,12 +26,9 @@ import io.specmesh.apiparser.AsyncApiParser.APIParserException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
-import lombok.NoArgsConstructor;
 import lombok.experimental.Accessors;
 
 /**
@@ -41,14 +41,12 @@ import lombok.experimental.Accessors;
  */
 @Builder
 @Data
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(access = AccessLevel.PRIVATE)
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @SuppressFBWarnings
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @SuppressWarnings("rawtypes")
-public class Operation {
+public final class Operation {
     @EqualsAndHashCode.Include @JsonProperty private String operationId;
 
     @JsonProperty private String summary;
@@ -64,6 +62,24 @@ public class Operation {
 
     @JsonProperty private Message message;
 
+    @JsonCreator
+    private Operation(
+            @JsonProperty(required = true, value = "operationId") final String operationId,
+            @JsonProperty("summary") final String summary,
+            @JsonProperty("description") final String description,
+            @JsonProperty("tags") final List<Tag> tags,
+            @JsonProperty("bindings") final Bindings bindings,
+            @JsonProperty("traits") final Map traits,
+            @JsonProperty("message") final Message message) {
+        this.operationId = requireNonNull(operationId, "operationId");
+        this.summary = summary;
+        this.description = description;
+        this.tags = tags == null ? List.of() : List.copyOf(tags);
+        this.bindings = bindings;
+        this.traits = traits;
+        this.message = message;
+    }
+
     /**
      * @return schema info
      */
@@ -77,12 +93,6 @@ public class Operation {
             throw new APIParserException(
                     "Error extracting schemas from (publish|subscribe) operation: " + operationId,
                     e);
-        }
-    }
-
-    public void validate() {
-        if (operationId == null) {
-            throw new APIParserException("(publish|subscribe) operationId  is null");
         }
     }
 }

--- a/parser/src/test/java/io/specmesh/apiparser/model/OperationTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/model/OperationTest.java
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import com.fasterxml.jackson.databind.json.JsonMapper;
+import io.specmesh.apiparser.parse.SpecMapper;
+import org.junit.jupiter.api.Test;
+
+class OperationTest {
+
+    private static final JsonMapper MAPPER = SpecMapper.mapper();
+
+    @Test
+    void shouldParseMinimal() throws Exception {
+        // Given:
+        final String yaml = "operationId: something";
+
+        // When:
+        final Operation binding = MAPPER.readValue(yaml, Operation.class);
+
+        // Then:
+        assertThat(binding, is(Operation.builder().operationId("something").build()));
+    }
+
+    @Test
+    void shouldThrowWhenParsingIfMissingOperationId() {
+        // Given:
+        final String yaml = "summary: something";
+
+        // When:
+        final Exception e =
+                assertThrows(Exception.class, () -> MAPPER.readValue(yaml, Operation.class));
+
+        // Then:
+        assertThat(e.getMessage(), containsString("operationId"));
+    }
+
+    @Test
+    void shouldThrowFromBuilderIfMissingOperationId() {
+        // When:
+        final Exception e = assertThrows(Exception.class, () -> Operation.builder().build());
+
+        // Then:
+        assertThat(e.getMessage(), containsString("operationId"));
+    }
+}

--- a/parser/src/test/resources/parser_simple_schema_demo-api.yaml
+++ b/parser/src/test/resources/parser_simple_schema_demo-api.yaml
@@ -50,6 +50,7 @@ channels:
   london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
+      operationId: onSub
       bindings:
         kafka:
           groupId: 'aConsumerGroupId'

--- a/parser/src/test/resources/test-streetlights-simple-api.yaml
+++ b/parser/src/test/resources/test-streetlights-simple-api.yaml
@@ -54,6 +54,7 @@ channels:
   london.hammersmith.transport._public.tube:
     subscribe:
       summary: Humans arriving in the borough
+      operationId: onSub
       bindings:
         kafka:
           groupId: 'aConsumerGroupId'


### PR DESCRIPTION
`operationId` is a required field of `Operation`, but the check for it is only done in the provision call. This means the parser can return a spec that is invalid = bad.

This change makes the parsing fail if the `operationId` is missing.

The change also applies the "don't allow your objects to get into an invalid state" best practice. Which removes the need for a `validate` method.
