### PR TITLE
  #406 ensure schema references are ordered correctly

### DIFF
--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
@@ -34,6 +34,7 @@ import io.specmesh.kafka.provision.schema.SchemaReaders.SchemaReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -78,7 +79,15 @@ public final class SchemaProvisioner {
         }
 
         final var schemas = calculator(client, cleanUnspecified).calculate(existing, required);
-        return mutator(dryRun, cleanUnspecified, client).mutate(schemas);
+        return mutator(dryRun, cleanUnspecified, client).mutate(sortByReferences(schemas));
+    }
+
+    private static Collection<Schema> sortByReferences(final Collection<Schema> schemas) {
+        return schemas.stream()
+                .sorted(
+                        Comparator.comparingInt(
+                                o -> o.schemas.iterator().next().references().size()))
+                .collect(Collectors.toList());
     }
 
     /**

--- a/kafka/src/test/java/io/specmesh/kafka/provision/SchemaProvisionerReferenceTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/SchemaProvisionerReferenceTest.java
@@ -26,7 +26,6 @@ import io.specmesh.test.TestSpecLoader;
 import java.util.ArrayList;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.MethodOrderer;
-import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -61,7 +60,6 @@ class SchemaProvisionerReferenceTest {
                     .build();
 
     @Test
-    @Order(1)
     void shouldProvisionSpecWithMissingRefToCurrency() {
 
         final var provision =
@@ -80,7 +78,6 @@ class SchemaProvisionerReferenceTest {
     }
     /** publish common schema (via api) and also domain-owned schema */
     @Test
-    @Order(2)
     void shouldProvisionTwoSpecsWithRefs() {
 
         final var provisionCommon =
@@ -113,7 +110,6 @@ class SchemaProvisionerReferenceTest {
     }
 
     @Test
-    @Order(3)
     void shouldProvisionSpecsWithMultipleRefsSoThatZeroRefsRegisterFirst() {
 
         final var provisionBothSchemas =

--- a/kafka/src/test/java/io/specmesh/kafka/provision/SchemaProvisionerReferenceTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/SchemaProvisionerReferenceTest.java
@@ -26,6 +26,7 @@ import io.specmesh.test.TestSpecLoader;
 import java.util.ArrayList;
 import org.hamcrest.Matchers;
 import org.junit.jupiter.api.MethodOrderer;
+import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -60,6 +61,7 @@ class SchemaProvisionerReferenceTest {
                     .build();
 
     @Test
+    @Order(1)
     void shouldProvisionSpecWithMissingRefToCurrency() {
 
         final var provision =
@@ -78,6 +80,7 @@ class SchemaProvisionerReferenceTest {
     }
     /** publish common schema (via api) and also domain-owned schema */
     @Test
+    @Order(2)
     void shouldProvisionTwoSpecsWithRefs() {
 
         final var provisionCommon =
@@ -110,6 +113,7 @@ class SchemaProvisionerReferenceTest {
     }
 
     @Test
+    @Order(3)
     void shouldProvisionSpecsWithMultipleRefsSoThatZeroRefsRegisterFirst() {
 
         final var provisionBothSchemas =

--- a/kafka/src/test/resources/schema-ref/com.example.single-spec-with-refs-api.yml
+++ b/kafka/src/test/resources/schema-ref/com.example.single-spec-with-refs-api.yml
@@ -1,0 +1,58 @@
+asyncapi: '2.4.0'
+id: 'urn:com.example.refs'
+info:
+  title: Common Data Set
+  version: '1.0.0'
+  description: |
+    Contains both a TRADE and Currency - where Trade --> Currency, it will provision both - but should determine the ref and process the 0 refs first
+servers:
+  mosquitto:
+    url: mqtt://test.mosquitto.org
+    protocol: kafka
+channels:
+  _public.trade:
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 3
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+          retention.ms: 999000
+    publish:
+      summary: Trade feed
+      description: Doing clever things
+      operationId: onTrade received
+      message:
+        bindings:
+          kafka:
+            schemaIdLocation: "header"
+            key:
+              type: string
+
+        schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
+        contentType: "application/octet-stream"
+        payload:
+          $ref: "/schema/com.example.trading.Trade.avsc"
+  _public.currency:
+    bindings:
+      kafka:
+        configs:
+          retention.ms: 999000
+    publish:
+      summary: Currency things
+      operationId: onCurrencyUpdate
+      message:
+        schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
+        contentType: "application/octet-stream"
+        bindings:
+          kafka:
+            schemaIdLocation: "header"
+            schemaLookupStrategy: "RecordNameStrategy"
+            key:
+              type: string
+        payload:
+          $ref: "/schema/com.example.shared.Currency.avsc"
+


### PR DESCRIPTION
. Added test to load a spec with Currency and also Trade - currency is ref'd by Trade, the sort will ensure that '0' ref schemas register first. hard to test due to channel names being stored in a map


Labels marked with `**` are excluded from release notes

### Reviewer checklist
- [ ] Read the [contributing guide](https://github.com/mockito/mockito/blob/main/.github/CONTRIBUTING.md)
- [ ] PR should be motivated, i.e. what does it fix, why, and if relevant, how
- [ ] Ensure relevant issues are linked (description should include text like "Fixes #<issue number>")
- [ ] Ensure any appropriate documentation has been added or amended