### PR TITLE
Report incompatible schema

### DIFF
--- a/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
+++ b/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
@@ -405,6 +405,20 @@ public final class KafkaApiSpec {
         }
     }
 
+    /**
+     * Load from string
+     *
+     * @param spec the contents of the spec.
+     * @return loaded spec
+     */
+    public static KafkaApiSpec loadFromString(final String spec) {
+        try {
+            return new KafkaApiSpec(new AsyncApiParser().loadResource(spec));
+        } catch (Exception ex) {
+            throw new APIException("Failed to load spec:" + spec, ex);
+        }
+    }
+
     public ApiSpec apiSpec() {
         return apiSpec;
     }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/AclReaders.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/AclReaders.java
@@ -18,8 +18,8 @@ package io.specmesh.kafka.provision;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.specmesh.kafka.provision.AclProvisioner.Acl;
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import org.apache.kafka.clients.admin.Admin;
@@ -101,7 +101,7 @@ public class AclReaders {
                                 .toString()
                                 .contains(
                                         "org.apache.kafka.common.errors.SecurityDisabledException")) {
-                    return List.of();
+                    return new ArrayList<>();
                 }
                 throw new ProvisioningException("Failed to read ACLs", e);
             }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
@@ -83,7 +83,7 @@ public final class SchemaProvisioner {
         }
 
         final Collection<Schema> schemas =
-                calculator(client, cleanUnspecified).calculate(existing, required, apiSpec.id());
+                calculator(cleanUnspecified).calculate(existing, required, apiSpec.id());
         return mutator(dryRun, cleanUnspecified, client).mutate(schemas);
     }
 
@@ -112,8 +112,8 @@ public final class SchemaProvisioner {
      * @return calculator
      */
     private static SchemaChangeSetCalculators.ChangeSetCalculator calculator(
-            final SchemaRegistryClient client, final boolean cleanUnspecified) {
-        return SchemaChangeSetCalculators.builder().build(cleanUnspecified, client);
+            final boolean cleanUnspecified) {
+        return SchemaChangeSetCalculators.builder().build(cleanUnspecified);
     }
 
     /**

--- a/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaChangeSetCalculatorsTest.java
@@ -16,15 +16,11 @@
 package io.specmesh.kafka.provision.schema;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 
 import io.confluent.kafka.schemaregistry.ParsedSchema;
-import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
-import io.specmesh.kafka.DockerKafkaEnvironment;
-import io.specmesh.kafka.KafkaEnvironment;
 import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.Schema;
 import java.nio.file.Path;
@@ -33,77 +29,29 @@ import java.util.List;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-import org.junit.jupiter.api.extension.RegisterExtension;
 
 class SchemaChangeSetCalculatorsTest {
-
-    @RegisterExtension
-    private static final KafkaEnvironment KAFKA_ENV = DockerKafkaEnvironment.builder().build();
 
     private static final String DOMAIN_ID = "simple.provision_demo";
     private static final String SCHEMA_BASE = "simple.provision_demo._public.";
 
-    private SchemaRegistryClient client;
     private String subject;
 
     @BeforeEach
     void setUp() {
-        client = KAFKA_ENV.srClient();
         subject = "subject." + UUID.randomUUID();
     }
 
     @Test
-    void shouldOutputMessagesOnBorkedSchema() throws Exception {
+    void shouldDetectWhenSchemasHaveChanged() {
         // Given:
-        final ParsedSchema existingSchema = loadSchema(SCHEMA_BASE + "user_signed_up.avsc");
-
-        final int version = client.register(subject, existingSchema);
-
         final List<Schema> existing =
                 List.of(
                         Schema.builder()
                                 .type("AVRO")
                                 .subject(subject)
                                 .state(Status.STATE.READ)
-                                .schema(existingSchema.copy(version))
-                                .build());
-
-        final List<Schema> required =
-                List.of(
-                        Schema.builder()
-                                .type("AVRO")
-                                .subject(subject)
-                                .state(Status.STATE.READ)
-                                .schema(loadSchema(SCHEMA_BASE + "user_signed_up-v3-bad.avsc"))
-                                .build());
-
-        final var calculator = SchemaChangeSetCalculators.builder().build(false, client);
-
-        // When:
-        final Collection<Schema> schemas = calculator.calculate(existing, required, DOMAIN_ID);
-
-        // Then:
-        assertThat(schemas.iterator().next().state(), is(Status.STATE.FAILED));
-        assertThat(
-                schemas.iterator().next().messages(),
-                is(containsString("READER_FIELD_MISSING_DEFAULT_VALUE")));
-        assertThat(schemas.iterator().next().messages(), is(containsString("borked")));
-    }
-
-    @Test
-    void shouldDetectWhenSchemasHaveChanged() throws Exception {
-        // Given:
-        final ParsedSchema existingSchema = loadSchema(SCHEMA_BASE + "user_signed_up.avsc");
-
-        final int version = client.register(subject, existingSchema);
-
-        final List<Schema> existing =
-                List.of(
-                        Schema.builder()
-                                .type("AVRO")
-                                .subject(subject)
-                                .state(Status.STATE.READ)
-                                .schema(existingSchema.copy(version))
+                                .schema(loadSchema(SCHEMA_BASE + "user_signed_up.avsc").copy(1))
                                 .build());
 
         final List<Schema> required =
@@ -115,7 +63,7 @@ class SchemaChangeSetCalculatorsTest {
                                 .schema(loadSchema(SCHEMA_BASE + "user_signed_up-v2.avsc"))
                                 .build());
 
-        final var calculator = SchemaChangeSetCalculators.builder().build(false, client);
+        final var calculator = SchemaChangeSetCalculators.builder().build(false);
 
         // When:
         final Collection<Schema> schemas = calculator.calculate(existing, required, DOMAIN_ID);
@@ -129,19 +77,15 @@ class SchemaChangeSetCalculatorsTest {
     }
 
     @Test
-    void shouldDetectWhenSchemasHaveNotChanged() throws Exception {
+    void shouldDetectWhenSchemasHaveNotChanged() {
         // Given:
-        final ParsedSchema existingSchema = loadSchema(SCHEMA_BASE + "user_signed_up.avsc");
-
-        final int version = client.register(subject, existingSchema);
-
         final List<Schema> existing =
                 List.of(
                         Schema.builder()
                                 .type("AVRO")
                                 .subject(subject)
                                 .state(Status.STATE.READ)
-                                .schema(existingSchema.copy(version))
+                                .schema(loadSchema(SCHEMA_BASE + "user_signed_up.avsc").copy(1))
                                 .build());
 
         final List<Schema> required =
@@ -150,10 +94,10 @@ class SchemaChangeSetCalculatorsTest {
                                 .type("AVRO")
                                 .subject(subject)
                                 .state(Status.STATE.READ)
-                                .schema(existingSchema)
+                                .schema(loadSchema(SCHEMA_BASE + "user_signed_up.avsc"))
                                 .build());
 
-        final var calculator = SchemaChangeSetCalculators.builder().build(false, client);
+        final var calculator = SchemaChangeSetCalculators.builder().build(false);
 
         // When:
         final Collection<Schema> schemas = calculator.calculate(existing, required, DOMAIN_ID);
@@ -165,8 +109,6 @@ class SchemaChangeSetCalculatorsTest {
     @Test
     void shouldIgnoreSchemasOutsideOfDomain() {
         // Given:
-        final ParsedSchema requiredSchema = loadSchema("other.domain.Common.avsc");
-
         final List<Schema> existing = List.of();
 
         final List<Schema> required =
@@ -175,10 +117,10 @@ class SchemaChangeSetCalculatorsTest {
                                 .type("AVRO")
                                 .subject(subject)
                                 .state(Status.STATE.READ)
-                                .schema(requiredSchema)
+                                .schema(loadSchema("other.domain.Common.avsc"))
                                 .build());
 
-        final var calculator = SchemaChangeSetCalculators.builder().build(false, client);
+        final var calculator = SchemaChangeSetCalculators.builder().build(false);
 
         // When:
         final Collection<Schema> schemas = calculator.calculate(existing, required, DOMAIN_ID);

--- a/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaMutatorsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaMutatorsTest.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.specmesh.kafka.provision.schema;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import io.confluent.kafka.schemaregistry.ParsedSchema;
+import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
+import io.specmesh.kafka.DockerKafkaEnvironment;
+import io.specmesh.kafka.KafkaEnvironment;
+import io.specmesh.kafka.provision.Status;
+import java.nio.file.Path;
+import java.util.Collection;
+import java.util.List;
+import java.util.UUID;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+class SchemaMutatorsTest {
+
+    @RegisterExtension
+    private static final KafkaEnvironment KAFKA_ENV = DockerKafkaEnvironment.builder().build();
+
+    private static final String SCHEMA_BASE = "simple.provision_demo._public.";
+
+    private SchemaRegistryClient client;
+    private String subject;
+
+    @BeforeEach
+    void setUp() {
+        client = KAFKA_ENV.srClient();
+        subject = "subject." + UUID.randomUUID();
+    }
+
+    @Test
+    void shouldOutputMessagesOnBorkedSchema() throws Exception {
+        // Given:
+        client.register(subject, loadSchema(SCHEMA_BASE + "user_signed_up.avsc"));
+
+        final List<SchemaProvisioner.Schema> required =
+                List.of(
+                        SchemaProvisioner.Schema.builder()
+                                .type("AVRO")
+                                .subject(subject)
+                                .state(Status.STATE.UPDATE)
+                                .schema(loadSchema(SCHEMA_BASE + "user_signed_up-v3-bad.avsc"))
+                                .build());
+
+        final var mutators = SchemaMutators.builder().schemaRegistryClient(client).build();
+
+        // When:
+        final Collection<SchemaProvisioner.Schema> schemas = mutators.mutate(required);
+
+        // Then:
+        assertThat(schemas.iterator().next().state(), is(Status.STATE.FAILED));
+        assertThat(
+                schemas.iterator().next().messages(),
+                is(containsString("READER_FIELD_MISSING_DEFAULT_VALUE")));
+        assertThat(schemas.iterator().next().messages(), is(containsString("borked")));
+    }
+
+    private static ParsedSchema loadSchema(final String fileName) {
+        return new SchemaReaders.FileSystemSchemaReader()
+                .readLocal(Path.of("./src/test/resources/schema/" + fileName))
+                .iterator()
+                .next()
+                .schema();
+    }
+}

--- a/kafka/src/test/resources/provisioner-incompatible-functional-test-api.yaml
+++ b/kafka/src/test/resources/provisioner-incompatible-functional-test-api.yaml
@@ -1,0 +1,72 @@
+asyncapi: '2.4.0'
+id: 'urn:simple.provision_demo'
+info:
+  title: Streetlights API
+  version: '1.0.0'
+  description: |
+    The Smartylighting Streetlights API allows you
+    to remotely manage the city lights.
+  license:
+    name: Apache 2.0
+    url: 'https://www.apache.org/licenses/LICENSE-2.0'
+servers:
+  mosquitto:
+    url: mqtt://test.mosquitto.org
+    protocol: mqtt
+channels:
+  # PRODUCER/OWNER build pipe will publish schema to SR
+  _public.user_signed_up:
+    # publish bindings to instruct topic configuration per environment
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 99
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+          retention.ms: 999000
+
+    publish:
+      summary: Inform about signup
+      operationId: onUserSignedUp
+      message:
+        bindings:
+          kafka:
+            key:
+              $ref: schema/simple.provision_demo._public.user_signed_up.key.avsc
+            schemaIdLocation: "payload"
+        schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
+        contentType: "application/octet-stream"
+        payload:
+          $ref: "/schema/simple.provision_demo._public.user_signed_up-v3-bad.avsc"
+  _protected.user_info:
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 3
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+          retention.ms: 9900000
+
+    publish:
+      tags: [
+        name: "grant-access:some.other.domain.acme-A",
+        name: "grant-access:some.other.domain.acme-B"
+      ]
+      summary: User info confirmation
+      operationId: onUserCheckout
+      message:
+        bindings:
+          kafka:
+            key:
+              type: long
+            schemaIdLocation: "payload"
+        schemaFormat: "application/json;version=1.9.0"
+        contentType: "application/json"
+        payload:
+          $ref: "/schema/simple.provision_demo._public.user_info.proto"

--- a/parser/src/main/java/io/specmesh/apiparser/AsyncApiParser.java
+++ b/parser/src/main/java/io/specmesh/apiparser/AsyncApiParser.java
@@ -38,6 +38,17 @@ public class AsyncApiParser {
         return SpecMapper.mapper().readValue(inputStream, ApiSpec.class);
     }
 
+    /**
+     * Parse an {@link ApiSpec} from the supplied {@code content}.
+     *
+     * @param content the spec.
+     * @return the api spec
+     * @throws IOException on error
+     */
+    public final ApiSpec loadResource(final String content) throws IOException {
+        return SpecMapper.mapper().readValue(content, ApiSpec.class);
+    }
+
     public static class APIParserException extends RuntimeException {
         public APIParserException(final String message, final Exception cause) {
             super(message, cause);


### PR DESCRIPTION
fixes: https://github.com/specmesh/specmesh-build/issues/422

Previously, it was the change set calculator that checked for schema compatability, setting the status to `FAILED`. As there was no mutator to handled `FAILED` schema, any `FAILED` schema were filtered out and not returned to the caller.

This change sees the compatibility check moved to the mutator.
