### PR TITLE
Ensure `Status.check()` throws on Schema compatability issue

### DIFF
--- a/kafka/src/main/java/io/specmesh/kafka/provision/AclMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/AclMutators.java
@@ -77,9 +77,7 @@ public class AclMutators {
                 acls.stream()
                         .peek(
                                 acl ->
-                                        acl.state(STATE.FAILED)
-                                                .messages(
-                                                        acl.messages() + "\n Failed to delete ACLs")
+                                        acl.messages(acl.messages() + "\n Failed to delete ACLs")
                                                 .exception(
                                                         new ProvisioningException(
                                                                 "Failed to delete ACL", ex)));
@@ -135,7 +133,6 @@ public class AclMutators {
             } catch (Exception ex) {
                 createAcls.forEach(
                         acl -> {
-                            acl.state(STATE.FAILED);
                             acl.exception(
                                     new ProvisioningException(
                                             "Failed to provision set of Acls", ex));
@@ -153,9 +150,7 @@ public class AclMutators {
                         .filter(acl -> acl.state().equals(STATE.UPDATE))
                         .peek(
                                 acl ->
-                                        acl.state(STATE.FAILED)
-                                                .messages(
-                                                        acl.messages() + "\n Failed to delete ACLs")
+                                        acl.messages(acl.messages() + "\n Failed to delete ACLs")
                                                 .exception(
                                                         new ProvisioningException(
                                                                 "Failed to delete ACL", ex)));

--- a/kafka/src/main/java/io/specmesh/kafka/provision/AclProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/AclProvisioner.java
@@ -156,6 +156,7 @@ public final class AclProvisioner {
 
         public Acl exception(final Exception exception) {
             this.exception = new ExceptionWrapper(exception);
+            this.state = Status.STATE.FAILED;
             return this;
         }
     }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/ProvisioningException.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/ProvisioningException.java
@@ -21,4 +21,8 @@ public final class ProvisioningException extends RuntimeException {
     public ProvisioningException(final String msg, final Throwable cause) {
         super(msg, cause);
     }
+
+    public ProvisioningException(final String msg) {
+        super(msg);
+    }
 }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/Status.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/Status.java
@@ -80,7 +80,7 @@ public class Status {
                 all().flatMap(e -> Optional.ofNullable(e.exception()).stream())
                         .collect(Collectors.toList());
 
-        if (!exceptions.isEmpty()) {
+        if (!exceptions.isEmpty() || failed()) {
             throw new CompositeException(exceptions);
         }
     }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicMutators.java
@@ -165,8 +165,7 @@ public class TopicMutators {
                 topic.state(STATE.UPDATED);
 
             } catch (Exception ex) {
-                topic.state(STATE.FAILED)
-                        .exception(new ProvisioningException("Failed to update config ", ex));
+                topic.exception(new ProvisioningException("Failed to update config ", ex));
             }
         }
 
@@ -193,8 +192,7 @@ public class TopicMutators {
                                     + " higher");
                 }
             } catch (Exception ex) {
-                topic.state(STATE.FAILED)
-                        .exception(new ProvisioningException("Failed to update partitions", ex));
+                topic.exception(new ProvisioningException("Failed to update partitions", ex));
             }
         }
     }
@@ -248,9 +246,7 @@ public class TopicMutators {
                 unwanted.forEach(
                         topic ->
                                 topic.exception(
-                                                new ProvisioningException(
-                                                        "failed to delete topics", ex))
-                                        .state(STATE.FAILED));
+                                        new ProvisioningException("failed to delete topics", ex)));
             }
             return unwanted;
         }
@@ -306,9 +302,7 @@ public class TopicMutators {
                 topicsToCreate.forEach(
                         topic ->
                                 topic.exception(
-                                                new ProvisioningException(
-                                                        "failed to write topics", e))
-                                        .state(STATE.FAILED));
+                                        new ProvisioningException("failed to write topics", e)));
             }
             return topics;
         }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaMutators.java
@@ -19,14 +19,12 @@ package io.specmesh.kafka.provision.schema;
 import static io.specmesh.kafka.provision.Status.STATE.CREATED;
 import static io.specmesh.kafka.provision.Status.STATE.DELETE;
 import static io.specmesh.kafka.provision.Status.STATE.DELETED;
-import static io.specmesh.kafka.provision.Status.STATE.FAILED;
 import static io.specmesh.kafka.provision.Status.STATE.UPDATED;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.rest.exceptions.RestClientException;
 import io.specmesh.kafka.provision.ProvisioningException;
-import io.specmesh.kafka.provision.Status;
 import io.specmesh.kafka.provision.Status.STATE;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.Schema;
 import java.io.IOException;
@@ -121,7 +119,6 @@ public final class SchemaMutators {
                                             new ProvisioningException(
                                                     "Failed to update schema:" + schema.subject(),
                                                     e));
-                                    schema.state(FAILED);
                                 }
                             })
                     .collect(Collectors.toList());
@@ -165,7 +162,10 @@ public final class SchemaMutators {
                                     + "\nCompatibility test output:"
                                     + compatibilityMessages);
 
-                    schema.state(Status.STATE.FAILED);
+                    schema.exception(
+                            new ProvisioningException(
+                                    "Schema compatibility issue detected for subject: "
+                                            + schema.subject()));
                     return schema;
                 }
 
@@ -176,7 +176,6 @@ public final class SchemaMutators {
                 schema.exception(
                         new ProvisioningException(
                                 "Failed to update schema:" + schema.subject(), e));
-                schema.state(FAILED);
             }
             return schema;
         }
@@ -204,7 +203,6 @@ public final class SchemaMutators {
          */
         @Override
         public List<Schema> mutate(final Collection<Schema> schemas) {
-
             return schemas.stream()
                     .filter(schema -> schema.state().equals(STATE.CREATE))
                     .peek(
@@ -226,7 +224,6 @@ public final class SchemaMutators {
                                             new ProvisioningException(
                                                     "Failed to write schema:" + schema.subject(),
                                                     e));
-                                    schema.state(FAILED);
                                 }
                             })
                     .collect(Collectors.toList());

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
@@ -197,7 +197,6 @@ public final class SchemaProvisioner {
             return Stream.of(
                     Schema.builder()
                             .messages("Failed to parse: " + schemaRef)
-                            .state(FAILED)
                             .exception(ex)
                             .build());
         }


### PR DESCRIPTION
fixes: https://github.com/specmesh/specmesh-build/issues/422

Schema compatability issues were setting state to `FAILED` but not attaching an exception, which means `check()` wasn't throwing.

Updated the builder so setting an exception automatically sets state to `FAILED` and removed all explicit calls to `state(FAILED)`, instead ensuring exceptions are always set.
