### PR TITLE
Require domain id

### DIFF
--- a/parser/src/main/java/io/specmesh/apiparser/model/ApiSpec.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/ApiSpec.java
@@ -56,7 +56,7 @@ public final class ApiSpec {
     @JsonProperty private Map<String, Channel> channels;
 
     @JsonCreator
-    private ApiSpec(
+    ApiSpec(
             @JsonProperty("id") final String id,
             @JsonProperty("version") final String version,
             @JsonProperty("asyncapi") final String asyncapi,
@@ -67,7 +67,12 @@ public final class ApiSpec {
         this.channels = channels;
 
         if (!id.startsWith(URN_PREFIX)) {
-            throw new IllegalStateException("ID must be formatted as a URN, expecting urn:");
+            throw new IllegalArgumentException("ID must be formatted as a URN, expecting urn:");
+        }
+
+        if (id.substring(URN_PREFIX.length()).isBlank()) {
+            throw new IllegalArgumentException(
+                    "ID must define a domain id after the urn, e.g. urn:some.domain");
         }
     }
 

--- a/parser/src/test/java/io/specmesh/apiparser/model/ApiSpecTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/model/ApiSpecTest.java
@@ -1,0 +1,41 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.apiparser.model;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertThrows;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class ApiSpecTest {
+
+    @Test
+    void shouldThrowOnEmptyDomainId() {
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () -> new ApiSpec("urn: ", "1", "1", Map.of()));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("ID must define a domain id after the urn, e.g. urn:some.domain"));
+    }
+}


### PR DESCRIPTION
don't allow a spec to just have:

```
id: urn: 
```

It needs to define the domain id if things are to work correctly, e.g.

```
id: urn:my.domain.id
```