### PR TITLE
Allow loading schemas from the classpath

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -200,7 +200,6 @@ subprojects {
                 from(components["java"])
 
                 artifactId = "specmesh-${artifactId}"
-                project.group = "io.specmesh"
 
                 pom {
                     name.set("${project.group}:${artifactId}")

--- a/kafka-test/build.gradle.kts
+++ b/kafka-test/build.gradle.kts
@@ -25,8 +25,8 @@ val junitVersion : String by extra
 val protobufVersion : String by extra
 
 dependencies {
-    implementation(project(":parser"))
-    implementation(project(":kafka"))
+    api(project(":parser"))
+    api(project(":kafka"))
     api("org.junit.jupiter:junit-jupiter-api:$junitVersion")
     implementation("org.testcontainers:testcontainers:$testcontainersVersion")
     implementation("org.testcontainers:kafka:$testcontainersVersion")

--- a/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
@@ -45,7 +45,7 @@ public final class Provisioner {
     private String srApiSecret;
     private SchemaRegistryClient schemaRegistryClient;
     @Builder.Default private boolean closeSchemaClient = false;
-    private String schemaPath;
+    @Builder.Default private String schemaPath = "";
     @Builder.Default private String specPath = "";
     @Builder.Default private String domainUserAlias = "";
     private KafkaApiSpec apiSpec;

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaProvisioner.java
@@ -30,7 +30,7 @@ import io.specmesh.kafka.provision.ExceptionWrapper;
 import io.specmesh.kafka.provision.ProvisioningException;
 import io.specmesh.kafka.provision.ProvisioningTask;
 import io.specmesh.kafka.provision.Status;
-import io.specmesh.kafka.provision.schema.SchemaReaders.FileSystemSchemaReader.NamedSchema;
+import io.specmesh.kafka.provision.schema.SchemaReaders.NamedSchema;
 import io.specmesh.kafka.provision.schema.SchemaReaders.SchemaReader;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -174,7 +174,7 @@ public final class SchemaProvisioner {
         try {
             final Path schemaPath = Path.of(baseResourcePath.toString(), schemaRef);
             final List<NamedSchema> schemas =
-                    new SchemaReaders.FileSystemSchemaReader().readLocal(schemaPath);
+                    new SchemaReaders.LocalSchemaReader().read(schemaPath);
 
             return schemas.stream()
                     .map(

--- a/kafka/src/test/java/io/specmesh/kafka/provision/ProvisionerTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/ProvisionerTest.java
@@ -233,7 +233,7 @@ class ProvisionerTest {
         verify(srClientFactory).schemaRegistryClient("sr-url", null, null);
 
         verify(topicProvisioner).provision(false, false, spec, adminClient);
-        verify(schemaProvisioner).provision(false, false, spec, null, srClient);
+        verify(schemaProvisioner).provision(false, false, spec, "", srClient);
         verify(aclProvisioner).provision(false, false, spec, DOMAIN_ID, adminClient);
     }
 

--- a/kafka/src/test/java/io/specmesh/kafka/provision/SchemaProvisionerFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/SchemaProvisionerFunctionalTest.java
@@ -36,6 +36,7 @@ import io.specmesh.kafka.provision.schema.SchemaProvisioner;
 import io.specmesh.kafka.provision.schema.SchemaProvisioner.Schema;
 import io.specmesh.test.TestSpecLoader;
 import java.util.Collection;
+import java.util.List;
 import java.util.stream.Collectors;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -131,6 +132,19 @@ class SchemaProvisionerFunctionalTest {
 
     @Test
     @Order(2)
+    void shouldProvisionLoadingSchemaFromClassPath() {
+        // When:
+        final List<Schema> provisioned =
+                SchemaProvisioner.provision(false, false, API_SPEC, "", srClient);
+
+        // Then:
+        assertThat(
+                provisioned.stream().filter(topic -> topic.state() == STATE.FAILED).count(),
+                is(0L));
+    }
+
+    @Test
+    @Order(3)
     void shouldPublishUpdatedSchemas() throws Exception {
 
         final Collection<Schema> dryRunChangeset =
@@ -177,7 +191,7 @@ class SchemaProvisionerFunctionalTest {
     }
 
     @Test
-    @Order(3)
+    @Order(4)
     void shouldFailToPublishIncompatibleSchema() throws Exception {
         final Collection<Schema> dryRunChangeset =
                 SchemaProvisioner.provision(
@@ -214,7 +228,7 @@ class SchemaProvisionerFunctionalTest {
     }
 
     @Test
-    @Order(4)
+    @Order(5)
     void shouldRemoveUnspecdSchemas() throws Exception {
 
         final var subject = "simple.provision_demo._public.NOT_user_signed_up-value";

--- a/kafka/src/test/java/io/specmesh/kafka/provision/SchemaProvisionerReferenceTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/SchemaProvisionerReferenceTest.java
@@ -157,4 +157,18 @@ class SchemaProvisionerReferenceTest {
         final Schema commonSchema = bySubject.get("com.example.shared.Currency");
         assertThat(commonSchema.state(), is(Status.STATE.IGNORED));
     }
+
+    @Test
+    @Order(4)
+    void shouldProvisionFromClassPath() {
+        // When:
+        final List<Schema> provisioned =
+                SchemaProvisioner.provision(
+                        false, false, API_SPEC, "schema-ref", KAFKA_ENV.srClient());
+
+        // Then:
+        assertThat(
+                provisioned.stream().filter(topic -> topic.state() == Status.STATE.FAILED).count(),
+                is(0L));
+    }
 }

--- a/kafka/src/test/resources/provisioner-functional-test-api.yaml
+++ b/kafka/src/test/resources/provisioner-functional-test-api.yaml
@@ -40,7 +40,7 @@ channels:
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/simple.provision_demo._public.user_signed_up.avsc"
+          $ref: "schema/simple.provision_demo._public.user_signed_up.avsc"
   _protected.user_info:
     bindings:
       kafka:
@@ -68,4 +68,4 @@ channels:
         schemaFormat: "application/json;version=1.9.0"
         contentType: "application/json"
         payload:
-          $ref: "/schema/simple.provision_demo._public.user_info.proto"
+          $ref: "schema/simple.provision_demo._public.user_info.proto"

--- a/kafka/src/test/resources/schema-ref/com.example.shared-api.yml
+++ b/kafka/src/test/resources/schema-ref/com.example.shared-api.yml
@@ -31,5 +31,5 @@ channels:
             key:
               type: string
         payload:
-          $ref: "/schema/com.example.shared.Currency.avsc"
+          $ref: "schema/com.example.shared.Currency.avsc"
 

--- a/kafka/src/test/resources/schema-ref/com.example.trading-api.yml
+++ b/kafka/src/test/resources/schema-ref/com.example.trading-api.yml
@@ -39,7 +39,7 @@ channels:
         schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
         contentType: "application/octet-stream"
         payload:
-          $ref: "/schema/com.example.trading.Trade.avsc"
+          $ref: "schema/com.example.trading.Trade.avsc"
 
 
   # schema reference to - referenced here for topology reasons - schema also referenced from Trade.avsc
@@ -59,5 +59,5 @@ channels:
             key:
               type: string
         payload:
-          $ref: "/schema/com.example.shared.Currency.avsc"
+          $ref: "schema/com.example.shared.Currency.avsc"
 


### PR DESCRIPTION
There's already code to load a spec from the classpath, yet if that spec references schemas which as also available on the classpath, it fails.

This PR:
- introduces a `SchemaReaders.ClassPathSchemaReader` that loads schemas from the classpath
- introduces a `SchemaReaders.BaseLocalSchemaReader` and moves common functionality from `FileSystemSchemaReader` into it.
- introduces a `SchemaReaders.LocalSchemaReader` that tries to load from the classpath first and filesystem second.
- changes production usage of `FileSystemSchemaReader` to `LocalSchemaReader`

Additionally, this PR:
- sets the default schema path to an empty string, rather than an NPE being thrown if `schemaPath()` is not called.
- marks `:parser` and `:kafka` modules as part of the api of `:kafka-test` as they are part of the API of this module.
- removes a pointless `project.group = "io.specmesh"` line from in the build.gradle.kts file - its already set to that value higher up.
