### PR TITLE
Add tests to DockerKafkaEnvironment

### DIFF
--- a/kafka-test/src/main/java/io/specmesh/kafka/KafkaEnvironment.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/KafkaEnvironment.java
@@ -34,13 +34,6 @@ public interface KafkaEnvironment extends Extension {
 
     /**
      * @return Connection string for connecting to Schema Registry.
-     * @deprecated use {@link #schemaRegistryServer}
-     */
-    @Deprecated
-    String schemeRegistryServer();
-
-    /**
-     * @return Connection string for connecting to Schema Registry.
      */
     String schemaRegistryServer();
 

--- a/kafka-test/src/main/java/io/specmesh/kafka/schema/SchemaRegistryContainer.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/schema/SchemaRegistryContainer.java
@@ -66,7 +66,9 @@ public final class SchemaRegistryContainer extends GenericContainer<SchemaRegist
      *
      * @param kafka kafka container
      * @return self.
+     * @deprecated will be removed in future version.
      */
+    @Deprecated
     public SchemaRegistryContainer withKafka(final KafkaContainer kafka) {
         withNetwork(kafka.getNetwork());
         withEnv(

--- a/kafka-test/src/test/java/io/specmesh/kafka/DockerKafkaEnvironmentTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/DockerKafkaEnvironmentTest.java
@@ -1,0 +1,62 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package io.specmesh.kafka;
+
+import java.time.Duration;
+import java.util.function.Consumer;
+import org.junit.jupiter.api.Test;
+
+class DockerKafkaEnvironmentTest {
+
+    private static final int STARTUP_ATTEMPTS = 1;
+    private static final Duration STARTUP_DURATION = Duration.ofSeconds(15);
+
+    @Test
+    void shouldWorkWithoutSasl() {
+        assertStarts(builder -> {});
+    }
+
+    @Test
+    void shouldWorkWithSasl() {
+        assertStarts(
+                builder -> builder.withSaslAuthentication("admin", "admin-secret").withKafkaAcls());
+    }
+
+    private void assertStarts(final Consumer<DockerKafkaEnvironment.Builder> customizer) {
+        final DockerKafkaEnvironment.Builder builder =
+                DockerKafkaEnvironment.builder()
+                        .withContainerStartUpAttempts(STARTUP_ATTEMPTS)
+                        .withContainerStartUpTimeout(STARTUP_DURATION);
+
+        customizer.accept(builder);
+
+        try (DockerKafkaEnvironment kafkaEnvironment = builder.build()) {
+            try {
+                // When:
+                kafkaEnvironment.start();
+
+                // Then: did not throw
+            } catch (Exception e) {
+                System.out.println("----------Kafka Logs---------------");
+                System.out.println(kafkaEnvironment.kafkaLogs());
+                System.out.println("----------Schema Registry Logs---------------");
+                System.out.println(kafkaEnvironment.schemaRegistryLogs());
+                throw e;
+            }
+        }
+    }
+}


### PR DESCRIPTION
... and:
* added a public `start()` and `close()` method for when not using with JUnit.
* added simple test for `DockerKafkaEnvironment`
* removed a deprecated method.
* deprecated `SchemaRegistryContainer.withKafka` as its not used, not needed and the `KafkaContainer` parameter is deprecated in the next version of TestContainers.
* fix a few warnings.
