### PR TITLE
Test & document Kafka streams internal topics

### DIFF
--- a/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
@@ -250,11 +250,6 @@ class StorageConsumptionFunctionalTest {
         return count;
     }
 
-    // todo: can we get principal / account into this SpecMesh data?  Ideally we use SoecMesh for
-    // this and NOT ccloud.
-    // todo: does CCloud metrics API require use of RBAC? (Which we hate)
-    // Todo: produce and consume data to CCLoud and check out metrics.
-
     private static void shouldDoStorageStats() throws Exception {
         final var command = Storage.builder().build();
         final CommandLine.ParseResult parseResult =

--- a/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
@@ -344,7 +344,11 @@ public final class DockerKafkaEnvironment
 
         private static final String DEFAULT_KAFKA_DOCKER_IMAGE = "confluentinc/cp-kafka:7.5.3";
         private static final Map<String, String> DEFAULT_KAFKA_ENV =
-                Map.of("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false");
+                Map.of(
+                        "KAFKA_AUTO_CREATE_TOPICS_ENABLE",
+                        "false",
+                        "KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS",
+                        "0");
 
         private static final String DEFAULT_SCHEMA_REG_IMAGE =
                 "confluentinc/cp-schema-registry:7.5.3";

--- a/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
@@ -99,7 +99,7 @@ class ClientsFunctionalDemoTest {
     private static final KafkaApiSpec API_SPEC =
             TestSpecLoader.loadFromClassPath("kafka_test-simple_schema_demo-api.yaml");
 
-    private static final String OWNER_USER = "simple.schema_demo";
+    private static final String OWNER_USER = API_SPEC.id();
     private static final String DIFFERENT_USER = "different-user";
 
     @RegisterExtension

--- a/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
@@ -113,8 +113,6 @@ class ClientsFunctionalDemoTest {
                             DIFFERENT_USER,
                             DIFFERENT_USER + "-secret")
                     .withKafkaAcls(aclsForOtherDomain())
-                    .withKafkaEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
-                    .withKafkaEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
                     .build();
 
     private SchemaRegistryClient schemaRegistryClient;
@@ -442,7 +440,7 @@ class ClientsFunctionalDemoTest {
         final Map<String, Object> props =
                 Clients.kstreamsProperties(
                         API_SPEC.id(),
-                        "_private.client-func-demo",
+                        "client-func-demo",
                         KAFKA_ENV.kafkaBootstrapServers(),
                         KAFKA_ENV.schemaRegistryServer(),
                         Serdes.LongSerde.class,

--- a/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
@@ -22,13 +22,12 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.kafka.common.acl.AclOperation.ALL;
 import static org.apache.kafka.common.acl.AclPermissionType.ALLOW;
 import static org.apache.kafka.common.resource.PatternType.LITERAL;
+import static org.apache.kafka.common.resource.PatternType.PREFIXED;
 import static org.apache.kafka.common.resource.Resource.CLUSTER_NAME;
 import static org.apache.kafka.common.resource.ResourceType.CLUSTER;
 import static org.apache.kafka.common.resource.ResourceType.GROUP;
-import static org.apache.kafka.streams.kstream.Produced.with;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
-import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertThrows;
@@ -49,19 +48,17 @@ import io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfo.UserInfo;
 import io.specmesh.kafka.schema.SimpleSchemaDemoPublicUserInfoEnriched.UserInfoEnriched;
 import io.specmesh.test.TestSpecLoader;
 import java.time.Duration;
+import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
-import java.util.concurrent.TimeUnit;
-import java.util.stream.StreamSupport;
 import org.apache.commons.collections.MapUtils;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.ConsumerRecords;
 import org.apache.kafka.clients.consumer.KafkaConsumer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerRecord;
@@ -70,11 +67,25 @@ import org.apache.kafka.common.acl.AccessControlEntry;
 import org.apache.kafka.common.acl.AclBinding;
 import org.apache.kafka.common.errors.TopicAuthorizationException;
 import org.apache.kafka.common.resource.ResourcePattern;
+import org.apache.kafka.common.serialization.IntegerDeserializer;
 import org.apache.kafka.common.serialization.LongDeserializer;
 import org.apache.kafka.common.serialization.LongSerializer;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
+import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
+import org.apache.kafka.streams.StreamsConfig;
+import org.apache.kafka.streams.kstream.Consumed;
+import org.apache.kafka.streams.kstream.Grouped;
+import org.apache.kafka.streams.kstream.KStream;
+import org.apache.kafka.streams.kstream.Named;
+import org.apache.kafka.streams.kstream.Produced;
+import org.apache.kafka.streams.processor.api.Processor;
+import org.apache.kafka.streams.processor.api.ProcessorContext;
+import org.apache.kafka.streams.processor.api.ProcessorSupplier;
+import org.apache.kafka.streams.processor.api.Record;
+import org.apache.kafka.streams.state.KeyValueStore;
+import org.apache.kafka.streams.state.Stores;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
@@ -82,6 +93,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import simple.schema_demo.UserSignedUp;
 
+@SuppressWarnings("unchecked")
 class ClientsFunctionalDemoTest {
 
     private static final KafkaApiSpec API_SPEC =
@@ -101,6 +113,8 @@ class ClientsFunctionalDemoTest {
                             DIFFERENT_USER,
                             DIFFERENT_USER + "-secret")
                     .withKafkaAcls(aclsForOtherDomain())
+                    .withKafkaEnv("KAFKA_AUTO_CREATE_TOPICS_ENABLE", "false")
+                    .withKafkaEnv("KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS", "0")
                     .build();
 
     private SchemaRegistryClient schemaRegistryClient;
@@ -125,7 +139,7 @@ class ClientsFunctionalDemoTest {
     }
 
     @Test
-    void shouldProduceAndConsumeUsingAvro() throws Exception {
+    void shouldProduceAndConsumeUsingAvro() {
         // Given:
         final var userSignedUpTopic = topicName("_public.user_signed_up");
         final var sentRecord = new UserSignedUp("joe blogs", "blogy@twasmail.com", 100);
@@ -136,8 +150,8 @@ class ClientsFunctionalDemoTest {
                         avroProducer(OWNER_USER, RecordNameStrategy.class)) {
 
             // When:
-            producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L, sentRecord))
-                    .get(60, TimeUnit.SECONDS);
+            producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L, sentRecord));
+            producer.flush();
 
             // Then:
             assertThat(values(consumer), contains(sentRecord));
@@ -145,7 +159,7 @@ class ClientsFunctionalDemoTest {
     }
 
     @Test
-    void shouldProduceAndConsumeProto() throws Exception {
+    void shouldProduceAndConsumeProto() {
         // Given:
         final var userInfoTopic = topicName("_public.user_info");
         final var userSam =
@@ -155,12 +169,13 @@ class ClientsFunctionalDemoTest {
                         .setAge(52)
                         .build();
 
-        try (Consumer<Long, UserInfo> consumer = protoConsumer(UserInfo.class, userInfoTopic);
+        try (Consumer<Long, UserInfo> consumer =
+                        protoConsumer(Long.class, UserInfo.class, userInfoTopic);
                 Producer<Long, UserInfo> producer = protoProducer()) {
 
             // When:
-            producer.send(new ProducerRecord<>(userInfoTopic, 1000L, userSam))
-                    .get(60, TimeUnit.SECONDS);
+            producer.send(new ProducerRecord<>(userInfoTopic, 1000L, userSam));
+            producer.flush();
 
             // Then:
             assertThat(values(consumer), contains(userSam));
@@ -169,34 +184,46 @@ class ClientsFunctionalDemoTest {
 
     @SuppressWarnings("unused")
     @Test
-    void shouldStreamStuffUsingProto() throws Exception {
+    void shouldStreamStuffUsingProto() {
         // Given:
-        final var userInfoTopic = topicName("_public.user_info");
-        final var userInfoEnrichedTopic = topicName("_public.user_info_enriched");
-        final var userSam =
+        final String userInfoTopic = topicName("_public.user_info");
+        final String userInfoEnrichedTopic = topicName("_public.user_info_enriched");
+        final String repartitionByAge =
+                topicName("_private.client-func-demo-rekey.by-age-repartition");
+        final String storeByAge = topicName("_private.client-func-demo-store.age-changelog");
+
+        final long key = 1000L;
+        final UserInfo userSam =
                 UserInfo.newBuilder()
                         .setFullName("sam fteex")
                         .setEmail("hello-sam@bahamas.island")
                         .setAge(52)
                         .build();
-        final var expectedEnriched =
-                UserInfoEnriched.newBuilder()
-                        .setAddress("hiding in the bahamas")
-                        .setAge(userSam.getAge())
-                        .setEmail(userSam.getEmail())
-                        .build();
 
-        try (Consumer<Long, UserInfoEnriched> consumer =
-                        protoConsumer(UserInfoEnriched.class, userInfoEnrichedTopic);
-                AutoCloseable streamsApp = streamsApp(userInfoTopic, userInfoEnrichedTopic);
+        try (Consumer<Long, UserInfoEnriched> enhancedConsumer =
+                        protoConsumer(Long.class, UserInfoEnriched.class, userInfoEnrichedTopic);
+                Consumer<Integer, Integer> repartitionConsumer =
+                        protoConsumer(Integer.class, Integer.class, repartitionByAge);
+                Consumer<Long, Integer> storeConsumer =
+                        protoConsumer(Long.class, Integer.class, storeByAge);
+                KafkaStreams streamsApp = streamsApp(userInfoTopic, userInfoEnrichedTopic);
                 Producer<Long, UserInfo> producer = protoProducer()) {
 
             // When:
-            producer.send(new ProducerRecord<>(userInfoTopic, 1000L, userSam))
-                    .get(60, TimeUnit.SECONDS);
+            producer.send(new ProducerRecord<>(userInfoTopic, key, userSam));
+            producer.flush();
 
             // Then:
-            assertThat(values(consumer), contains(expectedEnriched));
+            final var expectedEnriched =
+                    UserInfoEnriched.newBuilder()
+                            .setAddress("hiding in the bahamas")
+                            .setAge(userSam.getAge())
+                            .setEmail(userSam.getEmail())
+                            .build();
+
+            assertThat(entries(enhancedConsumer, 1), contains(Map.entry(key, expectedEnriched)));
+            assertThat(entries(repartitionConsumer, 1), contains(Map.entry(userSam.getAge(), 1)));
+            assertThat(entries(storeConsumer, 1), contains(Map.entry(key, (userSam.getAge()))));
         }
     }
 
@@ -225,7 +252,7 @@ class ClientsFunctionalDemoTest {
         // Run one test in a nested class to test env works with such nesting...
 
         @Test
-        void shouldConsumeWithDifferentUser() throws Exception {
+        void shouldConsumeWithDifferentUser() {
             // Given:
             final var userSignedUpTopic = topicName("_public.user_signed_up");
             final var sentRecord = new UserSignedUp("joe blogs", "blogy@twasmail.com", 100);
@@ -237,19 +264,18 @@ class ClientsFunctionalDemoTest {
                             avroProducer(OWNER_USER, RecordNameStrategy.class)) {
 
                 // When:
-                producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L, sentRecord))
-                        .get(60, TimeUnit.SECONDS);
+                producer.send(new ProducerRecord<>(userSignedUpTopic, 1000L, sentRecord));
+                producer.flush();
 
                 // Then:
                 final var values = values(consumer);
-                assertThat("Should have received a record but got nothing", values, hasSize(1));
                 assertThat(values, contains(sentRecord));
             }
         }
     }
 
     @Test
-    void shouldProduceAndConsumeUsingAvroTopicRecordNameStrategy() throws Exception {
+    void shouldProduceAndConsumeUsingAvroTopicRecordNameStrategy() {
         // Given:
         final String topicName = topicName("_public.user_signed_up_2");
         final var sentRecord = new UserSignedUp("joe blogs", "blogy@twasmail.com", 100);
@@ -260,8 +286,8 @@ class ClientsFunctionalDemoTest {
                         avroProducer(OWNER_USER, TopicRecordNameStrategy.class)) {
 
             // When:
-            producer.send(new ProducerRecord<>(topicName, 1000L, sentRecord))
-                    .get(60, TimeUnit.SECONDS);
+            producer.send(new ProducerRecord<>(topicName, 1000L, sentRecord));
+            producer.flush();
 
             // Then:
             assertThat(values(consumer), contains(sentRecord));
@@ -269,12 +295,22 @@ class ClientsFunctionalDemoTest {
     }
 
     @SuppressFBWarnings("RV_RETURN_VALUE_IGNORED_NO_SIDE_EFFECT")
-    private static <V> Consumer<Long, V> consumer(
+    private static <K, V> Consumer<K, V> consumer(
+            final Class<K> keyClass,
             final Class<V> valueClass,
             final String topicName,
             final Class<?> valueDeserializer,
             final String userName,
             final Map<String, Object> additionalProps) {
+
+        final Class<?> keyDeserializer;
+        if (keyClass.equals(Long.class)) {
+            keyDeserializer = LongDeserializer.class;
+        } else if (keyClass.equals(Integer.class)) {
+            keyDeserializer = IntegerDeserializer.class;
+        } else {
+            throw new AssertionError("Unexpected Key type used in test: " + keyClass);
+        }
 
         final Map<String, Object> props =
                 Clients.consumerProperties(
@@ -282,26 +318,35 @@ class ClientsFunctionalDemoTest {
                         UUID.randomUUID().toString(),
                         KAFKA_ENV.kafkaBootstrapServers(),
                         KAFKA_ENV.schemaRegistryServer(),
-                        LongDeserializer.class,
+                        keyDeserializer,
                         valueDeserializer,
                         false,
                         additionalProps);
 
         props.putAll(Clients.clientSaslAuthProperties(userName, userName + "-secret"));
-        props.put(CommonClientConfigs.GROUP_ID_CONFIG, userName);
+        props.put(CommonClientConfigs.GROUP_ID_CONFIG, userName + "-" + UUID.randomUUID());
 
-        final KafkaConsumer<Long, V> consumer = Clients.consumer(Long.class, valueClass, props);
+        final KafkaConsumer<K, V> consumer = Clients.consumer(keyClass, valueClass, props);
         consumer.subscribe(List.of(topicName));
-        consumer.poll(Duration.ofSeconds(1));
+        consumer.poll(Duration.ofMillis(250));
         return consumer;
     }
 
-    private static <V> Consumer<Long, V> protoConsumer(
-            final Class<V> valueClass, final String topicName) {
+    private static <K, V> Consumer<K, V> protoConsumer(
+            final Class<K> keyClass, final Class<V> valueClass, final String topicName) {
+
+        final Class<?> valueDeserializer;
+        if (valueClass.equals(Integer.class)) {
+            valueDeserializer = IntegerDeserializer.class;
+        } else {
+            valueDeserializer = KafkaProtobufDeserializer.class;
+        }
+
         return consumer(
+                keyClass,
                 valueClass,
                 topicName,
-                KafkaProtobufDeserializer.class,
+                valueDeserializer,
                 OWNER_USER,
                 Map.of(KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_VALUE_TYPE, valueClass));
     }
@@ -311,6 +356,7 @@ class ClientsFunctionalDemoTest {
             final String userName,
             final Class<? extends SubjectNameStrategy> namingStrategy) {
         return consumer(
+                Long.class,
                 UserSignedUp.class,
                 topicName,
                 KafkaAvroDeserializer.class,
@@ -360,11 +406,26 @@ class ClientsFunctionalDemoTest {
                         "true"));
     }
 
-    private static <V> List<V> values(final Consumer<Long, V> consumer) {
-        final ConsumerRecords<Long, V> consumerRecords = consumer.poll(Duration.ofSeconds(10));
-        return StreamSupport.stream(consumerRecords.spliterator(), false)
-                .map(ConsumerRecord::value)
-                .collect(toList());
+    private static <K, V> List<Map.Entry<K, V>> entries(
+            final Consumer<K, V> consumer, final int expectedCount) {
+        final Instant timeout = Instant.now().plus(Duration.ofSeconds(60)); // Todo: reduce
+        final List<Map.Entry<K, V>> entries = new ArrayList<>();
+        while (entries.size() < expectedCount && Instant.now().isBefore(timeout)) {
+            consumer.poll(Duration.ofMillis(100))
+                    .forEach(record -> entries.add(Map.entry(record.key(), record.value())));
+        }
+
+        if (Instant.now().isBefore(timeout)) {
+            // Poll to detect unexpected messages:
+            consumer.poll(Duration.ofMillis(100))
+                    .forEach(record -> entries.add(Map.entry(record.key(), record.value())));
+        }
+
+        return entries;
+    }
+
+    private static <V> List<V> values(final Consumer<?, V> consumer) {
+        return entries(consumer, 1).stream().map(Map.Entry::getValue).collect(toList());
     }
 
     private static String topicName(final String topicSuffix) {
@@ -375,12 +436,13 @@ class ClientsFunctionalDemoTest {
                 .name();
     }
 
-    private AutoCloseable streamsApp(
+    private KafkaStreams streamsApp(
             final String userInfoTopic, final String userInfoEnrichedTopic) {
-        final var props =
+
+        final Map<String, Object> props =
                 Clients.kstreamsProperties(
                         API_SPEC.id(),
-                        "streams-appid-service-thing",
+                        "_private.client-func-demo",
                         KAFKA_ENV.kafkaBootstrapServers(),
                         KAFKA_ENV.schemaRegistryServer(),
                         Serdes.LongSerde.class,
@@ -389,24 +451,67 @@ class ClientsFunctionalDemoTest {
                         Clients.clientSaslAuthProperties(OWNER_USER, OWNER_USER + "-secret"),
                         Map.of(
                                 KafkaProtobufDeserializerConfig.SPECIFIC_PROTOBUF_VALUE_TYPE,
-                                UserInfo.class));
+                                UserInfo.class,
+                                StreamsConfig.COMMIT_INTERVAL_MS_CONFIG,
+                                1L));
+
+        final KafkaProtobufSerde<UserInfoEnriched> enhancedSerde =
+                new KafkaProtobufSerde<>(schemaRegistryClient, UserInfoEnriched.class);
 
         final var builder = new StreamsBuilder();
 
-        builder.<Long, UserInfo>stream(userInfoTopic)
-                .mapValues(
+        final String storeName = "store.age";
+        builder.addStateStore(
+                Stores.keyValueStoreBuilder(
+                                Stores.inMemoryKeyValueStore(storeName),
+                                Serdes.Long(),
+                                Serdes.Integer())
+                        .withLoggingEnabled(Map.of()));
+
+        final KStream<Long, UserInfo> users = builder.stream(userInfoTopic, Consumed.as("ingest"));
+
+        users.mapValues(
                         userInfo ->
                                 UserInfoEnriched.newBuilder()
                                         .setAddress("hiding in the bahamas")
                                         .setAge(userInfo.getAge())
                                         .setEmail(userInfo.getEmail())
-                                        .build())
+                                        .build(),
+                        Named.as("enhance"))
                 .to(
                         userInfoEnrichedTopic,
-                        with(
-                                Serdes.Long(),
-                                new KafkaProtobufSerde<>(
-                                        schemaRegistryClient, UserInfoEnriched.class)));
+                        Produced.<Long, UserInfoEnriched>as("emit-enhanced")
+                                .withValueSerde(enhancedSerde));
+
+        users.process(
+                new ProcessorSupplier<>() {
+                    @Override
+                    public Processor<Long, UserInfo, Object, Object> get() {
+                        return new Processor<>() {
+
+                            private KeyValueStore<Long, Integer> store;
+
+                            @Override
+                            public void init(final ProcessorContext<Object, Object> context) {
+                                this.store = context.getStateStore(storeName);
+                            }
+
+                            @Override
+                            public void process(final Record<Long, UserInfo> record) {
+                                store.put(record.key(), record.value().getAge());
+                            }
+                        };
+                    }
+                },
+                Named.as("store"),
+                storeName);
+
+        users.map((k, v) -> new KeyValue<>(v.getAge(), 1), Named.as("select-key"))
+                .groupByKey(
+                        Grouped.<Integer, Integer>as("rekey.by-age")
+                                .withKeySerde(Serdes.Integer())
+                                .withValueSerde(Serdes.Integer()))
+                .count(Named.as("count-by-age"));
 
         final var streams = new KafkaStreams(builder.build(), MapUtils.toProperties(props));
         streams.start();
@@ -420,7 +525,7 @@ class ClientsFunctionalDemoTest {
                         new ResourcePattern(CLUSTER, CLUSTER_NAME, LITERAL),
                         new AccessControlEntry(principal, "*", ALL, ALLOW)),
                 new AclBinding(
-                        new ResourcePattern(GROUP, DIFFERENT_USER, LITERAL),
+                        new ResourcePattern(GROUP, DIFFERENT_USER, PREFIXED),
                         new AccessControlEntry(principal, "*", ALL, ALLOW)));
     }
 }

--- a/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/ClientsFunctionalDemoTest.java
@@ -408,7 +408,7 @@ class ClientsFunctionalDemoTest {
 
     private static <K, V> List<Map.Entry<K, V>> entries(
             final Consumer<K, V> consumer, final int expectedCount) {
-        final Instant timeout = Instant.now().plus(Duration.ofSeconds(60)); // Todo: reduce
+        final Instant timeout = Instant.now().plus(Duration.ofSeconds(10));
         final List<Map.Entry<K, V>> entries = new ArrayList<>();
         while (entries.size() < expectedCount && Instant.now().isBefore(timeout)) {
             consumer.poll(Duration.ofMillis(100))

--- a/kafka-test/src/test/resources/kafka_test-simple_schema_demo-api.yaml
+++ b/kafka-test/src/test/resources/kafka_test-simple_schema_demo-api.yaml
@@ -22,7 +22,7 @@ channels:
         envs:
           - staging
           - prod
-        partitions: 3
+        partitions: 1
         replicas: 1
         configs:
           cleanup.policy: delete
@@ -47,7 +47,7 @@ channels:
         envs:
           - staging
           - prod
-        partitions: 3
+        partitions: 1
         replicas: 1
         configs:
           cleanup.policy: delete
@@ -73,7 +73,7 @@ channels:
         envs:
           - staging
           - prod
-        partitions: 3
+        partitions: 1
         replicas: 1
         configs:
           cleanup.policy: delete
@@ -97,7 +97,7 @@ channels:
         envs:
           - staging
           - prod
-        partitions: 3
+        partitions: 1
         replicas: 1
         configs:
           cleanup.policy: delete
@@ -115,6 +115,54 @@ channels:
         contentType: "application/json"
         payload:
           $ref: "/simple.schema_demo._public.user_info_enriched.proto"
+
+  _private.client-func-demo-rekey.by-age-repartition:
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 1
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+          retention.ms: 999000
+
+    publish:
+      operationId: onRepartitionByAge
+      message:
+        bindings:
+          kafka:
+            key:
+              type: int
+        schemaFormat: "application/vnd.apache.avro+json;version=1.9.0"
+        contentType: "application/octet-stream"
+        payload:
+          type: int
+
+  _private.client-func-demo-store.age-changelog:
+    bindings:
+      kafka:
+        envs:
+          - staging
+          - prod
+        partitions: 1
+        replicas: 1
+        configs:
+          cleanup.policy: delete
+          retention.ms: 999000
+
+    publish:
+      operationId: onStoreByAge
+      message:
+        bindings:
+          kafka:
+            key:
+              type: int
+        schemaFormat: "application/text"
+        payload:
+          type: long
+
 # SUBSCRIBER WILL REQUEST SCHEMA from SR and CodeGen required classes. Header will be used for Id
   london.hammersmith.transport._public.tube:
     subscribe:

--- a/kafka-test/src/test/resources/log4j2-test.xml
+++ b/kafka-test/src/test/resources/log4j2-test.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Configuration status="INFO">
+    <Appenders>
+        <Console name="Console" target="SYSTEM_OUT">
+            <PatternLayout pattern="%msg%n"/>
+        </Console>
+    </Appenders>
+    <Loggers>
+        <Root level="info">
+            <AppenderRef ref="Console"/>
+        </Root>
+    </Loggers>
+</Configuration>

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -31,8 +31,8 @@ If you wish to maintain the visibility marker for internal topics, then it is re
 in the Kafka Streams properties, should be set to `${domain.id}._private.${service.name}`. 
 This ensures the ACLs are correctly set for the private internal topics of the service.  
 
-Optionally, the Kafka `client.id` and `group.id` can be set to `${domain.id}.${service.name}`, to remove the `_private`
-component, if required.
+Optionally, the Kafka `client.id` can be set to `${domain.id}.${service.name}`, to remove the `_private` component, if required.
+Unfortunately, `group.id` can not be customised in streams apps, hence the `_private` component is unavoidable. 
 
 Chose store names and repartition node names so that they build the channel and topic names required. 
 

--- a/kafka/README.md
+++ b/kafka/README.md
@@ -17,26 +17,81 @@ For topic's owned by the domain, their full topic name is that used in the spec,
 i.e. `<domain-id>.<channel-name>`.  In this way, all topics owned by the domain and also prefixed by the domain name,
 making it trivial to trace back the topic name to its owning domain. 
 
+### Working with Kafka Streams internal topics
+
+Kafka Streams applications can create internal repartition and changelog topics.
+These internal topics should be defined as channels in the mesh spec.
+
+At the time of writing the names of internal topics are restricted to the following format by Kafka Streams:
+
+* Change log topics: `${application.id"}-${store.name}-changelog`
+* Repartition topics: `${application.id"}-${node.name}-repartition`
+
+If you wish to maintain the visibility marker for internal topics, then it is recommended the `application.id"`, passed
+in the Kafka Streams properties, should be set to `${domain.id}._private.${service.name}`. 
+This ensures the ACLs are correctly set for the private internal topics of the service.  
+
+Optionally, the Kafka `client.id` and `group.id` can be set to `${domain.id}.${service.name}`, to remove the `_private`
+component, if required.
+
+Chose store names and repartition node names so that they build the channel and topic names required. 
+
+#### Changelog example
+
+Given an `application.id` in the form `${domain.id}._private.${service.name}`, for example `acme.user._private.user-service`,
+and given a store name of `store.user`, for example:
+
+```java
+    streamBuilder.addStateStore(
+       Stores.keyValueStoreBuilder(
+           Stores.inMemoryKeyValueStore("store.user"),
+           storeKeySerde,
+           storeValSerde)
+     .withLoggingEnabled(logConfig));
+```
+
+The topology will require the spec to define a channel named `_private.user-service-store.user-changelog`, which will 
+provision a topic named `acme.user._private.user-service-store.user-changelog`.
+
+#### Repartition example
+
+Given an `application.id` in the form `${domain.id}._private.${service.name}`, for example `acme.user._private.user-service`,
+and given a node name of `rekey.by-age`, for example:
+
+```java
+ users.map((k, v) -> new KeyValue<>(v.getAge(), 1), Named.as("select-key"))
+    .groupByKey(
+      Grouped.<Integer, Integer>as("rekey.by-age")
+              .withKeySerde(Serdes.Integer())
+              .withValueSerde(Serdes.Integer()))
+    .count(Named.as("count-by-age"));
+```
+
+The topology will require the spec to define a channel named `_private.client-func-demo-rekey.by-age-repartition`, which will
+provision a topic named `acme.user._private.client-func-demo-rekey.by-age-repartition`.
+
 ## Authorisation
 
-## Group authorisation
+### Resource types
+
+#### Group authorisation
 
 The provisioner will set ACLs to allow the domain to use any consumer group prefixed with the domain id.
 It is recommended that, in most cases, domain services use a consumer group name of `<domain-id>-<service-name>`.
 
-## Transaction id authorisation
+#### Transaction id authorisation
 
 The provisioner will set ACLs to allow the domain to use any transaction id prefixed with the domain id. 
 
-## Topic authorisation
+#### Topic authorisation
 
 The provisioner will set ACLs to enforce the following topic authorisation:
 
-### Public topics:
+#### Public topics:
 
 Only the domain itself can `WRITE` to public topics; Any domain can `READ` from them.
 
-### Protected topics:
+#### Protected topics:
 
 Only the domain itself can `WRITE` to protected topics; Any domain specifically tagged in the spec can `READ` from them.
 
@@ -48,7 +103,7 @@ Access to a protected topic can be granted to another domain by adding a `grant-
       ]
 ```
 
-### Private topics:
+#### Private topics:
 
 Only the domain itself can `WRITE` to private topics; Only the domain itself can `READ` to private topics.
 
@@ -104,7 +159,6 @@ The set of ACLs created from the `provisioner-functional-test-api.yaml`
 =(principal=User:simple.provision_demo, host=*, operation=IDEMPOTENT_WRITE, permissionType=ALLOW)), 
 ]
 ```
-
 
 ### Custom usernames
 

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -283,7 +283,7 @@ public final class Clients {
         props.putAll(
                 Map.of(
                         StreamsConfig.APPLICATION_ID_CONFIG,
-                        domainId + "." + serviceId,
+                        domainId + "._private." + serviceId,
                         StreamsConfig.CLIENT_ID_CONFIG,
                         domainId + "." + serviceId + ".client",
                         StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG,
@@ -333,7 +333,7 @@ public final class Clients {
     /**
      * Create a map of consumer properties with sensible defaults.
      *
-     * @param domainId the domain id, used to scope resource names.
+     * @param domainId the domain id of the consumer, used to scope resource names.
      * @param serviceId the name of the service
      * @param bootstrapServers bootstrap servers config
      * @param schemaRegistryUrl url of schema registry


### PR DESCRIPTION
Test and document a way to set up a KafkaStreams topology so that internal topics, i.e. changelog and repartition topics, abide by SpecMesh channel / topic naming standards.
