### PR TITLE
Do not use reflection to build schema by default

### DIFF
--- a/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
@@ -327,6 +327,7 @@ class StorageConsumptionFunctionalTest {
                         .withProp(
                                 CommonClientConfigs.GROUP_ID_CONFIG, OWNER_USER + ":" + "testGroup")
                         .withProp(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, false)
+                        .withProp(AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true)
                         .consumer()
                         .withKeyType(Long.class)
                         .withValueDeserializerType(KafkaAvroDeserializer.class, UserSignedUp.class)
@@ -343,6 +344,7 @@ class StorageConsumptionFunctionalTest {
                         KAFKA_ENV.kafkaBootstrapServers(),
                         KAFKA_ENV.schemaRegistryServer())
                 .withProps(Clients.clientSaslAuthProperties(OWNER_USER, OWNER_USER + "-secret"))
+                .withProp(AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true)
                 .producer()
                 .withKeyType(Long.class)
                 .withValueSerializerType(KafkaAvroSerializer.class, UserSignedUp.class)

--- a/config/checkstyle/suppressions.xml
+++ b/config/checkstyle/suppressions.xml
@@ -26,4 +26,7 @@
 <suppressions>
     <!-- Exclude generated sources   -->
     <suppress files="[\\/]build[\\/]generated[\\/]source" checks=".*"/>
+    <suppress files="[\\/]build[\\/]generated-main-avro-java" checks=".*"/>
+    <suppress files="[\\/]build[\\/]generated-test-avro-java" checks=".*"/>
+    <suppress files="[\\/]build[\\/]jmh_generated[\\/]" checks=".*"/>
 </suppressions>

--- a/config/spotbugs/suppressions.xml
+++ b/config/spotbugs/suppressions.xml
@@ -24,4 +24,16 @@
         <!-- Exclude generated sources   -->
         <Source name="~.*[\\/]build[\\/]generated[\\/]source.*" />
     </Match>
+    <Match>
+        <!-- Exclude generated sources   -->
+        <Source name="~.*[\\/]build[\\/]generated-main-avro-java.*" />
+    </Match>
+    <Match>
+        <!-- Exclude generated sources   -->
+        <Source name="~.*[\\/]build[\\/]generated-test-avro-java.*" />
+    </Match>
+    <Match>
+        <!-- Exclude generated sources   -->
+        <Source name="~.*[\\/]jmh_generated[\\/].*" />
+    </Match>
 </FindBugsFilter>

--- a/kafka/build.gradle.kts
+++ b/kafka/build.gradle.kts
@@ -16,6 +16,7 @@
 
 plugins {
     `java-library`
+    id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
 }
 
 val kafkaVersion : String by extra

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -40,7 +40,7 @@ import java.util.Properties;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
-import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.IndexedRecord;
 import org.apache.kafka.clients.CommonClientConfigs;
 import org.apache.kafka.clients.admin.Admin;
 import org.apache.kafka.clients.admin.AdminClient;
@@ -408,12 +408,6 @@ public final class Clients {
     /** Type used to, erm, build clients. */
     public static final class ClientBuilder {
 
-        private static final Map<String, ?> BASE_PROPS =
-                Map.of(
-                        // schema-reflect MUST be true when writing Java objects (otherwise you send
-                        // a datum-container instead of a Pojo)
-                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true);
-
         private final String domainId;
         private final String serviceId;
         private final Map<String, ?> commonProps;
@@ -507,9 +501,7 @@ public final class Clients {
         }
 
         private Map<String, Object> baseProps() {
-            final Map<String, Object> props = new HashMap<>(BASE_PROPS);
-            props.putAll(commonProps);
-            return props;
+            return new HashMap<>(commonProps);
         }
     }
 
@@ -527,6 +519,7 @@ public final class Clients {
                         // Disable auto-reg to allow schemas to be published by controlled processes
                         AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS,
                         false,
+                        // Todo: seems wrong.
                         AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION,
                         true);
 
@@ -704,7 +697,7 @@ public final class Clients {
                 return castNonGeneric(KafkaProtobufSerializer.class, type);
             }
 
-            if (GenericRecord.class.isAssignableFrom(type)) {
+            if (IndexedRecord.class.isAssignableFrom(type)) {
                 return castNonGeneric(KafkaAvroSerializer.class, type);
             }
 
@@ -904,7 +897,7 @@ public final class Clients {
                 return castNonGeneric(KafkaProtobufDeserializer.class, type);
             }
 
-            if (GenericRecord.class.isAssignableFrom(type)) {
+            if (IndexedRecord.class.isAssignableFrom(type)) {
                 return castNonGeneric(KafkaAvroDeserializer.class, type);
             }
 
@@ -1099,7 +1092,7 @@ public final class Clients {
                 return castNonGeneric(KafkaProtobufSerde.class, type);
             }
 
-            if (GenericRecord.class.isAssignableFrom(type)) {
+            if (IndexedRecord.class.isAssignableFrom(type)) {
                 return castNonGeneric(GenericAvroSerde.class, type);
             }
 
@@ -1187,7 +1180,8 @@ public final class Clients {
             final Map<String, Object>... additionalProperties) {
 
         ClientBuilder builder =
-                Clients.builder(domainId, serviceId, bootstrapServers, schemaRegistryUrl);
+                Clients.builder(domainId, serviceId, bootstrapServers, schemaRegistryUrl)
+                        .withProp(AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true);
 
         for (final Map<String, Object> additional : additionalProperties) {
             builder = builder.withProps(additional);
@@ -1234,7 +1228,8 @@ public final class Clients {
             final Map<String, Object>... additionalProperties) {
 
         ClientBuilder builder =
-                Clients.builder(domainId, serviceId, bootstrapServers, schemaRegistryUrl);
+                Clients.builder(domainId, serviceId, bootstrapServers, schemaRegistryUrl)
+                        .withProp(AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true);
 
         for (final Map<String, Object> additional : additionalProperties) {
             builder = builder.withProps(additional);
@@ -1302,7 +1297,8 @@ public final class Clients {
             final Map<String, Object>... additionalProperties) {
 
         ClientBuilder builder =
-                Clients.builder(domainId, serviceId, bootstrapServers, schemaRegistryUrl);
+                Clients.builder(domainId, serviceId, bootstrapServers, schemaRegistryUrl)
+                        .withProp(AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true);
 
         for (final Map<String, Object> additional : additionalProperties) {
             builder = builder.withProps(additional);

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -519,7 +519,6 @@ public final class Clients {
                         // Disable auto-reg to allow schemas to be published by controlled processes
                         AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS,
                         false,
-                        // Todo: seems wrong.
                         AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION,
                         true);
 

--- a/kafka/src/test/avro/simple.schema_demo._public.user_signed_up.avsc
+++ b/kafka/src/test/avro/simple.schema_demo._public.user_signed_up.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "namespace": "simple.schema_demo",
+  "name": "UserSignedUp",
+  "fields": [
+    {"name": "fullName", "type": "string"},
+    {"name": "email",  "type": "string"},
+    {"name": "age", "type": "int"}
+  ]
+}

--- a/kafka/src/test/java/io/specmesh/kafka/ClientsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ClientsTest.java
@@ -94,8 +94,6 @@ class ClientsTest {
                         SCHEMA_REG_URL,
                         AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS,
                         false,
-                        KafkaAvroSerializerConfig.SCHEMA_REFLECTION_CONFIG,
-                        true,
                         KafkaAvroSerializerConfig.USE_LATEST_VERSION,
                         true);
         assertThat(props.asMap(), is(expected));
@@ -202,9 +200,7 @@ class ClientsTest {
                         ConsumerConfig.VALUE_DESERIALIZER_CLASS_CONFIG,
                         VAL_DESERIALIZER_TYPE,
                         AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
-                        SCHEMA_REG_URL,
-                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG,
-                        true);
+                        SCHEMA_REG_URL);
         assertThat(props.asMap(), is(expected));
     }
 
@@ -293,24 +289,27 @@ class ClientsTest {
 
         // Then:
         final Map<String, ?> expected =
-                Map.ofEntries(
-                        Map.entry(CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG, BOOTSTRAP_SERVERS),
-                        Map.entry(
-                                StreamsConfig.APPLICATION_ID_CONFIG,
-                                DOMAIN_ID + "._private." + SERVICE_ID),
-                        Map.entry(
-                                StreamsConfig.CLIENT_ID_CONFIG,
-                                DOMAIN_ID + "." + SERVICE_ID + ".client"),
-                        Map.entry(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, KEY_SERDE_TYPE),
-                        Map.entry(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, VAL_SERDE_TYPE),
-                        Map.entry(StreamsConfig.COMMIT_INTERVAL_MS_CONFIG, 10 * 1000L),
-                        Map.entry(ProducerConfig.ACKS_CONFIG, "all"),
-                        Map.entry(
-                                AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
-                                SCHEMA_REG_URL),
-                        Map.entry(AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS, false),
-                        Map.entry(KafkaAvroSerializerConfig.SCHEMA_REFLECTION_CONFIG, true),
-                        Map.entry(KafkaAvroSerializerConfig.USE_LATEST_VERSION, true));
+                Map.of(
+                        CommonClientConfigs.BOOTSTRAP_SERVERS_CONFIG,
+                        BOOTSTRAP_SERVERS,
+                        StreamsConfig.APPLICATION_ID_CONFIG,
+                        DOMAIN_ID + "._private." + SERVICE_ID,
+                        StreamsConfig.CLIENT_ID_CONFIG,
+                        DOMAIN_ID + "." + SERVICE_ID + ".client",
+                        StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG,
+                        KEY_SERDE_TYPE,
+                        StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG,
+                        VAL_SERDE_TYPE,
+                        StreamsConfig.COMMIT_INTERVAL_MS_CONFIG,
+                        10 * 1000L,
+                        ProducerConfig.ACKS_CONFIG,
+                        "all",
+                        AbstractKafkaSchemaSerDeConfig.SCHEMA_REGISTRY_URL_CONFIG,
+                        SCHEMA_REG_URL,
+                        AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS,
+                        false,
+                        KafkaAvroSerializerConfig.USE_LATEST_VERSION,
+                        true);
         assertThat(props.asMap(), is(expected));
     }
 

--- a/kafka/src/test/java/simple/schema_demo/UserSignedUpPojo.java
+++ b/kafka/src/test/java/simple/schema_demo/UserSignedUpPojo.java
@@ -23,7 +23,7 @@ import lombok.NoArgsConstructor;
 @Data
 @AllArgsConstructor
 @NoArgsConstructor
-public class UserSignedUp {
+public class UserSignedUpPojo {
     String fullName;
     String email;
     int age;

--- a/kafka/src/test/resources/schema/simple.schema_demo._public.user_signed_up_pojo.avsc
+++ b/kafka/src/test/resources/schema/simple.schema_demo._public.user_signed_up_pojo.avsc
@@ -1,0 +1,10 @@
+{
+  "type": "record",
+  "namespace": "simple.schema_demo",
+  "name": "UserSignedUpPojo",
+  "fields": [
+    {"name": "fullName", "type": "string"},
+    {"name": "email",  "type": "string"},
+    {"name": "age", "type": "int"}
+  ]
+}


### PR DESCRIPTION
Flip default of schema.reflection to false for new clients
The deprecated `Clients` method set `SCHEMA_REFLECTION_CONFIG` to `true`. This is _not_ a good default for production.

This setting means serde types will use reflection to _build_ a schema from a Pojo. Specmesh is all about taking manual control of the schema. So we shouldn't be using generated schemas.

Additionally, this setting is not need / actually causes problems, when the types in question are generated from the proto / avro schema, e.g. avro specific record types.

We should be encouraging people to generate pojos from the schema, rather than hand-crafting them.

This change flips the setting at the default `false`. It also uses the avro plugin to generate a specific record type from a schema and uses this in some test cases to show it works.

Other functional tests have been left using the hand-crafted Pojo: these need to have reflection turned on.

The legacy / deprecated methods in `Clients` have been left setting this to `true`.