### PR TITLE
Do not set `use.latest.version` to true in `Clients`

### DIFF
--- a/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/StorageConsumptionFunctionalTest.java
@@ -345,6 +345,7 @@ class StorageConsumptionFunctionalTest {
                         KAFKA_ENV.schemaRegistryServer())
                 .withProps(Clients.clientSaslAuthProperties(OWNER_USER, OWNER_USER + "-secret"))
                 .withProp(AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true)
+                .withProp(AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION, true)
                 .producer()
                 .withKeyType(Long.class)
                 .withValueSerializerType(KafkaAvroSerializer.class, UserSignedUp.class)

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -25,6 +25,7 @@ import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
+import io.confluent.kafka.serializers.KafkaAvroSerializerConfig;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufDeserializer;
 import io.confluent.kafka.serializers.protobuf.KafkaProtobufSerializer;
 import io.confluent.kafka.streams.serdes.avro.GenericAvroSerde;
@@ -519,7 +520,9 @@ public final class Clients {
                         // Disable auto-reg to allow schemas to be published by controlled processes
                         AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS,
                         false,
-                        AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION,
+                        // Remove "avro.java.string" fields from schema
+                        // Which would result in a schema different to the one SpecMesh registered.
+                        KafkaAvroSerializerConfig.AVRO_REMOVE_JAVA_PROPS_CONFIG,
                         true);
 
         private final ClientBuilder clientBuilder;
@@ -1180,6 +1183,7 @@ public final class Clients {
 
         ClientBuilder builder =
                 Clients.builder(domainId, serviceId, bootstrapServers, schemaRegistryUrl)
+                        .withProp(AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION, true)
                         .withProp(AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true);
 
         for (final Map<String, Object> additional : additionalProperties) {
@@ -1196,6 +1200,7 @@ public final class Clients {
         final Map<String, Object> props = new HashMap<>(producerProps.asMap());
         props.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, keySerializerClass);
         props.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, valueSerializerClass);
+        props.remove(KafkaAvroSerializerConfig.AVRO_REMOVE_JAVA_PROPS_CONFIG);
         return props;
     }
 
@@ -1228,6 +1233,7 @@ public final class Clients {
 
         ClientBuilder builder =
                 Clients.builder(domainId, serviceId, bootstrapServers, schemaRegistryUrl)
+                        .withProp(AbstractKafkaSchemaSerDeConfig.USE_LATEST_VERSION, true)
                         .withProp(AbstractKafkaSchemaSerDeConfig.SCHEMA_REFLECTION_CONFIG, true);
 
         for (final Map<String, Object> additional : additionalProperties) {
@@ -1244,6 +1250,7 @@ public final class Clients {
         final Map<String, Object> props = new HashMap<>(kstreamProps.asMap());
         props.put(StreamsConfig.DEFAULT_KEY_SERDE_CLASS_CONFIG, keySerdeClass);
         props.put(StreamsConfig.DEFAULT_VALUE_SERDE_CLASS_CONFIG, valueSerdeClass);
+        props.remove(KafkaAvroSerializerConfig.AVRO_REMOVE_JAVA_PROPS_CONFIG);
         return props;
     }
 

--- a/kafka/src/test/java/io/specmesh/kafka/ClientsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ClientsTest.java
@@ -94,7 +94,7 @@ class ClientsTest {
                         SCHEMA_REG_URL,
                         AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS,
                         false,
-                        KafkaAvroSerializerConfig.USE_LATEST_VERSION,
+                        KafkaAvroSerializerConfig.AVRO_REMOVE_JAVA_PROPS_CONFIG,
                         true);
         assertThat(props.asMap(), is(expected));
     }
@@ -308,7 +308,7 @@ class ClientsTest {
                         SCHEMA_REG_URL,
                         AbstractKafkaSchemaSerDeConfig.AUTO_REGISTER_SCHEMAS,
                         false,
-                        KafkaAvroSerializerConfig.USE_LATEST_VERSION,
+                        KafkaAvroSerializerConfig.AVRO_REMOVE_JAVA_PROPS_CONFIG,
                         true);
         assertThat(props.asMap(), is(expected));
     }


### PR DESCRIPTION
Updates the new `Clients` methods to _not_ set `use.latest.version` / `USE_LATEST_VERSION` to `true`.

We should _not_ be doing this by default, as it means producers use the latest registered schema, rather than the schema version they were compiled to run with.

With this setting on, rolling back a recent release would not mean the older version would use the older schema: it would continue to use the latest schema.

Some tests, i.e. those using reflection, have been updated to still set this to `true` as otherwise they won't work due to the fact that the generated isn't actually registered.

Also set `AVRO_REMOVE_JAVA_PROPS_CONFIG` / `avro.remove.java.properties` so that the additional fields avro has injected into the schema referenced by the generated classes are removed. Without this, the schema the generated classes have won't match the schema registered by specmesh.
