### PR TITLE
Allow records in private topics to be removed.

### DIFF
--- a/cli/src/test/java/io/specmesh/cli/ProvisionNestedFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/ProvisionNestedFunctionalTest.java
@@ -96,7 +96,7 @@ class ProvisionNestedFunctionalTest {
                         .collect(Collectors.toList()),
                 contains("other.domain.Common.subject"));
 
-        assertThat(status.acls(), hasSize(10));
+        assertThat(status.acls(), hasSize(12));
 
         // When:
         final var statusRepublish = provision.run();

--- a/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
+++ b/kafka/src/main/java/io/specmesh/kafka/KafkaApiSpec.java
@@ -22,6 +22,7 @@ import static io.specmesh.apiparser.model.ApiSpec.PROTECTED;
 import static io.specmesh.apiparser.model.ApiSpec.PUBLIC;
 import static java.util.Objects.requireNonNull;
 import static org.apache.kafka.common.acl.AclOperation.CREATE;
+import static org.apache.kafka.common.acl.AclOperation.DELETE;
 import static org.apache.kafka.common.acl.AclOperation.DESCRIBE;
 import static org.apache.kafka.common.acl.AclOperation.IDEMPOTENT_WRITE;
 import static org.apache.kafka.common.acl.AclOperation.READ;
@@ -256,11 +257,11 @@ public final class KafkaApiSpec {
     }
 
     private Set<AclBinding> ownGroupAcls(final String user) {
-        return prefixedAcls(GROUP, id(), principal(user), READ);
+        return prefixedAcls(GROUP, id(), principal(user), READ, DELETE);
     }
 
     private Set<AclBinding> ownTopicAcls(final String user) {
-        return prefixedAcls(TOPIC, id(), principal(user), DESCRIBE, READ, WRITE);
+        return prefixedAcls(TOPIC, id(), principal(user), DESCRIBE, READ, WRITE, DELETE);
     }
 
     private Set<AclBinding> ownTransactionIdsAcls(final String user) {

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecTest.java
@@ -77,6 +77,13 @@ public class KafkaAPISpecTest {
                         + " patternType=PREFIXED),"
                         + " entry=(principal=User:london.hammersmith.olympia.bigdatalondon,"
                         + " host=*, operation=WRITE, permissionType=ALLOW))"),
+        // Note: also allows `DELETE_RECORD` operation on private topics:
+        DELETE_OWN_PRIVATE_TOPICS(
+                "(pattern=ResourcePattern(resourceType=TOPIC,"
+                        + " name=london.hammersmith.olympia.bigdatalondon,"
+                        + " patternType=PREFIXED),"
+                        + " entry=(principal=User:london.hammersmith.olympia.bigdatalondon,"
+                        + " host=*, operation=DELETE, permissionType=ALLOW))"),
         CREATE_OWN_PRIVATE_TOPICS(
                 "(pattern=ResourcePattern(resourceType=TOPIC,"
                         + " name=london.hammersmith.olympia.bigdatalondon._private,"
@@ -89,6 +96,12 @@ public class KafkaAPISpecTest {
                         + " patternType=PREFIXED),"
                         + " entry=(principal=User:london.hammersmith.olympia.bigdatalondon,"
                         + " host=*, operation=READ, permissionType=ALLOW))"),
+        DELETE_OWN_GROUPS(
+                "(pattern=ResourcePattern(resourceType=GROUP,"
+                        + " name=london.hammersmith.olympia.bigdatalondon,"
+                        + " patternType=PREFIXED),"
+                        + " entry=(principal=User:london.hammersmith.olympia.bigdatalondon,"
+                        + " host=*, operation=DELETE, permissionType=ALLOW))"),
         WRITE_OWN_TX_IDS(
                 "(pattern=ResourcePattern(resourceType=TRANSACTIONAL_ID,"
                         + " name=london.hammersmith.olympia.bigdatalondon, patternType=PREFIXED),"

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecWithGrantAccessAclsTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecWithGrantAccessAclsTest.java
@@ -78,6 +78,13 @@ public class KafkaAPISpecWithGrantAccessAclsTest {
                         + " patternType=PREFIXED),"
                         + " entry=(principal=User:london.hammersmith.olympia.bigdatalondon,"
                         + " host=*, operation=WRITE, permissionType=ALLOW))"),
+        // Note: also allows `DELETE_RECORD` operation on private topics:
+        DELETE_OWN_PRIVATE_TOPICS(
+                "(pattern=ResourcePattern(resourceType=TOPIC,"
+                        + " name=london.hammersmith.olympia.bigdatalondon,"
+                        + " patternType=PREFIXED),"
+                        + " entry=(principal=User:london.hammersmith.olympia.bigdatalondon,"
+                        + " host=*, operation=DELETE, permissionType=ALLOW))"),
         CREATE_OWN_PRIVATE_TOPICS(
                 "(pattern=ResourcePattern(resourceType=TOPIC,"
                         + " name=london.hammersmith.olympia.bigdatalondon._private,"
@@ -90,6 +97,12 @@ public class KafkaAPISpecWithGrantAccessAclsTest {
                         + " patternType=PREFIXED),"
                         + " entry=(principal=User:london.hammersmith.olympia.bigdatalondon,"
                         + " host=*, operation=READ, permissionType=ALLOW))"),
+        DELETE_OWN_GROUPS(
+                "(pattern=ResourcePattern(resourceType=GROUP,"
+                        + " name=london.hammersmith.olympia.bigdatalondon,"
+                        + " patternType=PREFIXED),"
+                        + " entry=(principal=User:london.hammersmith.olympia.bigdatalondon,"
+                        + " host=*, operation=DELETE, permissionType=ALLOW))"),
         WRITE_OWN_TX_IDS(
                 "(pattern=ResourcePattern(resourceType=TRANSACTIONAL_ID,"
                         + " name=london.hammersmith.olympia.bigdatalondon, patternType=PREFIXED),"


### PR DESCRIPTION
Fixes: #454

KafkaStreams apps use the `DELETE_RECORDS` operation on repartition topics to automatically delete records that have been processed. This required the `DELETE` permission on the topic to succeed.

We need to decide if we are happy given domain users the writes to delete their own topics.

Personally, I think giving `DELETE` topic permissions seems like a valid thing to do: after all, they are owned by the domain user, so why can't they delete them if they want?  They can always provision them again later.

Con: this does open the doorway to the state in Kafka being out of whack with the spec.

Pro: it empowers domain owners to clean down Kafka topics if they need republishing etc.

Likewise, this change gives domain owners the ability to delete their own consumer groups, should they want to.
