### PR TITLE
Ensure the value types can be constructed in user code

### DIFF
--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaMutators.java
@@ -267,11 +267,11 @@ public final class SchemaMutators {
                                             client.register(schema.subject(), schema.schema());
                                     client.updateCompatibility(schema.subject(), DEFAULT_EVOLUTION);
                                     schema.messages(
-                                            "Subject:"
+                                            "Subject: "
                                                     + schema.subject()
-                                                    + "Created with id: "
+                                                    + ", created with id: "
                                                     + schemaId
-                                                    + ", evolution set to:"
+                                                    + ", evolution set to: "
                                                     + DEFAULT_EVOLUTION);
                                     schema.state(CREATED);
                                 } catch (IOException | RestClientException e) {

--- a/kafka/src/main/java/io/specmesh/kafka/schema/RegisteredSchema.java
+++ b/kafka/src/main/java/io/specmesh/kafka/schema/RegisteredSchema.java
@@ -21,11 +21,13 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.confluent.kafka.schemaregistry.ParsedSchema;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.NoArgsConstructor;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
 /** Pojo for holding data about a schema that is registered with the schema registry. */
+@Builder
 @Value
 @Accessors(fluent = true)
 @JsonIgnoreProperties(ignoreUnknown = true)

--- a/parser/src/main/java/io/specmesh/apiparser/model/Message.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/Message.java
@@ -23,6 +23,9 @@ import io.specmesh.apiparser.AsyncApiParser.APIParserException;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
@@ -32,8 +35,10 @@ import lombok.experimental.Accessors;
  * @see <a href= "https://www.asyncapi.com/docs/reference/specification/v2.4.0#messageObject">spec
  *     docs</a>
  */
+@Builder
 @Value
 @Accessors(fluent = true)
+@AllArgsConstructor(access = AccessLevel.PRIVATE)
 @JsonIgnoreProperties(ignoreUnknown = true)
 @SuppressFBWarnings
 @SuppressWarnings({"unchecked", "rawtypes"})

--- a/parser/src/main/java/io/specmesh/apiparser/model/SchemaInfo.java
+++ b/parser/src/main/java/io/specmesh/apiparser/model/SchemaInfo.java
@@ -19,11 +19,13 @@ package io.specmesh.apiparser.model;
 import static java.util.Objects.requireNonNull;
 
 import java.util.Optional;
+import lombok.Builder;
 import lombok.Value;
 import lombok.experimental.Accessors;
 
 /** Pojo representing a schmea */
 @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
+@Builder
 @Value
 @Accessors(fluent = true)
 public class SchemaInfo {

--- a/parser/src/test/java/io/specmesh/apiparser/model/TagTest.java
+++ b/parser/src/test/java/io/specmesh/apiparser/model/TagTest.java
@@ -16,24 +16,20 @@
 
 package io.specmesh.apiparser.model;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.NoArgsConstructor;
-import lombok.Value;
-import lombok.experimental.Accessors;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
 
-/** Pojo representing a tag */
-@Builder
-@Value
-@Accessors(fluent = true)
-@JsonIgnoreProperties(ignoreUnknown = true)
-@AllArgsConstructor(access = AccessLevel.PRIVATE)
-@NoArgsConstructor(force = true, access = AccessLevel.PRIVATE)
-public class Tag {
-    @JsonProperty String name;
+import org.junit.jupiter.api.Test;
 
-    @JsonProperty String description;
+class TagTest {
+
+    @Test
+    void shouldBeAbleToConstructPopulatedTag() {
+        // When:
+        final Tag tag = Tag.builder().name("name").description("description").build();
+
+        // Then:
+        assertThat(tag.name(), is("name"));
+        assertThat(tag.description(), is("description"));
+    }
 }


### PR DESCRIPTION
e.g. I couldn't create a `Tag` instance in my test code as there was only a private no-args constructor...
