### PR TITLE
Add ability to factor down partition counts

### DIFF
--- a/cli/src/main/java/io/specmesh/cli/Provision.java
+++ b/cli/src/main/java/io/specmesh/cli/Provision.java
@@ -194,10 +194,22 @@ public final class Provision implements Callable<Integer> {
     }
 
     @Option(
+            names = {"-pfc", "--partition-count-factor"},
+            description =
+                    "Optional factor used to scale the number of partitions used when provisioning"
+                        + " a topic. Must be 0 < factor <= 1.0. For example, if factor is 0.5, then"
+                        + " all topics will be created with half the number of partitions specified"
+                        + " in the spec. Topics with more than 2 or more partition in the spec will"
+                        + " always have at least 2 partitions after scaling.")
+    public void partitionCountFactor(final double factor) {
+        builder.partitionCountFactor(factor);
+    }
+
+    @Option(
             names = {"-D", "--property"},
             mapFallbackValue = "",
             description = "Specify Java runtime properties for Apache Kafka." + " ") // allow -Dkey
-    void setProperty(final Map<String, String> props) {
+    public void setProperty(final Map<String, String> props) {
         props.forEach(System::setProperty);
     }
 

--- a/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/Provisioner.java
@@ -55,6 +55,7 @@ public final class Provisioner {
     @Builder.Default private boolean closeAdminClient = false;
     private boolean dryRun;
     private boolean cleanUnspecified;
+    @Builder.Default private double partitionCountFactor = 1.0;
 
     public Status provision() {
         return provision(
@@ -114,7 +115,11 @@ public final class Provisioner {
                 Status.builder()
                         .topics(
                                 topicProvision.provision(
-                                        dryRun, cleanUnspecified, apiSpec, adminClient));
+                                        dryRun,
+                                        cleanUnspecified,
+                                        partitionCountFactor,
+                                        apiSpec,
+                                        adminClient));
         if (!srDisabled) {
             status.schemas(
                     schemaProvision.provision(
@@ -187,7 +192,11 @@ public final class Provisioner {
     @VisibleForTesting
     interface TopicProvision {
         Collection<TopicProvisioner.Topic> provision(
-                boolean dryRun, boolean cleanUnspecified, KafkaApiSpec apiSpec, Admin adminClient);
+                boolean dryRun,
+                boolean cleanUnspecified,
+                double partitionCountFactor,
+                KafkaApiSpec apiSpec,
+                Admin adminClient);
     }
 
     @VisibleForTesting

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicMutators.java
@@ -101,6 +101,10 @@ public class TopicMutators {
                             .filter(topic -> topic.state().equals(STATE.UPDATE))
                             .collect(Collectors.toList());
 
+            if (topicsToUpdate.isEmpty()) {
+                return topicsToUpdate;
+            }
+
             final var topicNames = toTopicNames(topicsToUpdate);
             final var describeTopics = adminClient.describeTopics(topicNames).topicNameValues();
 
@@ -290,6 +294,11 @@ public class TopicMutators {
                     topics.stream()
                             .filter(topic -> topic.state().equals(STATE.CREATE))
                             .collect(Collectors.toList());
+
+            if (topicsToCreate.isEmpty()) {
+                return topicsToCreate;
+            }
+
             try {
                 adminClient
                         .createTopics(asNewTopic(topicsToCreate))

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
@@ -42,10 +42,10 @@ public final class TopicProvisioner {
      * @param dryRun test or execute
      * @param cleanUnspecified remove unwanted resources
      * @param partitionCountFactor Optional factor used to scale the number of partitions used when
-     *     provisioning a topic. Must be 0 &lt; factor &lt;= 1.0. For example, if factor is 0.5, then all
-     *     topics will be created with half the number of partitions specified in the spec. Topics
-     *     with more than 2 or more partition in the spec will always have at least 2 partitions
-     *     after scaling.
+     *     provisioning a topic. Must be 0 &lt; factor &lt;= 1.0. For example, if factor is 0.5,
+     *     then all topics will be created with half the number of partitions specified in the spec.
+     *     Topics with more than 2 or more partition in the spec will always have at least 2
+     *     partitions after scaling.
      * @param apiSpec the api spec.
      * @param adminClient admin client for the Kafka cluster.
      * @return number of topics created

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
@@ -42,7 +42,7 @@ public final class TopicProvisioner {
      * @param dryRun test or execute
      * @param cleanUnspecified remove unwanted resources
      * @param partitionCountFactor Optional factor used to scale the number of partitions used when
-     *     provisioning a topic. Must be 0 < factor <= 1.0. For example, if factor is 0.5, then all
+     *     provisioning a topic. Must be 0 &lt; factor &lt;= 1.0. For example, if factor is 0.5, then all
      *     topics will be created with half the number of partitions specified in the spec. Topics
      *     with more than 2 or more partition in the spec will always have at least 2 partitions
      *     after scaling.

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicProvisioner.java
@@ -16,6 +16,7 @@
 
 package io.specmesh.kafka.provision;
 
+import com.google.common.base.Preconditions;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import io.specmesh.kafka.KafkaApiSpec;
 import java.util.Collection;
@@ -40,6 +41,11 @@ public final class TopicProvisioner {
      *
      * @param dryRun test or execute
      * @param cleanUnspecified remove unwanted resources
+     * @param partitionCountFactor Optional factor used to scale the number of partitions used when
+     *     provisioning a topic. Must be 0 < factor <= 1.0. For example, if factor is 0.5, then all
+     *     topics will be created with half the number of partitions specified in the spec. Topics
+     *     with more than 2 or more partition in the spec will always have at least 2 partitions
+     *     after scaling.
      * @param apiSpec the api spec.
      * @param adminClient admin client for the Kafka cluster.
      * @return number of topics created
@@ -48,9 +54,10 @@ public final class TopicProvisioner {
     public static Collection<Topic> provision(
             final boolean dryRun,
             final boolean cleanUnspecified,
+            final double partitionCountFactor,
             final KafkaApiSpec apiSpec,
             final Admin adminClient) {
-        final var domain = domainTopicsFromApiSpec(apiSpec);
+        final var domain = domainTopicsFromApiSpec(apiSpec, partitionCountFactor);
         final var existing = reader(apiSpec, adminClient).readall();
         final var changeSet = comparator(cleanUnspecified).calculate(existing, domain);
         return mutate(dryRun, cleanUnspecified, adminClient).mutate(changeSet);
@@ -95,20 +102,18 @@ public final class TopicProvisioner {
         return TopicReaders.TopicsReaderBuilder.builder(adminClient, apiSpec.id()).build();
     }
 
-    /**
-     * Topics from the api spec
-     *
-     * @param apiSpec - spec
-     * @return set of topics from the spec
-     */
-    private static Collection<Topic> domainTopicsFromApiSpec(final KafkaApiSpec apiSpec) {
+    private static Collection<Topic> domainTopicsFromApiSpec(
+            final KafkaApiSpec apiSpec, final double partitionCountFactor) {
         return apiSpec.listDomainOwnedTopics().stream()
                 .map(
                         newTopic ->
                                 Topic.builder()
                                         .name(newTopic.name())
                                         .state(Status.STATE.READ)
-                                        .partitions(newTopic.numPartitions())
+                                        .partitions(
+                                                topicPartitions(
+                                                        newTopic.numPartitions(),
+                                                        partitionCountFactor))
                                         .replication(newTopic.replicationFactor())
                                         .config(newTopic.configs())
                                         .build())
@@ -142,5 +147,14 @@ public final class TopicProvisioner {
             this.state = Status.STATE.FAILED;
             return this;
         }
+    }
+
+    private static int topicPartitions(
+            final int specPartitionCount, final double partitionCountFactor) {
+        Preconditions.checkArgument(
+                0.0 < partitionCountFactor && partitionCountFactor <= 1.0,
+                "0.0 < partitionCountFactor <= 1.0, but was: " + partitionCountFactor);
+        final int min = specPartitionCount < 2 ? 1 : 2;
+        return Math.max(min, (int) (specPartitionCount * partitionCountFactor));
     }
 }

--- a/kafka/src/main/java/io/specmesh/kafka/provision/TopicReaders.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/TopicReaders.java
@@ -59,6 +59,9 @@ public final class TopicReaders {
          */
         public Collection<TopicProvisioner.Topic> readall() {
             final var topicList = topicsForPrefix(adminClient, prefix);
+            if (topicList.isEmpty()) {
+                return List.of();
+            }
 
             final var topicDescriptions = topicDescriptions(topicList);
 

--- a/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/KafkaAPISpecFunctionalTest.java
@@ -130,7 +130,7 @@ class KafkaAPISpecFunctionalTest {
     @BeforeAll
     static void setUp() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
-            TopicProvisioner.provision(false, false, API_SPEC, adminClient);
+            TopicProvisioner.provision(false, false, 1.0, API_SPEC, adminClient);
             AclProvisioner.provision(false, false, API_SPEC, API_SPEC.id(), adminClient);
         }
     }

--- a/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/ProvisionerFreshStartFunctionalTest.java
@@ -110,7 +110,8 @@ class ProvisionerFreshStartFunctionalTest {
     void shouldDryRunTopicsFromEmptyCluster() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            final var changeset = TopicProvisioner.provision(true, false, API_SPEC, adminClient);
+            final var changeset =
+                    TopicProvisioner.provision(true, false, 1.0, API_SPEC, adminClient);
 
             assertThat(
                     changeset.stream().map(Topic::name).collect(Collectors.toSet()),
@@ -219,7 +220,8 @@ class ProvisionerFreshStartFunctionalTest {
     void shouldProvisionTopicsFromEmptyCluster() throws ExecutionException, InterruptedException {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
 
-            final var changeSet = TopicProvisioner.provision(false, false, API_SPEC, adminClient);
+            final var changeSet =
+                    TopicProvisioner.provision(false, false, 1.0, API_SPEC, adminClient);
 
             // Verify - changeset
             assertThat(

--- a/kafka/src/test/java/io/specmesh/kafka/TopicProvisionerUpdateFunctionalTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/TopicProvisionerUpdateFunctionalTest.java
@@ -104,7 +104,7 @@ class TopicProvisionerUpdateFunctionalTest {
     @Order(1)
     void shouldProvisionExistingSpec() {
         try (Admin adminClient = KAFKA_ENV.adminClient()) {
-            TopicProvisioner.provision(false, false, API_SPEC, adminClient);
+            TopicProvisioner.provision(false, false, 1.0, API_SPEC, adminClient);
         }
     }
 
@@ -115,7 +115,7 @@ class TopicProvisionerUpdateFunctionalTest {
 
             // DRY RUN Test
             final var dryRunChangeset =
-                    TopicProvisioner.provision(true, false, API_UPDATE_SPEC, adminClient);
+                    TopicProvisioner.provision(true, false, 1.0, API_UPDATE_SPEC, adminClient);
 
             assertThat(
                     dryRunChangeset.stream().map(Topic::name).collect(Collectors.toSet()),
@@ -127,7 +127,7 @@ class TopicProvisionerUpdateFunctionalTest {
 
             // REAL Test
             final var changeset =
-                    TopicProvisioner.provision(false, false, API_UPDATE_SPEC, adminClient);
+                    TopicProvisioner.provision(false, false, 1.0, API_UPDATE_SPEC, adminClient);
 
             final var change = changeset.iterator().next();
 
@@ -156,7 +156,7 @@ class TopicProvisionerUpdateFunctionalTest {
 
             // create the unspecified topic
             final var unSpecifiedTopics =
-                    TopicProvisioner.provision(true, true, API_SPEC, adminClient);
+                    TopicProvisioner.provision(true, true, 1.0, API_SPEC, adminClient);
             // 'should.not.be' topic that should not be
             assertThat(unSpecifiedTopics, is(hasSize(1)));
             assertThat(unSpecifiedTopics.iterator().next().state(), is(STATE.DELETE));
@@ -173,7 +173,7 @@ class TopicProvisionerUpdateFunctionalTest {
 
             // create the unspecified topic
             final var unSpecifiedTopics =
-                    TopicProvisioner.provision(false, true, API_SPEC, adminClient);
+                    TopicProvisioner.provision(false, true, 1.0, API_SPEC, adminClient);
 
             // 'should.not.be' topic that should not be
             assertThat(unSpecifiedTopics, is(hasSize(1)));

--- a/kafka/src/test/java/io/specmesh/kafka/provision/TopicProvisionerTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/TopicProvisionerTest.java
@@ -17,11 +17,36 @@ package io.specmesh.kafka.provision;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import io.specmesh.kafka.KafkaApiSpec;
+import java.util.Collection;
 import java.util.List;
+import java.util.Map;
+import org.apache.kafka.clients.admin.Admin;
+import org.apache.kafka.clients.admin.CreateTopicsResult;
+import org.apache.kafka.clients.admin.ListTopicsResult;
+import org.apache.kafka.clients.admin.NewTopic;
+import org.apache.kafka.clients.admin.TopicListing;
+import org.apache.kafka.common.internals.KafkaFutureImpl;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
 
+@ExtendWith(MockitoExtension.class)
 class TopicProvisionerTest {
+
+    @Mock private Admin adminClient;
+    @Mock private KafkaApiSpec apiSpec;
+    @Mock private NewTopic topic;
 
     @Test
     void shouldNotSwallowExceptions() {
@@ -37,5 +62,89 @@ class TopicProvisionerTest {
         assertThat(
                 swallowed.topics().iterator().next().exception().toString(),
                 containsString(".java:"));
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {-1.0, -0.1, 0.0, 1.00001})
+    void shouldThrowOnInvalidPartitionCountFactor(final double partitionCountFactor) {
+        // Given:
+        setUpMocks(false);
+
+        // When:
+        final Exception e =
+                assertThrows(
+                        IllegalArgumentException.class,
+                        () ->
+                                TopicProvisioner.provision(
+                                        false, false, partitionCountFactor, apiSpec, adminClient));
+
+        // Then:
+        assertThat(
+                e.getMessage(),
+                is("0.0 < partitionCountFactor <= 1.0, but was: " + partitionCountFactor));
+    }
+
+    @ParameterizedTest
+    @ValueSource(doubles = {0.0000001, 0.1, 0.5, 1.0})
+    void shouldSupportValidPartitionCountFactors(final double partitionCountFactor) {
+        // Given:
+        setUpMocks(true);
+        when(topic.numPartitions()).thenReturn(10);
+
+        // When:
+        TopicProvisioner.provision(false, false, partitionCountFactor, apiSpec, adminClient);
+
+        // Then:
+        verify(adminClient).createTopics(any());
+    }
+
+    @Test
+    void shouldNotFactoryTopicsWithOnePartition() {
+        // Given:
+        setUpMocks(true);
+        when(topic.numPartitions()).thenReturn(1);
+
+        // When:
+        TopicProvisioner.provision(false, false, 0.0001, apiSpec, adminClient);
+
+        // Then:
+        verify(adminClient)
+                .createTopics(List.of(new NewTopic(topic.name(), 1, (short) 3).configs(Map.of())));
+    }
+
+    @Test
+    void shouldNeverFactoryTopicsWithMoreOnePartitionBelowTwoPartitions() {
+        // Given:
+        setUpMocks(true);
+        when(topic.numPartitions()).thenReturn(10);
+
+        // When:
+        TopicProvisioner.provision(false, false, 0.0001, apiSpec, adminClient);
+
+        // Then:
+        verify(adminClient)
+                .createTopics(List.of(new NewTopic(topic.name(), 2, (short) 3).configs(Map.of())));
+    }
+
+    private void setUpMocks(final boolean forSuccess) {
+        when(apiSpec.listDomainOwnedTopics()).thenReturn(List.of(topic));
+        when(topic.name()).thenReturn("bob");
+
+        if (forSuccess) {
+            when(topic.replicationFactor()).thenReturn((short) 3);
+
+            final ListTopicsResult listTopicResult = mock();
+            final KafkaFutureImpl<Collection<TopicListing>> listTopicsFuture =
+                    new KafkaFutureImpl<>();
+            listTopicsFuture.complete(List.of());
+            when(listTopicResult.listings()).thenReturn(listTopicsFuture);
+            when(adminClient.listTopics()).thenReturn(listTopicResult);
+
+            final CreateTopicsResult createTopicResult = mock();
+            final KafkaFutureImpl<Void> createTopicsFuture = new KafkaFutureImpl<>();
+            createTopicsFuture.complete(null);
+            when(createTopicResult.all()).thenReturn(createTopicsFuture);
+            when(adminClient.createTopics(any())).thenReturn(createTopicResult);
+        }
     }
 }


### PR DESCRIPTION
Fixes: #464

Adds new `--partition-count-factor` command line argument and `Provisioner.partitionCountFactor()` method to allow a factor to be set (`0 < factor <= 1.0`) to reduce the number of partitions that will be created for new topics.

This can be useful to reduce partition counts in smaller non-prod environments, without changing the spec.

An alternative approach, worth considering, is to put the counts into the spec:

```yaml
channels:
  _private.instrument:
    bindings:
      kafka:
        envs:
          - loadtest:
              patitions: 10
          - prod:
              patitions: 10
        partitions: 3
```

Which may be a better solution, but requires more work
