### PR TITLE
SchemaReaders now use String, not Path, for resource locations of schema

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,6 +25,11 @@ plugins {
     id("com.bmuschko.docker-remote-api") version "9.4.0" apply false
 }
 
+
+scmVersion {
+    ignoreUncommittedChanges.set(false)
+}
+
 project.version = scmVersion.version
 project.group = "io.specmesh"
 

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/AvroReferenceFinder.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/AvroReferenceFinder.java
@@ -23,6 +23,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.json.JsonMapper;
 import com.fasterxml.jackson.databind.util.ClassUtil;
+import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -432,7 +433,8 @@ final class AvroReferenceFinder {
         }
     }
 
-    private static final class SchemaLoadException extends RuntimeException {
+    @VisibleForTesting
+    static final class SchemaLoadException extends RuntimeException {
         SchemaLoadException(final String type, final Route route, final Throwable cause) {
             super(
                     "Failed to load schema for type: %s, referenced via schema file chain: %s"

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaReaders.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaReaders.java
@@ -43,8 +43,6 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
-import java.util.Optional;
 import java.util.stream.Collectors;
 import lombok.Data;
 import lombok.experimental.Accessors;
@@ -65,45 +63,84 @@ public final class SchemaReaders {
         private final ClassPathSchemaReader cpReader = new ClassPathSchemaReader();
         private final FileSystemSchemaReader fsReader = new FileSystemSchemaReader();
 
+        /**
+         * @deprecated this version has compatibility issues with Windows, use {@link #read(String)}
+         */
+        @Deprecated
         public List<NamedSchema> read(final Path schemaFile) {
+            return read(schemaFile.toString());
+        }
+
+        public List<NamedSchema> read(final String schemaFile) {
             if (cpReader.has(schemaFile)) {
-                return cpReader.readLocal(schemaFile);
+                return cpReader.read(schemaFile);
             } else {
-                return fsReader.readLocal(schemaFile);
+                return fsReader.read(schemaFile);
             }
         }
     }
 
-    private abstract static class BaseLocalSchemaReader {
+    public interface LocalReader {
+        /**
+         * Read the content of the schema file, extracting named types and loading any unknown types
+         *
+         * @param schemaFile the path to the root schema file, either on the filesystem or on the
+         *     classpath.
+         * @return a list of named schemas, in leaf-first order. The last element in the list will
+         *     be the root schema.
+         */
+        List<NamedSchema> read(String schemaFile);
 
         /**
-         * @param filePath path to schema.
-         * @return ordered list of schema, with schema dependencies earlier in the list. The schema
-         *     loaded from {@code filePath} will have an empty subject
+         * Read the contents of the schema file.
+         *
+         * @param schemaFile the path to the schema file, either on the filesystem or on the
+         *     classpath.
+         * @return the contents.
          */
-        public List<NamedSchema> readLocal(final Path filePath) {
-            final String schemaContent = readSchema(filePath);
-            final String filename =
-                    Optional.ofNullable(filePath.getFileName()).map(Objects::toString).orElse("");
-            if (filename.endsWith(".avsc")) {
-                return referenceFinder(filePath)
-                        .findReferences(filePath.toString(), schemaContent)
+        String readContent(String schemaFile);
+    }
+
+    private abstract static class BaseLocalSchemaReader implements LocalReader {
+
+        @Override
+        public List<NamedSchema> read(final String schemaFile) {
+            final String schemaContent = readContent(schemaFile);
+            if (schemaFile.endsWith(".avsc")) {
+                return referenceFinder(schemaFile)
+                        .findReferences(schemaFile, schemaContent)
                         .stream()
                         .map(s -> new NamedSchema(s.typeName(), toAvroSchema(s)))
                         .collect(Collectors.toList());
-            } else if (filename.endsWith(".yml")) {
+            } else if (schemaFile.endsWith(".yml")) {
                 return List.of(new NamedSchema("", new JsonSchema(schemaContent)));
-            } else if (filename.endsWith(".proto")) {
+            } else if (schemaFile.endsWith(".proto")) {
                 return List.of(new NamedSchema("", new ProtobufSchema(schemaContent)));
             } else {
-                throw new UnsupportedOperationException(
-                        "Unsupported schema file: " + filePath.toAbsolutePath().normalize());
+                throw new UnsupportedOperationException("Unsupported schema file: " + schemaFile);
             }
         }
 
-        protected abstract String readSchema(Path path);
+        /**
+         * @param filePath path to schema.
+         * @return an ordered list of schema, with schema dependencies earlier in the list. The
+         *     schema loaded from {@code filePath} will be the last in the list.
+         */
+        public List<NamedSchema> readLocal(final Path filePath) {
+            return read(filePath.toString());
+        }
 
-        abstract AvroReferenceFinder referenceFinder(Path parentSchema);
+        @Deprecated
+        protected String readSchema(final Path path) {
+            return readContent(path.toString());
+        }
+
+        @Deprecated
+        AvroReferenceFinder referenceFinder(final Path parentSchema) {
+            return referenceFinder(parentSchema.toString());
+        }
+
+        abstract AvroReferenceFinder referenceFinder(String parentSchema);
 
         private static AvroSchema toAvroSchema(final DetectedSchema schema) {
 
@@ -127,40 +164,69 @@ public final class SchemaReaders {
 
     public static final class ClassPathSchemaReader extends BaseLocalSchemaReader {
 
+        private static final char RESOURCE_PATH_SEPARATOR = '/';
+
+        /**
+         * @param schemaFile the file to check for
+         * @return {@code true} if the schema file exists on the classpath.
+         * @deprecated this version has compatibility issues with Windows, use {@link #has(String)}
+         */
+        @Deprecated
         public boolean has(final Path schemaFile) {
-            return getClass().getClassLoader().getResource(schemaFile.toString()) != null;
+            return has(schemaFile.toString());
+        }
+
+        public boolean has(final String schemaFile) {
+            return getClass().getClassLoader().getResource(schemaFile) != null;
+        }
+
+        /**
+         * @deprecated use {@link #read(String)} as this version has issues on Windows.
+         */
+        @Deprecated(since = "0.18.0", forRemoval = true)
+        @Override
+        public List<NamedSchema> readLocal(final Path filePath) {
+            return super.readLocal(filePath);
         }
 
         @Override
-        protected String readSchema(final Path path) {
-            try (InputStream s = getClass().getClassLoader().getResourceAsStream(path.toString())) {
+        public String readContent(final String location) {
+            try (InputStream s = getClass().getClassLoader().getResourceAsStream(location)) {
                 if (s == null) {
-                    throw new RuntimeException(path + " not found");
+                    throw new RuntimeException(location + " not found");
                 }
                 return new String(s.readAllBytes(), StandardCharsets.UTF_8);
             } catch (Exception e) {
                 throw new SchemaProvisioningException(
-                        "Failed to read schema from classpath:" + path, e);
+                        "Failed to read schema from classpath:" + location, e);
             }
         }
 
         @Override
-        AvroReferenceFinder referenceFinder(final Path parentSchema) {
-            final Path schemaDir =
-                    Optional.ofNullable(parentSchema.getParent()).orElse(Path.of(""));
+        AvroReferenceFinder referenceFinder(final String rootSchemaLocation) {
+            final int idx = rootSchemaLocation.lastIndexOf(RESOURCE_PATH_SEPARATOR);
+            final String schemaDir = idx < 0 ? "" : rootSchemaLocation.substring(0, idx + 1);
 
             return new AvroReferenceFinder(
                     type -> {
-                        final Path path = schemaDir.resolve(type + ".avsc");
-                        final String content = readSchema(path);
-                        return new AvroReferenceFinder.LoadedSchema(path.toString(), content);
+                        final String location = "%s%s.avsc".formatted(schemaDir, type);
+                        final String content = readContent(location);
+                        return new AvroReferenceFinder.LoadedSchema(location, content);
                     });
         }
     }
 
     public static final class FileSystemSchemaReader extends BaseLocalSchemaReader {
 
-        protected String readSchema(final Path path) {
+        public List<NamedSchema> read(final Path path) {
+            return read(path.toAbsolutePath().normalize().toString());
+        }
+
+        public String readContent(final String path) {
+            return readContent(Path.of(path));
+        }
+
+        public String readContent(final Path path) {
             try {
                 return Files.readString(path, StandardCharsets.UTF_8);
             } catch (IOException e) {
@@ -169,6 +235,7 @@ public final class SchemaReaders {
             }
         }
 
+        @SuppressWarnings("deprecation")
         @Override
         AvroReferenceFinder referenceFinder(final Path parentSchema) {
             final Path schemaDir = parentSchema.toAbsolutePath().getParent();
@@ -176,9 +243,14 @@ public final class SchemaReaders {
             return new AvroReferenceFinder(
                     type -> {
                         final Path path = schemaDir.resolve(type + ".avsc");
-                        final String content = readSchema(path);
+                        final String content = readContent(path);
                         return new AvroReferenceFinder.LoadedSchema(path.toString(), content);
                     });
+        }
+
+        @Override
+        AvroReferenceFinder referenceFinder(final String parentSchema) {
+            return referenceFinder(Path.of(parentSchema));
         }
     }
 

--- a/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaReadersTest.java
+++ b/kafka/src/test/java/io/specmesh/kafka/provision/schema/SchemaReadersTest.java
@@ -1,0 +1,219 @@
+/*
+ * Copyright 2023 SpecMesh Contributors (https://github.com/specmesh)
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.specmesh.kafka.provision.schema;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.instanceOf;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import io.specmesh.kafka.provision.schema.AvroReferenceFinder.SchemaLoadException;
+import io.specmesh.kafka.provision.schema.SchemaProvisioner.SchemaProvisioningException;
+import java.nio.file.NoSuchFileException;
+import java.nio.file.Path;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+class SchemaReadersTest {
+
+    @Nested
+    class ClassPathSchemaReaderTest {
+        private SchemaReaders.ClassPathSchemaReader reader;
+
+        @BeforeEach
+        void setUp() {
+            reader = new SchemaReaders.ClassPathSchemaReader();
+        }
+
+        @Test
+        void shouldReadSchemaContentFromClassPath() {
+            // When:
+            final String content = reader.readContent("schema/other.domain.Common.avsc");
+
+            // Then:
+            assertThat(
+                    content,
+                    containsString(
+                            """
+                            "name": "Common\"\
+                            """));
+        }
+
+        @Test
+        void shouldLoadedReferencedSchemaFromRootFolderInClassPath() {
+            // When:
+            final List<SchemaReaders.NamedSchema> result = reader.read("a.domain.Root.avsc");
+
+            // Then:
+            assertThat(result, hasSize(2));
+            assertThat(result.get(0).subject(), is("a.domain.Thing"));
+            assertThat(result.get(0).schema().name(), containsString("a.domain.Thing"));
+            assertThat(result.get(1).subject(), is("a.domain.Root"));
+            assertThat(result.get(1).schema().name(), containsString("a.domain.Root"));
+        }
+
+        @Test
+        void shouldLoadedReferencedSchemaFromSubFolderInClassPath() {
+            // When:
+            final List<SchemaReaders.NamedSchema> result =
+                    reader.read("schema/other.domain.Root.avsc");
+
+            // Then:
+            assertThat(result, hasSize(2));
+            assertThat(result.get(0).subject(), is("other.domain.Common"));
+            assertThat(result.get(0).schema().name(), containsString("other.domain.Common"));
+            assertThat(result.get(1).subject(), is("other.domain.Root"));
+            assertThat(result.get(1).schema().name(), containsString("other.domain.Root"));
+        }
+
+        @Test
+        void shouldThrowIfRootSchemaDoesNotExist() {
+            // When:
+            final Exception e =
+                    assertThrows(
+                            SchemaProvisioningException.class,
+                            () -> reader.read("schema/i.do.not.Exist.avsc"));
+
+            // Then:
+            assertThat(
+                    e.getMessage(),
+                    is("Failed to read schema from classpath:schema/i.do.not.Exist.avsc"));
+            assertThat(e.getCause().getMessage(), is("schema/i.do.not.Exist.avsc not found"));
+        }
+
+        @Test
+        void shouldThrowIfNestedSchemaDoesNotExist() {
+            // When:
+            final Exception e =
+                    assertThrows(
+                            SchemaLoadException.class,
+                            () -> reader.read("schema/other.domain.Bad.avsc"));
+
+            // Then:
+            assertThat(
+                    e.getMessage(),
+                    is(
+                            "Failed to load schema for type: some.unknown.Type, referenced via"
+                                    + " schema file chain: schema/other.domain.Bad.avsc"));
+            assertThat(e.getCause(), is(instanceOf(SchemaProvisioningException.class)));
+            assertThat(
+                    e.getCause().getMessage(),
+                    is("Failed to read schema from classpath:schema/some.unknown.Type.avsc"));
+        }
+    }
+
+    @Nested
+    class FileSystemSchemaReaderTest {
+        private SchemaReaders.FileSystemSchemaReader reader;
+        private Path resourcesDir;
+
+        @BeforeEach
+        void setUp() {
+            reader = new SchemaReaders.FileSystemSchemaReader();
+            resourcesDir = Path.of("src/test/resources");
+        }
+
+        @Test
+        void shouldReadSchemaContentFromClassPath() {
+            // When:
+            final String content =
+                    reader.readContent(resourcesDir.resolve("schema/other.domain.Common.avsc"));
+
+            // Then:
+            assertThat(
+                    content,
+                    containsString(
+                            """
+                            "name": "Common\"\
+                            """));
+        }
+
+        @Test
+        void shouldLoadedReferencedSchemaFromRootFolderInClassPath() {
+            // When:
+            final List<SchemaReaders.NamedSchema> result =
+                    reader.read(resourcesDir.resolve("a.domain.Root.avsc"));
+
+            // Then:
+            assertThat(result, hasSize(2));
+            assertThat(result.get(0).subject(), is("a.domain.Thing"));
+            assertThat(result.get(0).schema().name(), containsString("a.domain.Thing"));
+            assertThat(result.get(1).subject(), is("a.domain.Root"));
+            assertThat(result.get(1).schema().name(), containsString("a.domain.Root"));
+        }
+
+        @Test
+        void shouldLoadedReferencedSchemaFromSubFolderInClassPath() {
+            // When:
+            final List<SchemaReaders.NamedSchema> result =
+                    reader.read(resourcesDir.resolve("schema/other.domain.Root.avsc"));
+
+            // Then:
+            assertThat(result, hasSize(2));
+            assertThat(result.get(0).subject(), is("other.domain.Common"));
+            assertThat(result.get(0).schema().name(), containsString("other.domain.Common"));
+            assertThat(result.get(1).subject(), is("other.domain.Root"));
+            assertThat(result.get(1).schema().name(), containsString("other.domain.Root"));
+        }
+
+        @Test
+        void shouldThrowIfRootSchemaDoesNotExist() {
+            // Given:
+            final Path path = resourcesDir.resolve("schema/i.do.not.Exist.avsc");
+
+            // When:
+            final Exception e =
+                    assertThrows(SchemaProvisioningException.class, () -> reader.read(path));
+
+            // Then:
+            assertThat(
+                    e.getMessage(),
+                    is("Failed to read schema at path:" + path.toAbsolutePath().normalize()));
+            assertThat(e.getCause(), is(instanceOf(NoSuchFileException.class)));
+            assertThat(e.getCause().getMessage(), is(path.toAbsolutePath().normalize().toString()));
+        }
+
+        @Test
+        void shouldThrowIfNestedSchemaDoesNotExist() {
+            // Given:
+            final Path path = resourcesDir.resolve("schema/other.domain.Bad.avsc");
+
+            // When:
+            final Exception e = assertThrows(SchemaLoadException.class, () -> reader.read(path));
+
+            // Then:
+            assertThat(
+                    e.getMessage(),
+                    is(
+                            "Failed to load schema for type: some.unknown.Type, referenced via"
+                                    + " schema file chain: "
+                                    + path.toAbsolutePath().normalize()));
+            assertThat(e.getCause(), is(instanceOf(SchemaProvisioningException.class)));
+            assertThat(
+                    e.getCause().getMessage(),
+                    is(
+                            "Failed to read schema at path:"
+                                    + resourcesDir
+                                            .resolve("schema/some.unknown.Type.avsc")
+                                            .toAbsolutePath()
+                                            .normalize()));
+        }
+    }
+}

--- a/kafka/src/test/resources/a.domain.Root.avsc
+++ b/kafka/src/test/resources/a.domain.Root.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "namespace": "a.domain",
+  "name": "Root",
+  "fields": [
+    {"name": "f0", "type": "Thing"}
+  ]
+}

--- a/kafka/src/test/resources/a.domain.Thing.avsc
+++ b/kafka/src/test/resources/a.domain.Thing.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "namespace": "a.domain",
+  "name": "Thing",
+  "fields": [
+    {"name": "f0", "type": "string"}
+  ]
+}

--- a/kafka/src/test/resources/schema/other.domain.Bad.avsc
+++ b/kafka/src/test/resources/schema/other.domain.Bad.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "namespace": "other.domain",
+  "name": "Root",
+  "fields": [
+    {"name": "common", "type": "some.unknown.Type"}
+  ]
+}

--- a/kafka/src/test/resources/schema/other.domain.Root.avsc
+++ b/kafka/src/test/resources/schema/other.domain.Root.avsc
@@ -1,0 +1,8 @@
+{
+  "type": "record",
+  "namespace": "other.domain",
+  "name": "Root",
+  "fields": [
+    {"name": "common", "type": "Common"}
+  ]
+}


### PR DESCRIPTION
On Windows a `Path` uses `\` as the separator, where as a resource path in Java should always use `/`.

Hence, SchemaReaders should not use `Path` for locations that are potentially class path locations.

Deprecated methods that take a `Path` for potential classpath locations and added `String` method variants.

Added a much-needed unit test for `SchemaReaders`.
