### PR TITLE
`DockerKafkaEnvironment` should accept `DockerImageName`

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -76,11 +76,10 @@ subprojects {
     }
 
     extra.apply {
-        set("kafkaVersion", "7.9.1-ce")
         set("openTracingVersion", "0.33.0")
         set("observabilityVersion", "1.1.8")
         set("guavaVersion", "33.5.0-jre")
-        set("confluentVersion", "7.9.1")
+        set("confluentVersion", "7.9.1") // note: update version in DockerKafkaEnvironment when changing this
         set("jacksonVersion", "2.20.0")
         set("jacksonAnnotationsVersion", "2.20")
         set("protobufVersion", "3.25.5")

--- a/cli/build.gradle.kts
+++ b/cli/build.gradle.kts
@@ -22,7 +22,6 @@ plugins {
     id("com.bmuschko.docker-remote-api")
 }
 
-val kafkaVersion : String by extra
 val spotBugsVersion : String by extra
 val jacksonVersion : String by extra
 val lombokVersion : String by extra

--- a/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
@@ -346,7 +346,8 @@ public final class DockerKafkaEnvironment
         private static final int DEFAULT_CONTAINER_STARTUP_ATTEMPTS = 3;
         private static final Duration DEFAULT_CONTAINER_STARTUP_TIMEOUT = Duration.ofSeconds(30);
 
-        private static final String DEFAULT_KAFKA_DOCKER_IMAGE = "confluentinc/cp-kafka:7.5.3";
+        private static final DockerImageName DEFAULT_KAFKA_DOCKER_IMAGE =
+                DockerImageName.parse("confluentinc/cp-kafka:7.9.1");
         private static final Map<String, String> DEFAULT_KAFKA_ENV =
                 Map.of(
                         "KAFKA_AUTO_CREATE_TOPICS_ENABLE",
@@ -354,8 +355,8 @@ public final class DockerKafkaEnvironment
                         "KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS",
                         "0");
 
-        private static final String DEFAULT_SCHEMA_REG_IMAGE =
-                "confluentinc/cp-schema-registry:7.5.3";
+        private static final DockerImageName DEFAULT_SCHEMA_REG_IMAGE =
+                SchemaRegistryContainer.DEFAULT_IMAGE_NAME;
 
         private int startUpAttempts = DEFAULT_CONTAINER_STARTUP_ATTEMPTS;
         private Duration startUpTimeout = DEFAULT_CONTAINER_STARTUP_TIMEOUT;
@@ -411,9 +412,21 @@ public final class DockerKafkaEnvironment
          *
          * @param imageName the Docker image name.
          * @return self.
+         * @deprecated since 0.18.2, use {@link #withKafkaImage(DockerImageName)} instead.
          */
+        @Deprecated(since = "0.18.2", forRemoval = true)
         public Builder withKafkaImage(final String imageName) {
-            this.kafkaDockerImage = DockerImageName.parse(imageName);
+            return withKafkaImage(DockerImageName.parse(imageName));
+        }
+
+        /**
+         * Customise the Docker image to use for Kafka.
+         *
+         * @param imageName the Docker image name.
+         * @return self.
+         */
+        public Builder withKafkaImage(final DockerImageName imageName) {
+            this.kafkaDockerImage = requireNonNull(imageName, "imageName");
             return this;
         }
 
@@ -455,10 +468,23 @@ public final class DockerKafkaEnvironment
          *
          * @param imageName the Docker image name.
          * @return self.
+         * @deprecated since 0.18.2, use {@link #withSchemaRegistryImage(DockerImageName)} instead.
          */
         @SuppressWarnings("UnusedReturnValue")
+        @Deprecated(since = "0.18.2", forRemoval = true)
         public Builder withSchemaRegistryImage(final String imageName) {
-            this.srImage = Optional.of(DockerImageName.parse(imageName));
+            return withSchemaRegistryImage(DockerImageName.parse(imageName));
+        }
+
+        /**
+         * Customise the Docker image to use for Schema Registry.
+         *
+         * @param imageName the Docker image name.
+         * @return self.
+         */
+        @SuppressWarnings("UnusedReturnValue")
+        public Builder withSchemaRegistryImage(final DockerImageName imageName) {
+            this.srImage = Optional.of(imageName);
             return this;
         }
 

--- a/kafka-test/src/main/java/io/specmesh/kafka/schema/SchemaRegistryContainer.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/schema/SchemaRegistryContainer.java
@@ -27,8 +27,8 @@ import org.testcontainers.utility.DockerImageName;
 /** Test container for the Schema Registry */
 public final class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
 
-    private static final DockerImageName DEFAULT_IMAGE_NAME =
-            DockerImageName.parse("confluentinc/cp-schema-registry:7.5.3");
+    public static final DockerImageName DEFAULT_IMAGE_NAME =
+            DockerImageName.parse("confluentinc/cp-schema-registry:7.9.1");
 
     /** Port the SR will listen on. */
     public static final int SCHEMA_REGISTRY_PORT = 8081;

--- a/kafka/build.gradle.kts
+++ b/kafka/build.gradle.kts
@@ -19,7 +19,6 @@ plugins {
     id("com.github.davidmc24.gradle.plugin.avro") version "1.9.1"
 }
 
-val kafkaVersion : String by extra
 val spotBugsVersion : String by extra
 val jacksonVersion : String by extra
 val lombokVersion : String by extra
@@ -40,8 +39,8 @@ dependencies {
 
     api(project(":parser"))
 
-    implementation("org.apache.kafka:kafka-streams:$kafkaVersion")
-    implementation("org.apache.kafka:kafka-clients:$kafkaVersion")
+    implementation("org.apache.kafka:kafka-streams:$confluentVersion-ce")
+    implementation("org.apache.kafka:kafka-clients:$confluentVersion-ce")
     implementation("commons-io:commons-io:2.20.0")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
 


### PR DESCRIPTION
As this allows caller to use higher versions that they know to be compatible, e.g.

```
DockerImageName.parse("confluentinc/cp-schema-registry:8.0.1").asCompatibleSubstituteFor("confluentinc/cp-schema-registry:7.9.1"
```
