### PR TITLE
Write new any schema before updating existing

### DIFF
--- a/cli/src/test/java/io/specmesh/cli/ProvisionExternalSchemaReferencesFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/ProvisionExternalSchemaReferencesFunctionalTest.java
@@ -35,13 +35,17 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
+import java.util.Map;
+import java.util.UUID;
 import org.hamcrest.Matcher;
 import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Order;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.TestMethodOrder;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.io.TempDir;
 import picocli.CommandLine;
 
 /** Functional test of specs that use schema files that reference other schema files. */
@@ -61,9 +65,18 @@ class ProvisionExternalSchemaReferencesFunctionalTest {
                     .withKafkaAcls()
                     .build();
 
+    @TempDir Path tempDir;
+
+    private String domainId;
+
     @BeforeAll
     static void beforeAll() {
         givenSchemaFromOtherDomainsAreRegistered();
+    }
+
+    @BeforeEach
+    void setUp() {
+        domainId = "some.domain." + UUID.randomUUID().toString().toLowerCase();
     }
 
     @Order(1)
@@ -92,26 +105,134 @@ class ProvisionExternalSchemaReferencesFunctionalTest {
         testProvision("primitive", false, false);
     }
 
-    private static void testProvision(
-            final String rootType, final boolean requireShared, final boolean expectShared) {
-        final Provision provision = new Provision();
-        new CommandLine(provision)
-                .parseArgs(
-                        "--bootstrap-server",
-                        KAFKA_ENV.kafkaBootstrapServers(),
-                        "--spec",
-                        "examples/references/avro/" + rootType + ".spec.yaml",
-                        "--username",
-                        "admin",
-                        "--secret",
-                        "admin-secret",
-                        "--schema-registry",
-                        KAFKA_ENV.schemaRegistryServer(),
-                        "--schema-path",
-                        "./src/test/resources/examples/references/avro");
+    @Test
+    void shouldProvisionAddedNestedSchema() {
+        // Given:
+        final String initialSchemaC =
+                """
+                {
+                  "type": "record",
+                  "name": "C",
+                  "namespace": "{domain.id}",
+                  "fields": [
+                    {"name": "initial", "type": "string"}
+                  ]
+                }
+                """;
+
+        assertThat(provision(Map.of("C", initialSchemaC)).failed(), is(false));
+
+        final String schemaA =
+                """
+                {
+                  "type": "record",
+                  "name": "A",
+                  "namespace": "{domain.id}",
+                  "fields": [
+                    {"name": "val", "type": "string"}
+                  ]
+                }
+                """;
+
+        final String schemaB =
+                """
+                {
+                  "type": "record",
+                  "name": "B",
+                  "namespace": "{domain.id}",
+                  "fields": [
+                    {"name": "val", "type": "A"}
+                  ]
+                }
+                """;
+
+        final String updatedSchemaC =
+                """
+                {
+                  "type": "record",
+                  "name": "C",
+                  "namespace": "{domain.id}",
+                  "fields": [
+                    {"name": "initial", "type": "string"},
+                    {"name": "added", "type": ["null", "B"], "default": null}
+                  ]
+                }
+                """;
 
         // When:
-        final var status = provision.run();
+        final Status status =
+                provision(
+                        Map.of(
+                                "A", schemaA,
+                                "B", schemaB,
+                                "C", updatedSchemaC));
+
+        // Then:
+        status.check();
+    }
+
+    private Status provision(final Map<String, String> schema) {
+        writeSchema(schema);
+        final Path spec = writeSpec();
+        final Provision provision = buildCommand(spec, tempDir);
+        return provision.run();
+    }
+
+    private void writeSchema(final Map<String, String> schema) {
+        for (final Map.Entry<String, String> e : schema.entrySet()) {
+            final String entityName = e.getKey();
+            final String content = e.getValue();
+            final Path path = tempDir.resolve(domainId + "." + entityName + ".avsc");
+            writeFile(path, content);
+        }
+    }
+
+    private Path writeSpec() {
+        final String content =
+                """
+                asyncapi: '2.4.0'
+                id: 'urn:{domain.id}'
+                info:
+                  title: Avro Schema Reference Demo
+                  version: '1.0.0'
+                channels:
+                  _public.thing:
+                    bindings:
+                      kafka:
+                        partitions: 3
+
+                    publish:
+                      operationId: publishRecord
+                      message:
+                        bindings:
+                          kafka:
+                            key:
+                              type: long
+                        payload:
+                          $ref: {domain.id}.C.avsc
+                """;
+
+        final Path path = tempDir.resolve(domainId + ".spec.avsc");
+        return writeFile(path, content);
+    }
+
+    private Path writeFile(final Path path, final String content) {
+        try {
+            return Files.writeString(path, content.replace("{domain.id}", domainId));
+        } catch (IOException ex) {
+            throw new AssertionError("Failed to write to " + path, ex);
+        }
+    }
+
+    private static void testProvision(
+            final String rootType, final boolean requireShared, final boolean expectShared) {
+        final Provision provision =
+                buildCommand(
+                        Path.of("examples/references/avro/" + rootType + ".spec.yaml"),
+                        Path.of("./src/test/resources/examples/references/avro"));
+
+        // When:
+        final Status status = provision.run();
 
         // Then:
         assertThat(status.failed(), is(false));
@@ -152,6 +273,25 @@ class ProvisionExternalSchemaReferencesFunctionalTest {
                         .toList();
 
         assertThat(schemas, is(empty()));
+    }
+
+    private static Provision buildCommand(final Path spec, final Path schemaPath) {
+        final Provision provision = new Provision();
+        new CommandLine(provision)
+                .parseArgs(
+                        "--bootstrap-server",
+                        KAFKA_ENV.kafkaBootstrapServers(),
+                        "--spec",
+                        spec.toString(),
+                        "--username",
+                        "admin",
+                        "--secret",
+                        "admin-secret",
+                        "--schema-registry",
+                        KAFKA_ENV.schemaRegistryServer(),
+                        "--schema-path",
+                        schemaPath.toString());
+        return provision;
     }
 
     private static Matcher<Iterable<? extends String>> expectedCreatedSchemaSubjects(

--- a/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaMutators.java
+++ b/kafka/src/main/java/io/specmesh/kafka/provision/schema/SchemaMutators.java
@@ -397,8 +397,8 @@ public final class SchemaMutators {
             } else {
                 return new CollectiveMutator(
                         new EnsureSharedRegistered(domainId, client),
-                        new UpdateMutator(client),
                         new WriteMutator(client),
+                        new UpdateMutator(client),
                         new IgnoredMutator());
             }
         }


### PR DESCRIPTION
Fixes #643

Updating an existing schema to reference a new schema would previously fail because `SchemaMutators` was updating any existing schema _before_ writing new schema.  Hence, the update would fail.

Now `SchemaMutators` writes new schema first.

