### PR TITLE
Update Avro 1.12.1

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,15 @@ subprojects {
     val hamcrestVersion : String by extra
     val log4jVersion : String by extra
 
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "org.apache.avro" && requested.name == "avro") {
+                useVersion("1.12.1")
+                because("Upgrade avro to fix security vulnerabilities (CVE-2024-47561)")
+            }
+        }
+    }
+
     dependencies {
         testImplementation(project(":parser"))
         testImplementation(project(":kafka"))


### PR DESCRIPTION
Fixes CVE-2024-47561

Issue only affects the build, not the published artefacts.