### PR TITLE
Update commons-beanutils 1.11.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -103,6 +103,15 @@ subprojects {
     val hamcrestVersion : String by extra
     val log4jVersion : String by extra
 
+    configurations.all {
+        resolutionStrategy.eachDependency {
+            if (requested.group == "commons-beanutils" && requested.name == "commons-beanutils") {
+                useVersion("1.11.0")
+                because("Upgrade commons-beanutils to fix CVE-2025-48734")
+            }
+        }
+    }
+
     dependencies {
         testImplementation(project(":parser"))
         testImplementation(project(":kafka"))


### PR DESCRIPTION
Fixes CVE-2025-48734

Only affects the build, not the published artefacts.