### PR TITLE
Enforce Log4J version in plugins

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -126,6 +126,10 @@ subprojects {
                 useVersion("1.11.0")
                 because("Upgrade commons-beanutils to fix CVE-2025-48734")
             }
+            if (requested.group == "org.apache.logging.log4j") {
+                useVersion(log4jVersion)
+                because("Upgrade commons-beanutils to fix CVE-2026-34478")
+            }
         }
     }
 


### PR DESCRIPTION
Fixes CVE-2026-34478

Only affects the build, not the released artefacts