### PR TITLE
Standardise on the community edition of Confluent Platform

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -79,7 +79,7 @@ subprojects {
         set("openTracingVersion", "0.33.0")
         set("observabilityVersion", "1.1.8")
         set("guavaVersion", "33.5.0-jre")
-        set("confluentVersion", "8.2.0") // note: update version in DockerKafkaEnvironment when changing this
+        set("confluentVersion", "8.2.0")
         set("jacksonVersion", "2.21.2")
         set("jacksonAnnotationsVersion", "2.21")
         set("protobufVersion", "3.25.9")

--- a/cli/src/test/java/io/specmesh/cli/ProvisionExternalSchemaReferencesFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/ProvisionExternalSchemaReferencesFunctionalTest.java
@@ -76,7 +76,7 @@ class ProvisionExternalSchemaReferencesFunctionalTest {
 
     @BeforeEach
     void setUp() {
-        domainId = "some.domain." + UUID.randomUUID().toString().toLowerCase().replace("-", "_");
+        domainId = "some.domain.d" + UUID.randomUUID().toString().toLowerCase().replace("-", "_");
     }
 
     @Order(1)

--- a/cli/src/test/java/io/specmesh/cli/ProvisionExternalSchemaReferencesFunctionalTest.java
+++ b/cli/src/test/java/io/specmesh/cli/ProvisionExternalSchemaReferencesFunctionalTest.java
@@ -76,7 +76,7 @@ class ProvisionExternalSchemaReferencesFunctionalTest {
 
     @BeforeEach
     void setUp() {
-        domainId = "some.domain." + UUID.randomUUID().toString().toLowerCase();
+        domainId = "some.domain." + UUID.randomUUID().toString().toLowerCase().replace("-", "_");
     }
 
     @Order(1)

--- a/kafka-test/build.gradle.kts
+++ b/kafka-test/build.gradle.kts
@@ -24,6 +24,7 @@ val testcontainersVersion : String by extra
 val lombokVersion : String by extra
 val junitVersion : String by extra
 val protobufVersion : String by extra
+val confluentVersion : String by extra
 
 dependencies {
     api(project(":parser"))
@@ -40,4 +41,8 @@ dependencies {
     testImplementation("com.google.protobuf:protobuf-java:$protobufVersion")
     testImplementation("org.testcontainers:testcontainers-junit-jupiter:$testcontainersVersion")
     testRuntimeOnly("commons-codec:commons-codec:1.21.0")
+}
+
+tasks.test {
+    systemProperty("confluentVersion", confluentVersion)
 }

--- a/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/DockerKafkaEnvironment.java
@@ -86,6 +86,9 @@ public final class DockerKafkaEnvironment
     /** The port to use when connecting to Kafka from inside the Docker network */
     public static final int KAFKA_DOCKER_NETWORK_PORT = 9093;
 
+    /** Default version of Kafka and Schema Registry containers to use. */
+    public static final String DEFAULT_CONFLUENT_PLATFORM_VERSION = "8.2.0";
+
     private final int startUpAttempts;
     private final Duration startUpTimeout;
     private final DockerImageName kafkaDockerImage;
@@ -337,7 +340,8 @@ public final class DockerKafkaEnvironment
         private static final Duration DEFAULT_CONTAINER_STARTUP_TIMEOUT = Duration.ofSeconds(30);
 
         public static final DockerImageName DEFAULT_KAFKA_DOCKER_IMAGE =
-                DockerImageName.parse("confluentinc/cp-kafka:8.2.0");
+                DockerImageName.parse(
+                        "confluentinc/cp-kafka:" + DEFAULT_CONFLUENT_PLATFORM_VERSION);
         private static final Map<String, String> DEFAULT_KAFKA_ENV =
                 Map.of(
                         "KAFKA_AUTO_CREATE_TOPICS_ENABLE",

--- a/kafka-test/src/main/java/io/specmesh/kafka/schema/SchemaRegistryContainer.java
+++ b/kafka-test/src/main/java/io/specmesh/kafka/schema/SchemaRegistryContainer.java
@@ -16,6 +16,8 @@
 
 package io.specmesh.kafka.schema;
 
+import static io.specmesh.kafka.DockerKafkaEnvironment.DEFAULT_CONFLUENT_PLATFORM_VERSION;
+
 import java.net.MalformedURLException;
 import java.net.URL;
 import org.testcontainers.containers.GenericContainer;
@@ -25,7 +27,8 @@ import org.testcontainers.utility.DockerImageName;
 public final class SchemaRegistryContainer extends GenericContainer<SchemaRegistryContainer> {
 
     public static final DockerImageName DEFAULT_IMAGE_NAME =
-            DockerImageName.parse("confluentinc/cp-schema-registry:7.9.1");
+            DockerImageName.parse(
+                    "confluentinc/cp-schema-registry:" + DEFAULT_CONFLUENT_PLATFORM_VERSION);
 
     /** Port the SR will listen on. */
     public static final int SCHEMA_REGISTRY_PORT = 8081;

--- a/kafka-test/src/test/java/io/specmesh/kafka/DockerKafkaEnvironmentTest.java
+++ b/kafka-test/src/test/java/io/specmesh/kafka/DockerKafkaEnvironmentTest.java
@@ -16,6 +16,10 @@
 
 package io.specmesh.kafka;
 
+import static io.specmesh.kafka.DockerKafkaEnvironment.DEFAULT_CONFLUENT_PLATFORM_VERSION;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+
 import java.time.Duration;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Tag;
@@ -26,6 +30,11 @@ class DockerKafkaEnvironmentTest {
 
     private static final int STARTUP_ATTEMPTS = 1;
     private static final Duration STARTUP_DURATION = Duration.ofSeconds(15);
+
+    @Test
+    void shouldAlignConfluentDockerAndGradleDependencyVersions() {
+        assertThat(DEFAULT_CONFLUENT_PLATFORM_VERSION, is(System.getProperty("confluentVersion")));
+    }
 
     @Test
     void shouldWorkWithoutSasl() {

--- a/kafka/build.gradle.kts
+++ b/kafka/build.gradle.kts
@@ -39,8 +39,8 @@ dependencies {
 
     api(project(":parser"))
 
-    implementation("org.apache.kafka:kafka-streams:$confluentVersion-ce")
-    implementation("org.apache.kafka:kafka-clients:$confluentVersion-ce")
+    implementation("org.apache.kafka:kafka-streams:$confluentVersion-ccs")
+    implementation("org.apache.kafka:kafka-clients:$confluentVersion-ccs")
     implementation("commons-io:commons-io:2.21.0")
     implementation("com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:$jacksonVersion")
 

--- a/kafka/src/main/java/io/specmesh/kafka/Clients.java
+++ b/kafka/src/main/java/io/specmesh/kafka/Clients.java
@@ -19,9 +19,12 @@ package io.specmesh.kafka;
 import static java.util.Objects.requireNonNull;
 
 import com.google.protobuf.MessageLiteOrBuilder;
+import io.confluent.kafka.schemaregistry.avro.AvroSchemaProvider;
 import io.confluent.kafka.schemaregistry.client.CachedSchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClient;
 import io.confluent.kafka.schemaregistry.client.SchemaRegistryClientConfig;
+import io.confluent.kafka.schemaregistry.json.JsonSchemaProvider;
+import io.confluent.kafka.schemaregistry.protobuf.ProtobufSchemaProvider;
 import io.confluent.kafka.serializers.AbstractKafkaSchemaSerDeConfig;
 import io.confluent.kafka.serializers.KafkaAvroDeserializer;
 import io.confluent.kafka.serializers.KafkaAvroSerializer;
@@ -35,6 +38,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.time.Duration;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Properties;
@@ -309,7 +313,13 @@ public final class Clients {
                     SchemaRegistryClientConfig.USER_INFO_CONFIG, srApiKey + ":" + srApiSecret);
         }
         return new CachedSchemaRegistryClient(
-                requireNonNull(schemaRegistryUrl, "schemaRegistryUrl"), 5, properties);
+                List.of(requireNonNull(schemaRegistryUrl, "schemaRegistryUrl")),
+                5,
+                List.of(
+                        new AvroSchemaProvider(),
+                        new JsonSchemaProvider(),
+                        new ProtobufSchemaProvider()),
+                properties);
     }
 
     /**


### PR DESCRIPTION
Confluent has decided to introduce binary incompatibilities between the community (`-ccs`) and enterprise (`-ce`) versions of the Confluent Platform java libraries.  Mixing them on the classpath now results in `NotSuchMethod` and other such exceptions - a total PITA!

This project brings in community edition transitive dependencies. Hence, standardising on the community edition, so the specmesh libraries don't bring in both.

Users can still choose to constrain the Kafka jar versions to enterprise if they want.
